### PR TITLE
[mod_verto] Setting transfer_disposition to recv_replace on aleg

### DIFF
--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -2995,6 +2995,7 @@ static switch_bool_t attended_transfer(switch_core_session_t *session, switch_co
 
 	if (tech_pvt && b_tech_pvt) {
 		switch_channel_set_variable(tech_pvt->channel, "refer_uuid", switch_core_session_get_uuid(b_tech_pvt->session));
+		switch_channel_set_variable(tech_pvt->channel, "transfer_disposition", "recv_replace");
 		switch_channel_set_variable(b_tech_pvt->channel, "transfer_disposition", "replaced");
 
 		br_a = switch_channel_get_partner_uuid(tech_pvt->channel);
@@ -3206,6 +3207,7 @@ static switch_bool_t verto__modify_func(const char *method, cJSON *params, jsock
 			if (switch_core_session_get_partner(tech_pvt->session, &other_session) == SWITCH_STATUS_SUCCESS) {
 				switch_ivr_session_transfer(other_session, destination, NULL, NULL);
 				cJSON_AddItemToObject(obj, "message", cJSON_CreateString("CALL TRANSFERRED"));
+				switch_channel_set_variable(tech_pvt->channel, "transfer_disposition", "recv_replace");
 				switch_core_session_rwunlock(other_session);
 			} else {
 				cJSON_AddItemToObject(obj, "message", cJSON_CreateString("call is not bridged"));


### PR DESCRIPTION
According to mod_sofia, when a leg receives a cmd replace the first leg get transfer_disposition variable equals recv_replace and this step is missing on mod_verto

[mod_verto]: Setting transfer_disposition to recv_replace on aleg for command replace handler (attended transfer)

[mod_verto]: Setting transfer_disposition to recv_replace on aleg for command replace handler (blind transfer)