### PR TITLE
[core] Fix copy/paste mistake in switch_xml.h

### DIFF
--- a/src/include/switch_xml.h
+++ b/src/include/switch_xml.h
@@ -233,7 +233,7 @@ SWITCH_DECLARE(char *) switch_xml_tohtml_ex(_In_ switch_xml_t xml, _In_ switch_b
 ///\param prn_header add <?xml version..> header too
 ///\param use_utf8_encoding encoding into ampersand entities for UTF-8 chars
 ///\return the xml text string
-#define switch_xml_toxml_buf(xml, buf, buflen, offset, prn_header) switch_xml_toxml_buf(xml, buf, buflen, offset, prn_header, USE_UTF_8_ENCODING);
+#define switch_xml_toxml_buf(xml, buf, buflen, offset, prn_header) switch_xml_toxml_buf_ex(xml, buf, buflen, offset, prn_header, USE_UTF_8_ENCODING);
 SWITCH_DECLARE(char *) switch_xml_toxml_buf_ex(_In_ switch_xml_t xml, _In_z_ char *buf, _In_ switch_size_t buflen, _In_ switch_size_t offset,
 											_In_ switch_bool_t prn_header, switch_bool_t use_utf8_encoding);
 


### PR DESCRIPTION
Commit 7907994 introduced a copy/paste mistake that may result in
compile failure:

In file included from ../../../../src/include/switch.h:134,
                 from mod_xml_ldap.c:34:
mod_xml_ldap.c: In function 'xml_ldap_search':
../../../../src/include/switch_xml.h:236:68: error: implicit declaration of function 'switch_xml_toxml_buf'; did you mean 'switch_xml_toxml_buf_ex'? [-Werror=implicit-function-declaration]
 #define switch_xml_toxml_buf(xml, buf, buflen, offset, prn_header) switch_xml_toxml_buf(xml, buf, buflen, offset, prn_header, USE_UTF_8_ENCODING);
                                                                    ^~~~~~~~~~~~~~~~~~~~
mod_xml_ldap.c:764:9: note: in expansion of macro 'switch_xml_toxml_buf'
         switch_xml_toxml_buf(xml, buf, 0, 0, 1);
         ^~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[7]: *** [Makefile:710: mod_xml_ldap_la-mod_xml_ldap.lo] Error 1

This commit fixes the mistake.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Ping @seven1240 