### PR TITLE
Add Charge SIP Header Support

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -11344,6 +11344,8 @@ void sofia_handle_sip_i_invite(switch_core_session_t *session, nua_t *nua, sofia
 				switch_channel_set_variable(channel, "sip_geolocation_error", un->un_value);
 			} else if (!strcasecmp(un->un_name, "userLocation")) {
 				switch_channel_set_variable(channel, "sip_user_location", un->un_value);
+			} else if (!strcasecmp(un->un_name, "Charge")) {
+				switch_channel_set_variable(channel, "sip_charge", un->un_value);
 			} else if (!strncasecmp(un->un_name, "X-", 2) || !strncasecmp(un->un_name, "P-", 2) || !strcasecmp(un->un_name, "User-to-User") || !strncasecmp(un->un_name, "On", 2) || !strncasecmp(un->un_name, "K-", 2)) {
 				if (!zstr(un->un_value)) {
 					char new_name[512] = "";


### PR DESCRIPTION
I have found that some proprietary PBX's (such as Broadsoft) send the Charge header as identification instead of using Diversion or X-Accountcode.