### PR TITLE
[mod_amqp] open logging and produced connections from within their threads

### DIFF
--- a/src/mod/event_handlers/mod_amqp/mod_amqp_logging.c
+++ b/src/mod/event_handlers/mod_amqp/mod_amqp_logging.c
@@ -238,34 +238,7 @@ switch_status_t mod_amqp_logging_create(char *name, switch_xml_t cfg)
 		}
 	}
 	profile->conn_active = NULL;
-
-	if ( mod_amqp_connection_open(profile->conn_root, &(profile->conn_active), profile->name, profile->custom_attr) != SWITCH_STATUS_SUCCESS) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Profile[%s] was unable to connect to any connection\n", profile->name);
-		goto err;
-	}
-
-#if AMQP_VERSION_MAJOR == 0 && AMQP_VERSION_MINOR >= 6
-	amqp_exchange_declare(profile->conn_active->state, 1,
-						  amqp_cstring_bytes(profile->exchange),
-						  amqp_cstring_bytes(profile->exchange_type),
-						  0, /* passive */
-						  profile->exchange_durable,
-						  profile->exchange_auto_delete,
-						  0,
-						  amqp_empty_table);
-#else
-	amqp_exchange_declare(profile->conn_active->state, 1,
-						  amqp_cstring_bytes(profile->exchange),
-						  amqp_cstring_bytes(profile->exchange_type),
-						  0, /* passive */
-						  profile->exchange_durable,
-						  amqp_empty_table);
-#endif
-
-	if (mod_amqp_log_if_amqp_error(amqp_get_rpc_reply(profile->conn_active->state), "Declaring exchange")) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Profile[%s] failed to create exchange\n", profile->name);
-		goto err;
-	}
+	/* We are not going to open the logging queue connection on create, but instead wait for the running thread to open it */
 
 	/* Create a bounded FIFO queue for sending messages */
 	if (switch_queue_create(&(profile->send_queue), profile->send_queue_size, profile->pool) != SWITCH_STATUS_SUCCESS) {

--- a/src/mod/event_handlers/mod_amqp/mod_amqp_producer.c
+++ b/src/mod/event_handlers/mod_amqp/mod_amqp_producer.c
@@ -325,33 +325,7 @@ switch_status_t mod_amqp_producer_create(char *name, switch_xml_t cfg)
 		}
 	}
 	profile->conn_active = NULL;
-
-	if ( mod_amqp_connection_open(profile->conn_root, &(profile->conn_active), profile->name, profile->custom_attr) != SWITCH_STATUS_SUCCESS) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Profile[%s] was unable to connect to any connection\n", profile->name);
-		goto err;
-	}
-#if AMQP_VERSION_MAJOR == 0 && AMQP_VERSION_MINOR >= 6
-	amqp_exchange_declare(profile->conn_active->state, 1,
-						  amqp_cstring_bytes(profile->exchange),
-						  amqp_cstring_bytes(profile->exchange_type),
-						  0, /* passive */
-						  profile->exchange_durable,
-						  profile->exchange_auto_delete,
-						  0,
-						  amqp_empty_table);
-#else
-	amqp_exchange_declare(profile->conn_active->state, 1,
-						  amqp_cstring_bytes(profile->exchange),
-						  amqp_cstring_bytes(profile->exchange_type),
-						  0, /* passive */
-						  profile->exchange_durable,
-						  amqp_empty_table);
-#endif
-
-	if (mod_amqp_log_if_amqp_error(amqp_get_rpc_reply(profile->conn_active->state), "Declaring exchange\n")) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Profile[%s] failed to create exchange\n", profile->name);
-		goto err;
-	}
+	/* We are not going to open the producer queue connection on create, but instead wait for the running thread to open it */
 
 	/* Create a bounded FIFO queue for sending messages */
 	if (switch_queue_create(&(profile->send_queue), profile->send_queue_size, profile->pool) != SWITCH_STATUS_SUCCESS) {


### PR DESCRIPTION
For the logging and the producer queues, the connections are open both in their respective threads as well as during the profile initialization. This PR removes the latter attempt as it is redundant as well as it prevents the configured profiles from ever attempting to reconnect, as described in #59

Please note the command queue is not affected by the behaviour described in the ticket as it was already tweaked a while back (commit https://github.com/signalwire/freeswitch/commit/ba63cc45744ddc45ee24961ddf348044821830eb)