### PR TITLE
[mod_portaudio] CF_AUDIO flag is not set

### DIFF
--- a/src/mod/endpoints/mod_portaudio/mod_portaudio.c
+++ b/src/mod/endpoints/mod_portaudio/mod_portaudio.c
@@ -282,6 +282,14 @@ SWITCH_STANDARD_API(pa_cmd);
 */
 static switch_status_t channel_on_init(switch_core_session_t *session)
 {
+	switch_channel_t *channel;
+
+	if (session) {
+		if ((channel = switch_core_session_get_channel(session))) {
+			switch_channel_set_flag(channel, CF_AUDIO);
+		}
+	}
+
 	return SWITCH_STATUS_SUCCESS;
 }
 
@@ -1267,6 +1275,7 @@ static switch_call_cause_t channel_outgoing_channel(switch_core_session_t *sessi
 
 	switch_set_flag_locked(tech_pvt, TFLAG_OUTBOUND);
 	switch_channel_set_state(channel, CS_INIT);
+	switch_channel_set_flag(channel, CF_AUDIO);
 	return SWITCH_CAUSE_SUCCESS;
 
 error:


### PR DESCRIPTION
Fixes https://github.com/signalwire/freeswitch/issues/169