### PR TITLE
[Core] switch_loadable_module wrongly logs that modules.conf loading fails while it's pre_load_modules.conf

### DIFF
--- a/src/switch_loadable_module.c
+++ b/src/switch_loadable_module.c
@@ -2229,7 +2229,7 @@ SWITCH_DECLARE(switch_status_t) switch_loadable_module_init(switch_bool_t autolo
 
 	}
 	else {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CONSOLE, "open of %s failed\n", cf);
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CONSOLE, "open of %s failed\n", precf);
 	}
 
 	if (switch_core_sqldb_init(&err) != SWITCH_STATUS_SUCCESS)


### PR DESCRIPTION
fix print log error