### PR TITLE
[mod_callcenter] Generate event on agent delete and additional check for Status and State before delete

### DIFF
--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -929,16 +929,36 @@ done:
 
 cc_status_t cc_agent_del(const char *agent)
 {
-	cc_status_t result = CC_STATUS_SUCCESS;
+	switch_event_t *event;
+	cc_status_t result;
 
 	char *sql;
+	int deleted_row_count;
 
-	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Deleted Agent %s\n", agent);
-	sql = switch_mprintf("DELETE FROM agents WHERE name = '%q';"
-			"DELETE FROM tiers WHERE agent = '%q';",
-			agent, agent);
+	sql = switch_mprintf("DELETE FROM tiers WHERE agent = '%q';", agent);
 	cc_execute_sql(NULL, sql, NULL);
 	switch_safe_free(sql);
+
+	sql = switch_mprintf("DELETE FROM agents WHERE name = '%q';",	agent);
+	deleted_row_count = cc_execute_sql_affected_rows(sql);
+	switch_safe_free(sql);
+
+  if (deleted_row_count > 0) {
+
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Deleted Agent %s\n", agent);
+
+		if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, CALLCENTER_EVENT) == SWITCH_STATUS_SUCCESS) {
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "CC-Agent", agent);
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "CC-Action", "agent-del");
+			switch_event_fire(&event);
+		}
+		result = CC_STATUS_SUCCESS;
+
+	} else {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Agent %s not found, can not be deleted\n", agent);
+		result = CC_STATUS_AGENT_NOT_FOUND;
+	}
+
 	return result;
 }
 
@@ -3588,6 +3608,9 @@ SWITCH_STANDARD_API(cc_config_api_function)
 					case CC_STATUS_SUCCESS:
 						stream->write_function(stream, "%s", "+OK\n");
 						break;
+					case CC_STATUS_AGENT_NOT_FOUND:
+						stream->write_function(stream, "%s", "-ERR Agent not found!\n");
+						goto done;
 					default:
 						stream->write_function(stream, "%s", "-ERR Unknown Error!\n");
 						goto done;


### PR DESCRIPTION
This is similar to #141 regarding issues #140 , where the original patch from ukolovda remain.  But I've added additional security check that make agent delete safe to use.

Before, you could delete an agent even when it in the middle of being called or in a call with a member, which then could cause undefined behavior.  The changed is made to check for the agent to be in State Waiting and Status Logged Out.