### PR TITLE
[mod_callcenter] Unreserve callcenter events when config errors loading

### DIFF
--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -4208,12 +4208,6 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_callcenter_load)
 	switch_json_api_interface_t *json_api_interface;
 	switch_status_t status;
 
-
-	if (switch_event_reserve_subclass(CALLCENTER_EVENT) != SWITCH_STATUS_SUCCESS) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", CALLCENTER_EVENT);
-		return SWITCH_STATUS_TERM;
-	}
-
 	memset(&globals, 0, sizeof(globals));
 	globals.pool = pool;
 
@@ -4222,6 +4216,11 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_callcenter_load)
 
 	if ((status = load_config()) != SWITCH_STATUS_SUCCESS) {
 		return status;
+	}
+
+	if (switch_event_reserve_subclass(CALLCENTER_EVENT) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", CALLCENTER_EVENT);
+		return SWITCH_STATUS_TERM;
 	}
 
 	if (switch_event_bind_removable(modname, SWITCH_EVENT_PRESENCE_PROBE, SWITCH_EVENT_SUBCLASS_ANY,

--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -4208,6 +4208,19 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_callcenter_load)
 	switch_json_api_interface_t *json_api_interface;
 	switch_status_t status;
 
+	/* create/register custom event message type */
+	if (switch_event_reserve_subclass(CALLCENTER_EVENT) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", CALLCENTER_EVENT);
+		return SWITCH_STATUS_TERM;
+	}
+
+	/* Subscribe to presence request events */
+	if (switch_event_bind_removable(modname, SWITCH_EVENT_PRESENCE_PROBE, SWITCH_EVENT_SUBCLASS_ANY,
+									cc_presence_event_handler, NULL, &globals.node) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to subscribe for presence events!\n");
+		return SWITCH_STATUS_GENERR;
+	}
+
 	memset(&globals, 0, sizeof(globals));
 	globals.pool = pool;
 
@@ -4215,18 +4228,10 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_callcenter_load)
 	switch_mutex_init(&globals.mutex, SWITCH_MUTEX_NESTED, globals.pool);
 
 	if ((status = load_config()) != SWITCH_STATUS_SUCCESS) {
+		switch_event_unbind(&globals.node);
+		switch_event_free_subclass(CALLCENTER_EVENT);
+		switch_core_hash_destroy(&globals.queue_hash);
 		return status;
-	}
-
-	if (switch_event_reserve_subclass(CALLCENTER_EVENT) != SWITCH_STATUS_SUCCESS) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", CALLCENTER_EVENT);
-		return SWITCH_STATUS_TERM;
-	}
-
-	if (switch_event_bind_removable(modname, SWITCH_EVENT_PRESENCE_PROBE, SWITCH_EVENT_SUBCLASS_ANY,
-									cc_presence_event_handler, NULL, &globals.node) != SWITCH_STATUS_SUCCESS) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to subscribe for presence events!\n");
-		return SWITCH_STATUS_GENERR;
 	}
 
 	switch_mutex_lock(globals.mutex);


### PR DESCRIPTION

Ref: https://freeswitch.org/jira/browse/FS-11094

When you load mod_callcenter and there is an issue with the configuration, it doesn't allow you to reload it a second time, this is caused before we reserve the `callcenter::info` event before loading the module successfully.

Here some of the error logs when this is occurring:

> 2018-04-05 06:44:46.614437 [ERR] mod_callcenter.c:4140 Couldn't register subclass callcenter::info!
> 2018-04-05 06:44:46.614437 [CRIT] switch_loadable_module.c:1522 Error Loading module /usr/lib/freeswitch/mod/mod_callcenter.so
*Module load routine returned an error*

To easily reproduce you can put an error in your odbc settings, the load mod_callcenter, after it fails you will not be able to load it again.
