### PR TITLE
$.FSRTC.prototype.stopPeer() missing self variable declaration

### DIFF
--- a/html5/verto/js/src/jquery.FSRTC.js
+++ b/html5/verto/js/src/jquery.FSRTC.js
@@ -282,6 +282,8 @@
     };
 
     $.FSRTC.prototype.stopPeer = function() {
+        var self = this;
+
         if (self.peer) {
             console.log("stopping peer");
             self.peer.stop();


### PR DESCRIPTION
The stopPeer() method in jquery.FSRTC.js is missing a 'var self = this;'
declaration at the top of the function, which leads the wrong object being
assigned to self, and the self.peer.stop() function never being called.

This breaks proper hangup of calls using this function, such as a screenshare
call.