### PR TITLE
Add support for the Elbrus architecture

### DIFF
--- a/libs/libzrtp/include/zrtp_config.h
+++ b/libs/libzrtp/include/zrtp_config.h
@@ -119,6 +119,12 @@
  */
 #define ZRTP_BYTE_ORDER ZBO_LITTLE_ENDIAN
 
+#elif defined(__e2k__)
+/*
+ * Elbrus, little endian
+ */
+#define ZRTP_BYTE_ORDER ZBO_LITTLE_ENDIAN
+
 #endif /* Automatic byte order detection */
 
 #endif


### PR DESCRIPTION
The Elbrus architecture (aka E2K, aka 2000) is LE.

Signed-off-by: Andrew Savchenko <bircoph@altlinux.org>