### PR TITLE
mod_xml_radius, mod_rad_auth, mod_radius_cdr: now use system freeradius-client

### DIFF
--- a/freeswitch.spec
+++ b/freeswitch.spec
@@ -519,6 +519,8 @@ while calls are in progress.
 Summary:	FreeSWITCH mod_rad_auth
 Group:          System/Libraries
 Requires:       %{name} = %{version}-%{release}
+Requires:       freeradius-client
+BuildRequires:  freeradius-client-devel
 
 %description application-rad_auth
 Provides FreeSWITCH mod_rad_auth, authetication via RADIUS protocol from FreeSWITCH dialplan
@@ -1088,7 +1090,9 @@ JSON CDR Logger for FreeSWITCH.
 %package event-radius-cdr
 Summary:        RADIUS Logger for the FreeSWITCH open source telephony platform
 Group:          System/Libraries
-Requires:        %{name} = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
+Requires:       freeradius-client
+BuildRequires:  freeradius-client-devel
 
 %description event-radius-cdr
 RADIUS Logger for the FreeSWITCH open source telephony platform
@@ -1641,7 +1645,7 @@ TIMERS_MODULES+="timers/mod_timerfd"
 #						XML Modules
 #
 ######################################################################################################################
-XML_INT_MODULES="xml_int/mod_xml_cdr xml_int/mod_xml_curl xml_int/mod_xml_rpc"
+XML_INT_MODULES="xml_int/mod_xml_cdr xml_int/mod_xml_curl xml_int/mod_xml_radius xml_int/mod_xml_rpc"
 
 ######################################################################################################################
 #
@@ -2604,6 +2608,9 @@ fi
 
 %files xml-curl
 %{MODINSTDIR}/mod_xml_curl.so*
+
+%files xml-radius
+%{MODINSTDIR}/mod_xml_radius.so*
 
 ######################################################################################################################
 #			FreeSWITCH ESL language modules

--- a/src/mod/applications/mod_rad_auth/Makefile.am
+++ b/src/mod/applications/mod_rad_auth/Makefile.am
@@ -1,29 +1,8 @@
 include $(top_srcdir)/build/modmake.rulesam
 MODNAME=mod_rad_auth
 
-RADCLIENT_VERSION=1.1.7
-RADCLIENT=freeradius-client-$(RADCLIENT_VERSION)
-RADCLIENT_DIR=$(switch_srcdir)/libs/$(RADCLIENT)
-RADCLIENT_BUILDDIR=$(switch_builddir)/libs/$(RADCLIENT)
-RADCLIENT_LIBDIR=$(RADCLIENT_BUILDDIR)/lib
-RADCLIENT_LA=${RADCLIENT_LIBDIR}/libfreeradius-client.la
-
 mod_LTLIBRARIES = mod_rad_auth.la
 mod_rad_auth_la_SOURCES  = mod_rad_auth.c
-mod_rad_auth_la_CFLAGS   = $(AM_CFLAGS) -I$(RADCLIENT_DIR)/include
-mod_rad_auth_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(RADCLIENT_LA)
+mod_rad_auth_la_CFLAGS   = $(AM_CFLAGS)
+mod_rad_auth_la_LIBADD   = $(switch_builddir)/libfreeswitch.la
 mod_rad_auth_la_LDFLAGS  = -avoid-version -module -no-undefined -shared
-
-BUILT_SOURCES=$(RADCLIENT_LA)
-
-$(RADCLIENT_DIR):
-	$(GETLIB) $(RADCLIENT).tar.gz
-
-$(RADCLIENT_BUILDDIR)/Makefile: $(RADCLIENT_DIR)
-	mkdir -p $(RADCLIENT_BUILDDIR)
-	cd $(RADCLIENT_BUILDDIR) && $(DEFAULT_VARS) $(RADCLIENT_DIR)/configure $(DEFAULT_ARGS) --srcdir=$(RADCLIENT_DIR)
-	$(TOUCH_TARGET)
-
-$(RADCLIENT_LA): $(RADCLIENT_BUILDDIR)/Makefile
-	cd $(RADCLIENT_BUILDDIR) && CFLAGS="$(CFLAGS)" $(MAKE)
-	$(TOUCH_TARGET)

--- a/src/mod/event_handlers/mod_radius_cdr/Makefile.am
+++ b/src/mod/event_handlers/mod_radius_cdr/Makefile.am
@@ -1,30 +1,8 @@
 include $(top_srcdir)/build/modmake.rulesam
 MODNAME=mod_radius_cdr
 
-RADCLIENT_VERSION=1.1.7
-RADCLIENT=freeradius-client-$(RADCLIENT_VERSION)
-RADCLIENT_DIR=$(switch_srcdir)/libs/$(RADCLIENT)
-RADCLIENT_BUILDDIR=$(switch_builddir)/libs/$(RADCLIENT)
-RADCLIENT_LIBDIR=$(RADCLIENT_BUILDDIR)/lib
-RADCLIENT_LA=${RADCLIENT_LIBDIR}/libfreeradius-client.la
-
 mod_LTLIBRARIES = mod_radius_cdr.la
 mod_radius_cdr_la_SOURCES  = mod_radius_cdr.c
 mod_radius_cdr_la_CFLAGS   = $(AM_CFLAGS) -I$(RADCLIENT_DIR)/include
-mod_radius_cdr_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(RADCLIENT_LA)
+mod_radius_cdr_la_LIBADD   = $(switch_builddir)/libfreeswitch.la
 mod_radius_cdr_la_LDFLAGS  = -avoid-version -module -no-undefined -shared
-BUILT_SOURCES=$(RADCLIENT_LA)
-
-$(RADCLIENT_DIR):
-	$(GETLIB) $(RADCLIENT).tar.gz
-
-$(RADCLIENT_BUILDDIR)/Makefile: $(RADCLIENT_DIR)
-	mkdir -p $(RADCLIENT_BUILDDIR)
-	cd $(RADCLIENT_BUILDDIR) && $(DEFAULT_VARS) $(RADCLIENT_DIR)/configure $(DEFAULT_ARGS) --srcdir=$(RADCLIENT_DIR)
-	$(TOUCH_TARGET)
-
-$(RADCLIENT_LA): $(RADCLIENT_BUILDDIR)/Makefile
-	cd $(RADCLIENT_BUILDDIR) && CFLAGS="$(CFLAGS)" $(MAKE)
-	$(TOUCH_TARGET)
-
-

--- a/src/mod/xml_int/mod_xml_radius/Makefile.am
+++ b/src/mod/xml_int/mod_xml_radius/Makefile.am
@@ -1,31 +1,8 @@
 include $(top_srcdir)/build/modmake.rulesam
 MODNAME=mod_xml_radius
 
-RADCLIENT_VERSION=1.1.7
-RADCLIENT=freeradius-client-$(RADCLIENT_VERSION)
-RADCLIENT_DIR=$(switch_srcdir)/libs/$(RADCLIENT)
-RADCLIENT_BUILDDIR=$(switch_builddir)/libs/$(RADCLIENT)
-RADCLIENT_LIBDIR=$(RADCLIENT_BUILDDIR)/lib
-RADCLIENT_LA=${RADCLIENT_LIBDIR}/libfreeradius-client.la
-
 mod_LTLIBRARIES = mod_xml_radius.la
 mod_xml_radius_la_SOURCES  = mod_xml_radius.c
-mod_xml_radius_la_CFLAGS   = $(AM_CFLAGS) -I$(RADCLIENT_DIR)/include
-mod_xml_radius_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(RADCLIENT_LA)
+mod_xml_radius_la_CFLAGS   = $(AM_CFLAGS)
+mod_xml_radius_la_LIBADD   = $(switch_builddir)/libfreeswitch.la
 mod_xml_radius_la_LDFLAGS  = -avoid-version -module -no-undefined -shared
-
-BUILT_SOURCES=$(RADCLIENT_LA)
-
-$(RADCLIENT_DIR):
-	$(GETLIB) $(RADCLIENT).tar.gz
-
-$(RADCLIENT_BUILDDIR)/Makefile: $(RADCLIENT_DIR)
-	mkdir -p $(RADCLIENT_BUILDDIR)
-	cd $(RADCLIENT_BUILDDIR) && $(DEFAULT_VARS) $(RADCLIENT_DIR)/configure $(DEFAULT_ARGS) --srcdir=$(RADCLIENT_DIR)
-	$(TOUCH_TARGET)
-
-$(RADCLIENT_LA): $(RADCLIENT_BUILDDIR)/Makefile
-	cd $(RADCLIENT_BUILDDIR) && CFLAGS="$(CFLAGS)" $(MAKE)
-	$(TOUCH_TARGET)
-
-


### PR DESCRIPTION
For CentOS 7 need rebuild freeradius-client and place to RPM repo.

For debian may be need create binary package and place to repo. Or simple wait when updated on dist.
