### PR TITLE
Verto clientReady reattached_sessions

### DIFF
--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -1256,7 +1256,7 @@ static void attach_calls(jsock_t *jsock)
 			}
 
 			tech_reattach(tech_pvt, jsock);
-			cJSON_AddItemToArray(reattached_sessions, cJSON_CreateString(jsock->uuid_str));
+			cJSON_AddItemToArray(reattached_sessions, cJSON_CreateString(switch_core_session_get_uuid(tech_pvt->session)));
 		}
 	}
 	switch_thread_rwlock_unlock(verto_globals.tech_rwlock);


### PR DESCRIPTION
Make mod_verto clientReady reattached_sessions array send channel IDs rather than the same connection ID repeatedly.

See issue #111 for the reasons behind this change.

Resolves:#111 