### PR TITLE
[SpanDSP] Remove unused x_repeats variable from header_row_read_handler()

### DIFF
--- a/libs/spandsp/src/t4_tx.c
+++ b/libs/spandsp/src/t4_tx.c
@@ -1476,7 +1476,6 @@ static int make_header(t4_tx_state_t *s)
 
 static int header_row_read_handler(void *user_data, uint8_t buf[], size_t len)
 {
-    int x_repeats;
     int y_repeats;
     int pattern;
     int pos;
@@ -1490,51 +1489,40 @@ static int header_row_read_handler(void *user_data, uint8_t buf[], size_t len)
     {
     default:
     case T4_RESOLUTION_100_100:
-        x_repeats = 1;
         y_repeats = 1;
         break;
     case T4_RESOLUTION_R8_STANDARD:
     case T4_RESOLUTION_200_100:
-        x_repeats = 2;
         y_repeats = 1;
         break;
     case T4_RESOLUTION_R8_FINE:
     case T4_RESOLUTION_200_200:
-        x_repeats = 2;
         y_repeats = 2;
         break;
     case T4_RESOLUTION_300_300:
-        x_repeats = 3;
         y_repeats = 3;
         break;
     case T4_RESOLUTION_R8_SUPERFINE:
     case T4_RESOLUTION_200_400:
-        x_repeats = 2;
         y_repeats = 4;
         break;
     case T4_RESOLUTION_R16_SUPERFINE:
     case T4_RESOLUTION_400_400:
-        x_repeats = 4;
         y_repeats = 4;
         break;
     case T4_RESOLUTION_400_800:
-        x_repeats = 4;
         y_repeats = 8;
         break;
     case T4_RESOLUTION_300_600:
-        x_repeats = 3;
         y_repeats = 6;
         break;
     case T4_RESOLUTION_600_600:
-        x_repeats = 6;
         y_repeats = 6;
         break;
     case T4_RESOLUTION_600_1200:
-        x_repeats = 6;
         y_repeats = 12;
         break;
     case T4_RESOLUTION_1200_1200:
-        x_repeats = 12;
         y_repeats = 12;
         break;
     }
@@ -1543,10 +1531,8 @@ static int header_row_read_handler(void *user_data, uint8_t buf[], size_t len)
     case T4_SUPPORT_WIDTH_215MM:
         break;
     case T4_SUPPORT_WIDTH_255MM:
-        x_repeats *= 2;
         break;
     case T4_SUPPORT_WIDTH_303MM:
-        x_repeats *= 3;
         break;
     }
     if (s->header_overlays_image)


### PR DESCRIPTION
Scan-build should be happier with this.