### PR TITLE
Make API command response more accurate when command is exists but return error

### DIFF
--- a/src/mod/event_handlers/mod_event_socket/mod_event_socket.c
+++ b/src/mod/event_handlers/mod_event_socket/mod_event_socket.c
@@ -1539,7 +1539,7 @@ static void *SWITCH_THREAD_FUNC api_exec(switch_thread_t *thread, void *obj)
 
 	if (acs->console_execute) {
 		if ((status = switch_console_execute(acs->api_cmd, 0, &stream)) != SWITCH_STATUS_SUCCESS) {
-			stream.write_function(&stream, "-ERR %s Command not found!\n", acs->api_cmd);
+			stream.write_function(&stream, "-ERR %s Command %s!\n", acs->api_cmd, status == SWITCH_STATUS_NOTFOUND ? "not found" : "return error");
 		}
 	} else {
 		status = switch_api_execute(acs->api_cmd, acs->arg, NULL, &stream);
@@ -1548,7 +1548,7 @@ static void *SWITCH_THREAD_FUNC api_exec(switch_thread_t *thread, void *obj)
 	if (status == SWITCH_STATUS_SUCCESS) {
 		reply = stream.data;
 	} else {
-		freply = switch_mprintf("-ERR %s Command not found!\n", acs->api_cmd);
+		freply = switch_mprintf("-ERR %s Command %s!\n", acs->api_cmd, status == SWITCH_STATUS_NOTFOUND ? "not found" : "return error");
 		reply = freply;
 	}
 

--- a/src/switch_console.c
+++ b/src/switch_console.c
@@ -330,7 +330,7 @@ static int switch_console_process(char *xcmd)
 			r = 0;
 		}
 		if (handle) {
-			fprintf(handle, "Unknown Command: %s\n", xcmd);
+			fprintf(handle, "Command %s: %s\n", status == SWITCH_STATUS_NOTFOUND ? "not found": "return error", xcmd);
 			fflush(handle);
 		}
 	}

--- a/src/switch_loadable_module.c
+++ b/src/switch_loadable_module.c
@@ -3008,8 +3008,7 @@ SWITCH_DECLARE(switch_status_t) switch_api_execute(const char *cmd, const char *
 		}
 		UNPROTECT_INTERFACE(api);
 	} else {
-		status = SWITCH_STATUS_FALSE;
-		stream->write_function(stream, "INVALID COMMAND!\n");
+		status = api == 0 ? SWITCH_STATUS_NOTFOUND : SWITCH_STATUS_FALSE;
 	}
 
 	if (stream->param_event) {

--- a/src/switch_loadable_module.c
+++ b/src/switch_loadable_module.c
@@ -3008,7 +3008,7 @@ SWITCH_DECLARE(switch_status_t) switch_api_execute(const char *cmd, const char *
 		}
 		UNPROTECT_INTERFACE(api);
 	} else {
-		status = api == 0 ? SWITCH_STATUS_NOTFOUND : SWITCH_STATUS_FALSE;
+		status = api ? SWITCH_STATUS_FALSE : SWITCH_STATUS_NOTFOUND;
 	}
 
 	if (stream->param_event) {


### PR DESCRIPTION
This PR makes an API command response more accurate when they exist but return an error. Before this patch:

```
root@freeswitch-test:~# fs_cli -x "http_get {profile=aws_s3}https://baonq5.s3-ap-southeast-1.amazonaws.com/this_file_does_not_exist.txt"
-ERR http_get {profile=aws_s3}https://baonq5.s3-ap-southeast-1.amazonaws.com/this_file_does_not_exist.txt Command not found!

root@freeswitch-test:~# 
```

After this patch

```
root@freeswitch-test:~# fs_cli -x "http_get {profile=aws_s3}https://baonq5.s3-ap-southeast-1.amazonaws.com/this_file_does_not_exist.txt"
-ERR http_get {profile=aws_s3}https://baonq5.s3-ap-southeast-1.amazonaws.com/this_file_does_not_exist.txt Command return error!

root@freeswitch-test:~# 
```

This patch also fixes the same thing when you run API commands inside the console. Before this patch:

```
freeswitch@freeswitch-test> http_get {profile=aws_s3}https://baonq5.s3-ap-southeast-1.amazonaws.com/this_file_does_not_exist.txt
Unknown Command: http_get {profile=aws_s3}https://baonq5.s3-ap-southeast-1.amazonaws.com/this_file_does_not_exist.txt
freeswitch@freeswitch-test> 
```

After this patch

```
freeswitch@freeswitch-test> http_get {profile=aws_s3}https://baonq5.s3-ap-southeast-1.amazonaws.com/this_file_does_not_exist.txt
Command return error: http_get {profile=aws_s3}https://baonq5.s3-ap-southeast-1.amazonaws.com/this_file_does_not_exist.txt
freeswitch@freeswitch-test> 
```
