### PR TITLE
Update avformat.c

### DIFF
--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -49,7 +49,7 @@ GCC_DIAG_OFF(deprecated-declarations)
 #define swr_get_out_samples avresample_get_out_samples
 #define swr_get_out_samples avresample_get_out_samples
 #define swr_convert(ctx, odata, osamples, idata, isamples) \
-	avresample_convert(ctx, odata, osamples, 0, (uint8_t **)idata, isamples, 0)
+	avresample_convert(ctx, odata, 0, osamples, (uint8_t **)idata, 0, isamples)
 #else
 #include <libswresample/swresample.h>
 #endif


### PR DESCRIPTION
fix mod_av not have auido when use avresample.
the define swr_convert is error.
----it cost my long time to find it.