### PR TITLE
execute_on_audio_change on codec related changes

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -3711,7 +3711,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_set_codec(switch_core_session_
 		if (strcasecmp(a_engine->read_impl.iananame, a_engine->cur_payload_map->iananame) ||
 			(uint32_t) a_engine->read_impl.microseconds_per_packet / 1000 != a_engine->cur_payload_map->codec_ms ||
 			a_engine->read_impl.samples_per_second != a_engine->cur_payload_map->rm_rate ) {
-
+                        switch_channel_execute_on(session->channel, "execute_on_audio_change");
 			if (session->read_resampler) {
 				switch_mutex_lock(session->resample_mutex);
 				switch_resample_destroy(&session->read_resampler);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -3710,8 +3710,9 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_set_codec(switch_core_session_
 
 		if (strcasecmp(a_engine->read_impl.iananame, a_engine->cur_payload_map->iananame) ||
 			(uint32_t) a_engine->read_impl.microseconds_per_packet / 1000 != a_engine->cur_payload_map->codec_ms ||
-			a_engine->read_impl.samples_per_second != a_engine->cur_payload_map->rm_rate ) {
-                        switch_channel_execute_on(session->channel, "execute_on_audio_change");
+			a_engine->read_impl.samples_per_second != a_engine->cur_payload_map->rm_rate ) {	
+			switch_channel_execute_on(session->channel, "execute_on_audio_change");
+			
 			if (session->read_resampler) {
 				switch_mutex_lock(session->resample_mutex);
 				switch_resample_destroy(&session->read_resampler);


### PR DESCRIPTION
`execute_on_audio_change` is used to set a callback on audio parameters changes during sdp renegotiation. Rightnow, `execute_on_audio_change` is getting executed only when remote-rtp-ip and remote-rtp-port getting changed during reinvite.

This fix is provided to have `execute_on_audio_change` for codec related changes also.