### PR TITLE
Disable MSRP option

### DIFF
--- a/conf/vanilla/autoload_configs/msrp.conf.xml
+++ b/conf/vanilla/autoload_configs/msrp.conf.xml
@@ -1,8 +1,8 @@
 <configuration name="msrp.conf" description="MSRP">
   <settings>
     <param name="listen-ip" value="$${local_ip_v4}"/>
-    <param name="listen-port" value="2855"/>
-    <param name="listen-ssl-port" value="2856"/>
+    <!-- <param name="listen-port" value="2855"/> -->
+    <!-- <param name="listen-ssl-port" value="2856"/> -->
     <!-- <param name="message-buffer-size" value="50"/> -->
     <!-- <param name="debug" value="true"/> -->
     <!-- <param name="secure-cert" value="$${certs_dir}/wss.pem"/> -->

--- a/conf/vanilla/autoload_configs/msrp.conf.xml
+++ b/conf/vanilla/autoload_configs/msrp.conf.xml
@@ -3,6 +3,7 @@
     <param name="listen-ip" value="$${local_ip_v4}"/>
     <param name="listen-port" value="2855"/>
     <param name="listen-ssl-port" value="2856"/>
+    <!-- <param name="disable-msrp" value="true"/> -->
     <!-- <param name="message-buffer-size" value="50"/> -->
     <!-- <param name="debug" value="true"/> -->
     <!-- <param name="secure-cert" value="$${certs_dir}/wss.pem"/> -->

--- a/conf/vanilla/autoload_configs/msrp.conf.xml
+++ b/conf/vanilla/autoload_configs/msrp.conf.xml
@@ -3,7 +3,6 @@
     <param name="listen-ip" value="$${local_ip_v4}"/>
     <param name="listen-port" value="2855"/>
     <param name="listen-ssl-port" value="2856"/>
-    <!-- <param name="disable-msrp" value="true"/> -->
     <!-- <param name="message-buffer-size" value="50"/> -->
     <!-- <param name="debug" value="true"/> -->
     <!-- <param name="secure-cert" value="$${certs_dir}/wss.pem"/> -->

--- a/src/include/switch_msrp.h
+++ b/src/include/switch_msrp.h
@@ -34,9 +34,6 @@
 
 #include <switch.h>
 
-#define MSRP_LISTEN_PORT 2855
-#define MSRP_SSL_LISTEN_PORT 2856
-
 enum {
 	MSRP_ST_WAIT_HEADER,
 	MSRP_ST_PARSE_HEADER,


### PR DESCRIPTION
MSRP is enabled by default; this PR implements a configuration option so the default behaviour can be changed when desired.

Also addresses signalwire/freeswitch#22