### PR TITLE
[mod_sofia] multi-server call recovery

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -2246,6 +2246,12 @@ int sofia_recover_callback(switch_core_session_t *session)
 	switch_mutex_init(&tech_pvt->flag_mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
 	switch_mutex_init(&tech_pvt->sofia_mutex, SWITCH_MUTEX_NESTED, switch_core_session_get_pool(session));
 
+	// replace "local_media_ip" and "advertised_media_ip" channel variables, with
+	// values from local server's profile. This would enable an instance to recover
+	// calls tracked by a different instance.
+	switch_channel_set_variable_printf(channel, "local_media_ip", "%s", *profile->rtpip);
+	switch_channel_set_variable_printf(channel, "advertised_media_ip", "%s", profile->extrtpip);
+
 	tech_pvt->mparams.remote_ip = (char *) switch_channel_get_variable(channel, "sip_network_ip");
 	tech_pvt->mparams.remote_port = atoi(switch_str_nil(switch_channel_get_variable(channel, "sip_network_port")));
 	tech_pvt->caller_profile = switch_channel_get_caller_profile(channel);

--- a/src/switch_ivr.c
+++ b/src/switch_ivr.c
@@ -2766,7 +2766,7 @@ static int switch_ivr_set_xml_chan_var(switch_xml_t xml, const char *var, const 
 	if (!zstr(var) && ((variable = switch_xml_add_child_d(xml, var, off++)))) {
 		if ((data = malloc(dlen))) {
 			memset(data, 0, dlen);
-			switch_url_encode(val, data, dlen);
+			switch_url_encode_opt(val, data, dlen, SWITCH_TRUE);
 			switch_xml_set_txt_d(variable, data);
 			free(data);
 		} else abort();


### PR DESCRIPTION
Scenario :
Two FS instances (FS1 and FS2), share same database to track calls.
FS1 : internal IP = 10.1.1.1, external IP = 1.1.1.1
FS2 : internal IP = 10.2.2.2, external IP = 2.2.2.2

Now, when FS1 is tracking calls, it will store it's own private and public IPs in the database. if FS1 crashes, and we try to recover those calls on FS2, currently it will not succeed, as FS2 will try to use FS1 IPs stored in the DB.
This commit will replace FS1 IPs in local_media_ip and advertised_media_ip channel variables, with FS2's IPs as configured per profile, to make sure the call recovery works.

We have tested this setup and functionality, with two instances running versions 1.8.5, 1.10.2 and 1.10.3.dev

P.S. : This commit also includes a small fix for a scenario, where call data is inserted single escaped into the database, and on recovery, un-escaping will break the call.