### PR TITLE
Update to current OpenSSL APIs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1602,11 +1602,10 @@ SAC_OPENSSL
 if test x$HAVE_OPENSSL = x1; then
 	openssl_CFLAGS="$openssl_CFLAGS -DHAVE_OPENSSL";
 	APR_ADDTO(SWITCH_AM_CFLAGS, -DHAVE_OPENSSL)
-	AC_CHECK_LIB(ssl, SSL_CTX_set_tlsext_use_srtp, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLS_SRTP, 1, HAVE_OPENSSL_DTLS_SRTP), AC_MSG_ERROR([OpenSSL >= 1.0.1e and associated developement headers required]))
-	AC_CHECK_LIB(ssl, DTLSv1_method, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLS, 1, HAVE_OPENSSL_DTLS), AC_MSG_ERROR([OpenSSL >= 1.0.1e and associaed developement headers required]))
-	AC_CHECK_LIB(ssl, DTLSv1_2_method, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLSv1_2_method, 1, [DTLS version 1.2 is available]))
+	AC_CHECK_LIB(ssl, SSL_CTX_set_tlsext_use_srtp, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLS_SRTP, 1, HAVE_OPENSSL_DTLS_SRTP), AC_MSG_ERROR([OpenSSL >= 1.0.2 and associated developement headers required]))
+	AC_CHECK_LIB(ssl, DTLS_method, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLS, 1, HAVE_OPENSSL_DTLS), AC_MSG_ERROR([OpenSSL >= 1.0.2 and associaed developement headers required]))
 else
-	AC_MSG_ERROR([OpenSSL >= 1.0.1e and associated developement headers required])
+	AC_MSG_ERROR([OpenSSL >= 1.0.2 and associated developement headers required])
 fi
 
 AX_CHECK_JAVA

--- a/libs/sofia-sip/libsofia-sip-ua/tport/tport_tls.c
+++ b/libs/sofia-sip/libsofia-sip-ua/tport/tport_tls.c
@@ -53,6 +53,10 @@
 #include <openssl/bio.h>
 #include <openssl/opensslv.h>
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(OPENSSL_NO_DH)
+#include <openssl/dh.h>
+#endif
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -95,8 +99,12 @@ static int tls_ex_data_idx = -1; /* see SSL_get_ex_new_index(3ssl) */
 static void
 tls_init_once(void)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+  OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
+#else
   SSL_library_init();
   SSL_load_error_strings();
+#endif
   tls_ex_data_idx = SSL_get_ex_new_index(0, "sofia-sip private data", NULL, NULL, NULL);
 }
 

--- a/src/include/switch_ssl.h
+++ b/src/include/switch_ssl.h
@@ -48,13 +48,28 @@
 #include <openssl/err.h>
 #include <openssl/bio.h>
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#define HAVE_OPENSSL_1_1_API
+#endif
+
+#ifdef HAVE_OPENSSL_1_1_API
+#include <openssl/rsa.h>
+#include <openssl/bn.h>
+#include <openssl/dh.h>
+#else
+#define X509_get0_notBefore(X) X509_get_notBefore(X)
+#define X509_get0_notAfter(X) X509_get_notAfter(X)
+#endif
+
 SWITCH_DECLARE(int) switch_core_cert_extract_fingerprint(X509* x509, dtls_fingerprint_t *fp);
 
 #else
 static inline int switch_core_cert_extract_fingerprint(void* x509, dtls_fingerprint_t *fp) { return 0; }
 #endif
 
+#ifndef HAVE_OPENSSL_1_1_API
 SWITCH_DECLARE(void) switch_ssl_destroy_ssl_locks(void);
 SWITCH_DECLARE(void) switch_ssl_init_ssl_locks(void);
+#endif
 
 #endif

--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -1936,8 +1936,15 @@ SWITCH_DECLARE(switch_status_t) switch_core_init(switch_core_flag_t flags, switc
 		runtime.console = stdout;
 	}
 
+#ifdef HAVE_OPENSSL_1_1_API
+	if (!OPENSSL_init_ssl(0, NULL)) {
+		*err = "FATAL ERROR! Could not initialize OpenSSL\n";
+		return SWITCH_STATUS_MEMERR;
+	}
+#else
 	SSL_library_init();
 	switch_ssl_init_ssl_locks();
+#endif
 	switch_curl_init();
 
 	switch_core_set_variable("hostname", runtime.hostname);
@@ -3000,7 +3007,9 @@ SWITCH_DECLARE(switch_status_t) switch_core_destroy(void)
 
 	switch_curl_destroy();
 
+#ifndef HAVE_OPENSSL_1_1_API
 	switch_ssl_destroy_ssl_locks();
+#endif
 
 	switch_scheduler_task_thread_stop();
 

--- a/src/switch_core_cert.c
+++ b/src/switch_core_cert.c
@@ -46,9 +46,9 @@ static inline void switch_ssl_ssl_lock_callback(int mode, int type, char *file, 
 	}
 }
 
-static inline unsigned long switch_ssl_ssl_thread_id(void)
+static inline void switch_ssl_ssl_thread_id(CRYPTO_THREADID *id)
 {
-	return (unsigned long) switch_thread_self();
+	CRYPTO_THREADID_set_numeric(id, (unsigned long)switch_thread_self());
 }
 
 SWITCH_DECLARE(void) switch_ssl_init_ssl_locks(void)
@@ -69,7 +69,7 @@ SWITCH_DECLARE(void) switch_ssl_init_ssl_locks(void)
 			switch_assert(ssl_mutexes[i] != NULL);
 		}
 
-		CRYPTO_set_id_callback(switch_ssl_ssl_thread_id);
+		CRYPTO_THREADID_set_callback(switch_ssl_ssl_thread_id);
 		CRYPTO_set_locking_callback((void (*)(int, int, const char*, int))switch_ssl_ssl_lock_callback);
 	}
 
@@ -82,6 +82,7 @@ SWITCH_DECLARE(void) switch_ssl_destroy_ssl_locks(void)
 
 	if (ssl_count == 1) {
 		CRYPTO_set_locking_callback(NULL);
+		CRYPTO_THREADID_set_callback(NULL);
 		for (i = 0; i < CRYPTO_num_locks(); i++) {
 			if (ssl_mutexes[i]) {
 				switch_mutex_destroy(ssl_mutexes[i]);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8476,11 +8476,7 @@ static void check_dtls_reinvite(switch_core_session_t *session, switch_rtp_engin
 
 		if (!zstr(engine->local_dtls_fingerprint.str) && switch_rtp_has_dtls() && dtls_ok(session)) {
 
-#ifdef HAVE_OPENSSL_DTLSv1_2_method
 			uint8_t want_DTLSv1_2 = 1;
-#else
-			uint8_t want_DTLSv1_2 = 0;
-#endif // HAVE_OPENSSL_DTLSv1_2_method
 
 			dtls_type_t xtype, dtype = engine->dtls_controller ? DTLS_TYPE_CLIENT : DTLS_TYPE_SERVER;
 
@@ -8520,12 +8516,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_activate_rtp(switch_core_sessi
 	switch_rtp_engine_t *a_engine, *v_engine, *t_engine;
 	switch_media_handle_t *smh;
 	int is_reinvite = 0;
-
-#ifdef HAVE_OPENSSL_DTLSv1_2_method
-			uint8_t want_DTLSv1_2 = 1;
-#else
-			uint8_t want_DTLSv1_2 = 0;
-#endif
+	uint8_t want_DTLSv1_2 = 1;
 
 	switch_assert(session);
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -3757,11 +3757,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_add_dtls(switch_rtp_t *rtp_session, d
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
 	dtls->ssl_ctx = SSL_CTX_new((type & DTLS_TYPE_SERVER) ? DTLS_server_method() : DTLS_client_method());
 #else
-    #ifdef HAVE_OPENSSL_DTLSv1_2_method
-	        dtls->ssl_ctx = SSL_CTX_new((type & DTLS_TYPE_SERVER) ? (want_DTLSv1_2 ? DTLSv1_2_server_method() : DTLSv1_server_method()) : (want_DTLSv1_2 ? DTLSv1_2_client_method() : DTLSv1_client_method()));
-    #else
-            dtls->ssl_ctx = SSL_CTX_new((type & DTLS_TYPE_SERVER) ? DTLSv1_server_method() : DTLSv1_client_method());
-    #endif // HAVE_OPENSSL_DTLSv1_2_method
+	dtls->ssl_ctx = SSL_CTX_new((type & DTLS_TYPE_SERVER) ? (want_DTLSv1_2 ? DTLSv1_2_server_method() : DTLSv1_server_method()) : (want_DTLSv1_2 ? DTLSv1_2_client_method() : DTLSv1_client_method()));
 #endif
 	switch_assert(dtls->ssl_ctx);
 


### PR DESCRIPTION
Hi all,

This is a follow-up to #105. The PR breaks with old OpenSSL releases. It updates the baseline to OpenSSL 1.0.2 and adds support for OpenSSL 1.1.0.

I'm not a programmer, so I assume some things may not be perfect. But maybe this PR can serve as a stepping stone.

I compile-tested this against OpenSSL 1.1.1d three different ways:

1. OpenSSL compiled with "no-deprecated"
2. OpenSSL compiled without "no-deprecated" and "OPENSSL_API_COMPAT=0x10002000L" defined in FreeSWITCH's CFLAGS and CPPFLAGS (in hindsight this may have been gratuitous because the patches check OPENSSL_VERSION_NUMBER)
3. OpenSSL compiled without "no-deprecated" and "OPENSSL_API_COMPAT=0x10100000L" defined in FreeSWITCH's CFLAGS and CPPFLAGS

I run-tested this on a mips box with OpenSSL 1.1.1d. I setup two phones registering to FS. Both were able to use SRTP without issues.

```
2019-11-10 19:43:46.523847 [INFO] switch_rtp.c:4208 Activating audio Secure RTP SEND
2019-11-10 19:43:46.543737 [DEBUG] switch_core_sqldb.c:2799 Secure Type: srtp:sdes:AES_CM_256_HMAC_SHA1_80
2019-11-10 19:43:46.543737 [INFO] switch_rtp.c:4186 Activating audio Secure RTP RECV
2019-11-10 19:43:46.543737 [DEBUG] switch_core_sqldb.c:2799 Secure Type: srtp:sdes:AES_CM_256_HMAC_SHA1_80
```

On both phones Linphone showed the lock on the upper right corner.

Then I configured TLS on the server and had one phone register with TLS. I told Linphone not to verify neither certificate nor cn (you can't setup the CA pem in Android app directly, I needed to get an ADB shell and I didn't feel like playing around with this for an hour).

Linphone was able to register successfully:

```
 send 440 bytes to tls/[192.168.0.120]:49198 at 19:43:38.002055:
------------------------------------------------------------------------
SIP/2.0 200 OK
v:SIP/2.0/TLS 192.168.0.120:49198;alias;branch=z9hG4bK.AJVeuQKUu;rport=49198
From: <sip:301@192.168.0.1>;tag=2CaNlWS4E
t:sip:301@192.168.0.1;tag=BaBt9HFpagFFB
Call-ID: lSoaFTRPL6
CSeq: 21 REGISTER
m:<sip:301@192.168.0.120:49198;transport=tls>;expires=3600
Date:Sun, 10 Nov 2019 18:43:37 GMT
User-Agent:FreeSWITCH
Allow:INVITE,ACK,BYE,CANCEL,OPTIONS,MESSAGE,INFO,UPDATE,REGISTER,NOTIFY
k:timer,path,replaces
l:0
```

I dumped the traffic and had a look. TLSv1.2 was used:

```
Transport Layer Security
    TLSv1.2 Record Layer: Handshake Protocol: New Session Ticket
        Content Type: Handshake (22)
        Version: TLS 1.2 (0x0303)
        Length: 202
```

Android had offered TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 up top, which OpenSSL accepted.

Kind regards,
Seb