### PR TITLE
[mod_event_multicast] Fix memory leak

### DIFF
--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
@@ -324,7 +324,7 @@ static void event_handler(switch_event_t *event)
 									  &tmplen, (unsigned char *) MAGIC, (int) strlen((char *) MAGIC));
 					outlen += tmplen;
 					EVP_EncryptFinal(ctx, (unsigned char *) buf + SWITCH_UUID_FORMATTED_LENGTH + outlen, &tmplen);
-					EVP_CIPHER_CTX_cleanup(ctx);
+					EVP_CIPHER_CTX_free(ctx);
 #else
 					EVP_CIPHER_CTX_init(&ctx);
 					EVP_EncryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);
@@ -577,7 +577,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_event_multicast_runtime)
 			EVP_DecryptInit(ctx, NULL, (unsigned char *) globals.psk, (unsigned char *) uuid_str);
 			EVP_DecryptUpdate(ctx, (unsigned char *) tmp, &outl, (unsigned char *) packet, (int) len);
 			EVP_DecryptFinal(ctx, (unsigned char *) tmp + outl, &tmplen);
-			EVP_CIPHER_CTX_cleanup(ctx);
+			EVP_CIPHER_CTX_free(ctx);
 #else
 			EVP_CIPHER_CTX_init(&ctx);
 			EVP_DecryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);


### PR DESCRIPTION
Taken from FS-11193:

In "event_handler()" function, when encrypting data using openssl 1.1.0,
the context ctx is allocated by "EVP_CIPHER_CTX_new()", then data is
encrypted, and at the end, EVP_CIPHER_CTX_cleanup is called. This
function resets the context (the function itself is deprecated, and has
been renamed to "EVP_CIPHER_CTX_reset) so that it can be used again. The
correct call would be to "EVP_CIPHER_CTX_free()", which frees the
memory. The code for openssl 1.0 is OK, since the "ctx" struct is kept
in stack.  The same thing happens during decryption. "ctx" is allocated,
but never freed.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>