### PR TITLE
[Build-system] Fallback for mariadb lib check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -708,7 +708,11 @@ AC_SUBST([POSTGRESQL_LIBDIR], [$POSTGRESQL_LIBDIR])
 
 PKG_CHECK_MODULES([MARIADB], [libmariadb >= 3.0.9],[
   AM_CONDITIONAL([HAVE_MARIADB],[true])],[
-  AC_MSG_RESULT([no]); AM_CONDITIONAL([HAVE_MARIADB],[false])])
+    AC_MSG_RESULT([no]);
+    PKG_CHECK_MODULES([MARIADB], [mariadb >= 3.0.9],[
+      AC_MSG_RESULT([no]); AM_CONDITIONAL([HAVE_MARIADB],[false])
+    ])
+])
 
 AC_ARG_ENABLE(deprecated-core-db-events,
 	[AS_HELP_STRING([--enable-deprecated-core-db-events], [Keep deprecated core db events])],,[enable_deprecated_core_db_events="no"])


### PR DESCRIPTION
Upstream libs for ubuntu seem to provide only mariadb.pc and not libmariadb.pc - simple fallback check gets the build working. 