### PR TITLE
[FreeSwitchConsole] -version option enabled in windows + read git revision

### DIFF
--- a/src/switch.c
+++ b/src/switch.c
@@ -686,11 +686,6 @@ int main(int argc, char *argv[])
 			reincarnate = SWITCH_TRUE;
 			reincarnate_reexec = SWITCH_TRUE;
 		}
-
-		else if (!strcmp(local_argv[x], "-version")) {
-			fprintf(stdout, "FreeSWITCH version: %s (%s)\n", switch_version_full(), switch_version_revision_human());
-			exit(EXIT_SUCCESS);
-		}
 #endif
 #ifdef HAVE_SETRLIMIT
 		else if (!strcmp(local_argv[x], "-core")) {
@@ -715,6 +710,11 @@ int main(int argc, char *argv[])
 #endif
 		}
 #endif
+		else if (!strcmp(local_argv[x], "-version")) {
+			fprintf(stdout, "FreeSWITCH version: %s (%s)\n", switch_version_full(), switch_version_revision_human());
+			exit(EXIT_SUCCESS);
+		}
+
 		else if (!strcmp(local_argv[x], "-hp") || !strcmp(local_argv[x], "-rp")) {
 			priority = 2;
 		}

--- a/w32/switch_version.props
+++ b/w32/switch_version.props
@@ -21,6 +21,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
+using System.Diagnostics;
 
     public class SwitchVersionTask : Microsoft.Build.Utilities.Task
     {
@@ -28,12 +29,43 @@ using Microsoft.Build.Framework;
         private string TemplatePath;
         private string DestinationPath;
 
+		private static string sys(string cmd, string args, string stdIn, out string err)
+        {
+            err = null;
+            using (Process p = new Process())
+            {
+                p.StartInfo.RedirectStandardInput = true;
+                p.StartInfo.UseShellExecute = false;
+                p.StartInfo.RedirectStandardOutput = true;
+                p.StartInfo.RedirectStandardError = true;
+                p.StartInfo.FileName = cmd;
+                p.StartInfo.Arguments = args;
+                p.Start();
+                p.StandardInput.Write(stdIn);
+                p.StandardInput.Close();
+                string output = p.StandardOutput.ReadToEnd();
+                err = p.StandardError.ReadToEnd();
+                p.WaitForExit();
+                return output;
+            }
+        }
+
         public override bool Execute()
         {
             basedir = Path.GetFullPath(@"$(BaseDir)");
 
             Log.LogMessage(MessageImportance.High,
-                  "Parsing FreeSWITCH version.");                    
+                  "Parsing FreeSWITCH version.");
+            string err;
+            string revision = sys("git", @"-C """ + basedir.Substring(0, basedir.Length-1) + @""" rev-parse --short HEAD", null, out err);
+            if (!string.IsNullOrWhiteSpace(err))
+            {
+                    revision = "";
+            }
+            else
+            {
+                    revision = revision.Trim();
+            }
 
             string ConfigureAC = File.ReadAllText(@"$(BaseDir)configure.ac");                
             string pattern = @"AC_SUBST\((SWITCH_VERSION_[A-Z_]+),.*\[(.*)\]\)";
@@ -49,9 +81,14 @@ using Microsoft.Build.Framework;
                    string[] tokens = value.Split('-');
                    value = tokens[0];
                }        
-               v.Add(m.Groups[1].Value.Trim(), value.Trim());
-               Log.LogMessage(MessageImportance.High,
-                    m.Groups[1].Value + " = '" + value.Trim() + "'");                    
+               var name = m.Groups[1].Value.Trim();
+               value = value.Trim();
+               if (name.StartsWith("SWITCH_VERSION_REVISION") && string.IsNullOrWhiteSpace(value))
+               {
+                   value = revision;
+               }
+               v.Add(name, value);
+               Log.LogMessage(MessageImportance.High, name + " = '" + value + "'");
             }
             
             //---------------------------------------------------------            

--- a/w32/switch_version.props
+++ b/w32/switch_version.props
@@ -16,6 +16,7 @@
              TaskFactory="CodeTaskFactory"  
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
              <ParameterGroup>
+                <commits Required="true" />
                 <revision Required="true" />
              </ParameterGroup>
              <Task>  
@@ -33,6 +34,7 @@ using Microsoft.Build.Framework;
     {
         [Required]
         public string revision { get; set; }
+        public string commits { get; set; }
 
         private string basedir;
         private string TemplatePath;
@@ -41,6 +43,9 @@ using Microsoft.Build.Framework;
         public override bool Execute()
         {
             basedir = Path.GetFullPath(@"$(BaseDir)");
+
+            int commit_count = 0;
+            Int32.TryParse(commits, out commit_count);
 
             Log.LogMessage(MessageImportance.High,
                   "Parsing FreeSWITCH version.");                    
@@ -61,8 +66,21 @@ using Microsoft.Build.Framework;
                }        
                var name = m.Groups[1].Value.Trim();
                value = value.Trim();
-               if (name.StartsWith("SWITCH_VERSION_REVISION") && string.IsNullOrWhiteSpace(value)) {
-                   value = revision;
+
+               if (name.StartsWith("SWITCH_VERSION_REVISION")) {
+                   if (string.IsNullOrWhiteSpace(value)) {
+                       value = revision;
+                   }
+
+                   if (name != "SWITCH_VERSION_REVISION_HUMAN") {
+                       value = "~" + value;
+                   
+                       if (commit_count > 0) {
+                           value = "-dev-"+ commits + value;
+                       } else {
+                           value = "-release" + value;
+                       }
+                   }
                }
                v.Add(name, value);
                Log.LogMessage(MessageImportance.High, name + " = '" + value + "'");
@@ -107,7 +125,7 @@ using Microsoft.Build.Framework;
   </UsingTask>  
 
   <Target Name="SwitchVersionTarget" BeforeTargets="CustomBuild;Build">  
-      <SwitchVersionTask revision="$(GitCommit)">         
+      <SwitchVersionTask commits="$(GitCommits)" revision="$(GitCommit)">
       </SwitchVersionTask>         
   </Target> 
 

--- a/w32/switch_version.props
+++ b/w32/switch_version.props
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" InitialTargets="GitVersion" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <GitSkipCache>true</GitSkipCache>
+  </PropertyGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="basedir.props" Condition=" '$(BaseDirImported)' == ''"/>
+    <Import Project="Setup\GitInfo\GitInfo.targets" />
   </ImportGroup>
 
   <PropertyGroup>
@@ -11,6 +15,9 @@
   <UsingTask TaskName="SwitchVersionTask" 
              TaskFactory="CodeTaskFactory"  
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+             <ParameterGroup>
+                <revision Required="true" />
+             </ParameterGroup>
              <Task>  
                 <Reference Include="Microsoft.Build" />
                 <Reference Include="Microsoft.Build.Framework" />
@@ -21,51 +28,22 @@ using System.IO;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
-using System.Diagnostics;
 
     public class SwitchVersionTask : Microsoft.Build.Utilities.Task
     {
+        [Required]
+        public string revision { get; set; }
+
         private string basedir;
         private string TemplatePath;
         private string DestinationPath;
-
-		private static string sys(string cmd, string args, string stdIn, out string err)
-        {
-            err = null;
-            using (Process p = new Process())
-            {
-                p.StartInfo.RedirectStandardInput = true;
-                p.StartInfo.UseShellExecute = false;
-                p.StartInfo.RedirectStandardOutput = true;
-                p.StartInfo.RedirectStandardError = true;
-                p.StartInfo.FileName = cmd;
-                p.StartInfo.Arguments = args;
-                p.Start();
-                p.StandardInput.Write(stdIn);
-                p.StandardInput.Close();
-                string output = p.StandardOutput.ReadToEnd();
-                err = p.StandardError.ReadToEnd();
-                p.WaitForExit();
-                return output;
-            }
-        }
 
         public override bool Execute()
         {
             basedir = Path.GetFullPath(@"$(BaseDir)");
 
             Log.LogMessage(MessageImportance.High,
-                  "Parsing FreeSWITCH version.");
-            string err;
-            string revision = sys("git", @"-C """ + basedir.Substring(0, basedir.Length-1) + @""" rev-parse --short HEAD", null, out err);
-            if (!string.IsNullOrWhiteSpace(err))
-            {
-                    revision = "";
-            }
-            else
-            {
-                    revision = revision.Trim();
-            }
+                  "Parsing FreeSWITCH version.");                    
 
             string ConfigureAC = File.ReadAllText(@"$(BaseDir)configure.ac");                
             string pattern = @"AC_SUBST\((SWITCH_VERSION_[A-Z_]+),.*\[(.*)\]\)";
@@ -83,8 +61,7 @@ using System.Diagnostics;
                }        
                var name = m.Groups[1].Value.Trim();
                value = value.Trim();
-               if (name.StartsWith("SWITCH_VERSION_REVISION") && string.IsNullOrWhiteSpace(value))
-               {
+               if (name.StartsWith("SWITCH_VERSION_REVISION") && string.IsNullOrWhiteSpace(value)) {
                    value = revision;
                }
                v.Add(name, value);
@@ -130,7 +107,7 @@ using System.Diagnostics;
   </UsingTask>  
 
   <Target Name="SwitchVersionTarget" BeforeTargets="CustomBuild;Build">  
-      <SwitchVersionTask>         
+      <SwitchVersionTask revision="$(GitCommit)">         
       </SwitchVersionTask>         
   </Target> 
 


### PR DESCRIPTION
Enabled `FreeSwitchConsole -version` opt which worked in the Linux version but not in the Windows build

`PS D:\dev\freeswitch\ruccfsfork> .\FreeSwitchConsole.exe -version`
Will output:
```
FreeSWITCH version: 1.10.3-release~ca04fc3104~64bit (ca04fc3104 64bit)
```
or
```
FreeSWITCH version: 1.10.3-dev-4560~ca04fc3104~64bit (ca04fc3104 64bit)
```