### PR TITLE
Replaced dead enum servers to working ones

### DIFF
--- a/conf/curl/autoload_configs/enum.conf.xml
+++ b/conf/curl/autoload_configs/enum.conf.xml
@@ -1,7 +1,7 @@
 <configuration name="enum.conf" description="ENUM Module">
   <settings>
-    <param name="default-root" value="e164.org"/>
-    <param name="default-isn-root" value="freenum.org"/>
+    <param name="default-root" value="enum.enumer.org"/>
+    <param name="default-isn-root" value="nrenum.net"/>
     <param name="query-timeout" value="10"/>
     <param name="auto-reload" value="true"/>
   </settings>

--- a/conf/insideout/autoload_configs/enum.conf.xml
+++ b/conf/insideout/autoload_configs/enum.conf.xml
@@ -1,7 +1,7 @@
 <configuration name="enum.conf" description="ENUM Module">
   <settings>
-    <param name="default-root" value="e164.org"/>
-    <param name="default-isn-root" value="freenum.org"/>
+    <param name="default-root" value="enum.enumer.org"/>
+    <param name="default-isn-root" value="nrenum.net"/>
     <param name="query-timeout" value="10"/>
     <param name="auto-reload" value="true"/>
   </settings>

--- a/conf/sbc/autoload_configs/enum.conf.xml
+++ b/conf/sbc/autoload_configs/enum.conf.xml
@@ -1,7 +1,7 @@
 <configuration name="enum.conf" description="ENUM Module">
   <settings>
-    <param name="default-root" value="e164.org"/>
-    <param name="default-isn-root" value="freenum.org"/>
+    <param name="default-root" value="enum.enumer.org"/>
+    <param name="default-isn-root" value="nrenum.net"/>
     <param name="query-timeout" value="10"/>
     <param name="auto-reload" value="true"/>
   </settings>

--- a/conf/softphone/freeswitch.xml
+++ b/conf/softphone/freeswitch.xml
@@ -38,8 +38,8 @@
 
     <configuration name="enum.conf" description="ENUM Module">
       <settings>
-	<param name="default-root" value="e164.org"/>
-	<param name="default-isn-root" value="freenum.org"/>
+	<param name="default-root" value="enum.enumer.org"/>
+	<param name="default-isn-root" value="nrenum.net"/>
 	<param name="query-timeout" value="10"/>
 	<param name="auto-reload" value="true"/>
       </settings>

--- a/conf/vanilla/autoload_configs/enum.conf.xml
+++ b/conf/vanilla/autoload_configs/enum.conf.xml
@@ -1,7 +1,7 @@
 <configuration name="enum.conf" description="ENUM Module">
   <settings>
-    <param name="default-root" value="e164.org"/>
-    <param name="default-isn-root" value="freenum.org"/>
+    <param name="default-root" value="enum.enumer.org"/>
+    <param name="default-isn-root" value="nrenum.net"/>
     <param name="auto-reload" value="true"/>
 
     <param name="query-timeout-ms" value="200"/>

--- a/fscomm/conf/freeswitch.xml
+++ b/fscomm/conf/freeswitch.xml
@@ -35,8 +35,8 @@
 
                 <configuration name="enum.conf" description="ENUM Module">
                         <settings>
-                                <param name="default-root" value="e164.org"/>
-                                <param name="default-isn-root" value="freenum.org"/>
+                                <param name="default-root" value="enum.enumer.org"/>
+                                <param name="default-isn-root" value="nrenum.net"/>
                                 <param name="query-timeout" value="10"/>
                                 <param name="auto-reload" value="true"/>
                         </settings>

--- a/src/mod/applications/mod_enum/conf/autoload_configs/enum.conf.xml
+++ b/src/mod/applications/mod_enum/conf/autoload_configs/enum.conf.xml
@@ -1,7 +1,7 @@
 <configuration name="enum.conf" description="ENUM Module">
   <settings>
-    <param name="default-root" value="e164.org"/>
-    <param name="default-isn-root" value="freenum.org"/>
+    <param name="default-root" value="enum.enumer.org"/>
+    <param name="default-isn-root" value="nrenum.net"/>
     <param name="query-timeout" value="10"/>
     <param name="auto-reload" value="true"/>
   </settings>

--- a/src/mod/applications/mod_enum/mod_enum.c
+++ b/src/mod/applications/mod_enum/mod_enum.c
@@ -196,11 +196,11 @@ static switch_status_t load_config(void)
 	}
 
 	if (!globals.root) {
-		set_global_root("e164.org");
+		set_global_root("enum.enumer.org");
 	}
 
 	if (!globals.isn_root) {
-		set_global_isn_root("freenum.org");
+		set_global_isn_root("nrenum.net");
 	}
 
 	return status;


### PR DESCRIPTION
*** 1 Problem ***

Current default ENUM servers, specified within FreeSWITCSH seems not working and abandoned for years. Try visit http://www.e164.org/ or http://freenum.org/
Moreover - freenum NAPTR server returns incorrect SIP URI to non-existing domain. Try:

$ dig +short NAPTR 0.9.8.3.4.2.5.0.0.8.1.freenum.org
100 10 "u" "E2U+sip" "!^\\+1800(.*)$!sip:1800\\1@tf.voipmich.com!" .
100 10 "u" "E2U+voice:sip" "!^\\+1800(.*)$!sip:1800\\1@tf.voipmich.com!" .
100 10 "u" "E2U+iax2" "!^\\+1800(.*)$!iax2:freenum@tf.voipmich.com/1800\\1!" .
100 10 "u" "E2U+voice:iax2" "!^\\+1800(.*)$!iax2:freenum@tf.voipmich.com/1800\\1!" .

$ host tf.voipmich.com
;; connection timed out; no servers could be reached

Such answer is worse than just its absence, because it disrupt connections.


*** 2 Solution ***

I updated ENUM domain roots to the system in good health.

- ENUMER - this is decentralized public ENUM, see the article: https://medium.com/@emer.tech/voip-made-free-with-blockchain-introducing-enumer-35235c4abec5
- NRENUM - Academic ENUM network, contains real routes (I tested), see: https://nrenum.net/

And of course, these systems have active web-sites, and provides correct ENUM resolving. I hope, my changes will deliver more functionality to FreeSWITCH customers.
