### PR TITLE
[mod_kazoo] Fix performance issue

### DIFF
--- a/src/mod/event_handlers/mod_kazoo/kazoo_node.c
+++ b/src/mod/event_handlers/mod_kazoo/kazoo_node.c
@@ -1505,7 +1505,7 @@ static void *SWITCH_THREAD_FUNC handle_node(switch_thread_t *thread, void *obj) 
 		}
 
 		while (++send_msg_count <= kazoo_globals.send_msg_batch
-			   && switch_queue_pop_timeout(ei_node->send_msgs, &pop, 20000) == SWITCH_STATUS_SUCCESS) {
+			   && switch_queue_trypop(ei_node->send_msgs, &pop) == SWITCH_STATUS_SUCCESS) {
 			ei_send_msg_t *send_msg = (ei_send_msg_t *) pop;
 			ei_helper_send(ei_node, &send_msg->pid, &send_msg->buf);
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Sent erlang message to %s <%d.%d.%d>\n"


### PR DESCRIPTION
We have found out that after commit https://github.com/signalwire/freeswitch/commit/df1ac5dbe0 (since FS v1.8.6)
the performance of fetch replies drastically decreased and it happened beacause of using
switch_queue_pop_timeout instead of switch_queue_trypop which was used before that commit
When we rolled back to switch_queue_trypop the perfomance was as good as in FS v1.8.5