### PR TITLE
[mod_amqp] Properly parse out heartbeat parameter

### DIFF
--- a/src/mod/event_handlers/mod_amqp/mod_amqp_connection.c
+++ b/src/mod/event_handlers/mod_amqp/mod_amqp_connection.c
@@ -220,7 +220,7 @@ switch_status_t mod_amqp_connection_create(mod_amqp_connection_t **conn, switch_
 			if (interval && interval > 0) {
 				port = interval;
 			}
-		} else if (!strncmp(var, "heartbeat", 4)) {
+		} else if (!strncmp(var, "heartbeat", 9)) {
 			int interval = atoi(val);
 			if (interval && interval > 0) {
 				heartbeat = interval;


### PR DESCRIPTION
The `heartbeat` connection parameter of `amqp.conf` is not currently parsed properly.

This PR also partially addresses #59 (the other subissues to be handled by different PRs)