### PR TITLE
[build] OSX Catalina configure does not support --extra-cflags and fix broken compiler option test for -Wno-extended-offsetof that was used to fix older osx clang issue

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -586,7 +586,7 @@ libs/libzrtp/libzrtp.a:
 	cd libs/libzrtp && $(MAKE)
 
 libs/libvpx/Makefile: libs/libvpx/.update
-	cd libs/libvpx && CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)" ./configure --enable-pic --disable-docs --disable-examples --disable-install-bins --disable-install-srcs --disable-unit-tests --size-limit=16384x16384 --extra-cflags="$(VISIBILITY_FLAG)"
+	cd libs/libvpx && CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS) $(VISIBILITY_FLAG)" CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)" ./configure --enable-pic --disable-docs --disable-examples --disable-install-bins --disable-install-srcs --disable-unit-tests --size-limit=16384x16384
 
 libs/libvpx/libvpx.a: libs/libvpx/Makefile libs/libvpx/.update
 	@cd libs/libvpx && $(MAKE)

--- a/configure.ac
+++ b/configure.ac
@@ -1052,14 +1052,17 @@ fi
 CFLAGS="$saved_CFLAGS"
 
 if test "x${ax_cv_c_compiler_vendor}" = "xclang" ; then
+     saved_CFLAGS="$CFLAGS"
      # Next check added for Xcode 5 and systems with clang 5 llvm 3.3 or above, extended offset must be off
      AC_CACHE_CHECK([whether compiler supports -Wextended-offsetof], [ac_cv_clang_extended_offsetof], [
+       CFLAGS="$CFLAGS -Wno-extended-offsetof"
        AC_TRY_COMPILE([],[return 0;],[ac_cv_clang_extended_offsetof=yes],[ac_cv_clang_extended_offsetof=no])
      ])
      AC_MSG_RESULT($ac_cv_clang_extended_offsetof)
      if test x"$ac_cv_clang_extended_offsetof" = xyes; then
          APR_ADDTO(CFLAGS, -Wno-extended-offsetof)
      fi
+     CFLAGS="$saved_CFLAGS"
 fi
 
 # Tested and fixed lot of modules, but some are untested.  Will be added back when the core team decide it ready


### PR DESCRIPTION
Need to confirm that this does not negatively impact debian builds