### PR TITLE
[core] minor logging fix for switch_rtp_set_max_missed_packets

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -2909,7 +2909,7 @@ SWITCH_DECLARE(void) switch_rtp_set_max_missed_packets(switch_rtp_t *rtp_session
 	if (rtp_session->missed_count >= max) {
 
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
-						  "new max missed packets (%d->%d) greater than current missed packets (%d). RTP will timeout.\n",
+						  "new max missed packets (%d->%d) lower than current missed packets (%d). RTP will timeout.\n",
 						  rtp_session->max_missed_packets, max, rtp_session->missed_count);
 	}
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -2909,8 +2909,8 @@ SWITCH_DECLARE(void) switch_rtp_set_max_missed_packets(switch_rtp_t *rtp_session
 	if (rtp_session->missed_count >= max) {
 
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_WARNING,
-						  "new max missed packets(%d->%d) greater than current missed packets(%d). RTP will timeout.\n",
-						  rtp_session->missed_count, max, rtp_session->missed_count);
+						  "new max missed packets (%d->%d) greater than current missed packets (%d). RTP will timeout.\n",
+						  rtp_session->max_missed_packets, max, rtp_session->missed_count);
 	}
 
 	rtp_session->max_missed_packets = max;


### PR DESCRIPTION
**Proposed Changes**:
Looks like the log to indicate that the max_missed_packets threshold is changing to something below the current missed packet threshold is incorrectly outputting the transition as `missed_count -> max` instead of `max_missed_count -> max`.
