### PR TITLE
[fs_cli] Fix typo, resolves garbled screen

### DIFF
--- a/libs/esl/fs_cli.c
+++ b/libs/esl/fs_cli.c
@@ -674,7 +674,7 @@ static void redisplay(void)
 	esl_mutex_lock(MUTEX);
 	{
 #ifdef HAVE_LIBEDIT
-#ifdef XHAVE_DECL_EL_REFRESH
+#ifdef HAVE_DECL_EL_REFRESH
 #ifdef HAVE_EL_WSET
 		/* Current libedit versions don't implement EL_REFRESH in eln.c so
 		 * use the wide version instead. */


### PR DESCRIPTION
Related to FS-11309.

Commit bc3e1c9e7de1855eec454bba467fd2586e5e251b introduced a typo that
results in EL_REFRESH never being used, even if available. This can
cause the screen to garble.

This fixes the typo.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>