### PR TITLE
[mod_httapi] Introduction of connect-timeout param

### DIFF
--- a/conf/vanilla/autoload_configs/httapi.conf.xml
+++ b/conf/vanilla/autoload_configs/httapi.conf.xml
@@ -105,6 +105,8 @@
 	<!-- <param name="ssl-key-password" value="MyPrivateKeyPassword"/> -->
 	<!-- optional timeout -->
 	<!-- <param name="timeout" value="10"/> -->
+	<!-- optional: maximum amount of time in seconds that is allowed to make the connection to the server -->
+	<!-- <param name="connect-timeout" value="2"/> -->
 
 	<!-- optional: use a custom CA certificate in PEM format to verify the peer
 	     with. This is useful if you are acting as your own certificate authority.

--- a/src/mod/applications/mod_httapi/conf/autoload_configs/httapi.conf.xml
+++ b/src/mod/applications/mod_httapi/conf/autoload_configs/httapi.conf.xml
@@ -105,6 +105,8 @@
 	<!-- <param name="ssl-key-password" value="MyPrivateKeyPassword"/> -->
 	<!-- optional timeout -->
 	<!-- <param name="timeout" value="10"/> -->
+	<!-- optional: maximum amount of time in seconds that is allowed to make the connection to the server -->
+	<!-- <param name="connect-timeout" value="2"/> -->
 
 	<!-- optional: use a custom CA certificate in PEM format to verify the peer
 	     with. This is useful if you are acting as your own certificate authority.

--- a/src/mod/applications/mod_httapi/docs/mod_httapi_doc.txt
+++ b/src/mod/applications/mod_httapi/docs/mod_httapi_doc.txt
@@ -319,6 +319,7 @@ auth-scheme                     : <string               >               basic   
 disable-100-continue            : <true|false>          true            Disable the 100 continue feature.
 method                          : <string>              ""              METHOD name to send.
 timeout                         : <number>              0               Timeout waiting for response.
+connect-timeout                 : <number>              0               Timeout to create connection.
 enable-cacert-check             : <true|false>          false           Check CA/CERT.
 ssl-cert-path                   : <string>              ""              path to file.
 ssl-key-path                    : <string>              ""              path to file.

--- a/src/mod/applications/mod_httapi/docs/mod_httapi_doc.txt
+++ b/src/mod/applications/mod_httapi/docs/mod_httapi_doc.txt
@@ -319,7 +319,8 @@ auth-scheme                     : <string               >               basic   
 disable-100-continue            : <true|false>          true            Disable the 100 continue feature.
 method                          : <string>              ""              METHOD name to send.
 timeout                         : <number>              0               Timeout waiting for response.
-connect-timeout                 : <number>              0               Timeout to create connection.
+connect-timeout                 : <number>              0               Timeout to create connection. Use default value 0 to switch to the
+                                                                        default built-in connection timeout - 300 seconds.
 enable-cacert-check             : <true|false>          false           Check CA/CERT.
 ssl-cert-path                   : <string>              ""              path to file.
 ssl-key-path                    : <string>              ""              path to file.


### PR DESCRIPTION
Added a new param for mod_httapi, which will limit the time taken to establish connection to the server.
Current default timeout (i.e. 300 seconds) is too high. 