### PR TITLE
[core] fix: don't terminate file before max_samples returned

### DIFF
--- a/src/switch_core_file.c
+++ b/src/switch_core_file.c
@@ -482,7 +482,6 @@ SWITCH_DECLARE(switch_status_t) switch_core_file_read(switch_file_handle_t *fh, 
 				if (status != SWITCH_STATUS_SUCCESS || !rlen) {
 					switch_set_flag_locked(fh, SWITCH_FILE_BUFFER_DONE);
 				} else {
-					fh->samples_in += rlen;
 					if (fh->real_channels != fh->channels && !switch_test_flag(fh, SWITCH_FILE_NOMUX)) {
 						switch_mux_channels((int16_t *) fh->pre_buffer_data, rlen, fh->real_channels, fh->channels);
 					}
@@ -492,6 +491,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_file_read(switch_file_handle_t *fh, 
 		}
 
 		rlen = switch_buffer_read(fh->pre_buffer, data, asis ? *len : *len * 2 * fh->channels);
+		fh->samples_in += rlen;
 		*len = asis ? rlen : rlen / 2 / fh->channels;
 
 		if (*len == 0) {


### PR DESCRIPTION
This PR attempts to fix the issue when a small part of a file should be played but almost nothing gets played instead.

The issue can be reproduced with the following steps:

1. create a conference
2. play a low bitrate file with a small timeout eg. conference test play {timeout=1800}sound.vox
[sound.zip](https://github.com/signalwire/freeswitch/files/4041022/sound.zip)

Problem:
If file buffer is considerably bigger than max_samples than keeping track of samples read instead of samples returned might result in a significantly shorter play

My fix:
increment fh->samples in only with the amount actually returned from each switch_core_file_read invocation