### PR TITLE
[mod_xml_curl] Allow XML_CURL_MAX_BYTES to be configured at runtime 

### DIFF
--- a/src/mod/xml_int/mod_xml_curl/conf/autoload_configs/xml_curl.conf.xml
+++ b/src/mod/xml_int/mod_xml_curl/conf/autoload_configs/xml_curl.conf.xml
@@ -44,6 +44,10 @@
 
       <!-- one or more of these imply you want to pick the exact variables that are transmitted -->
       <!--<param name="enable-post-var" value="Unique-ID"/>-->
+
+      <!-- optional: maximum response size for this binding in bytes. 
+           Defaults to XML_CURL_MAX_BYTES (1MB) if omitted -->
+      <!--<param name="response-max-bytes" value="10485760"/>-->
     </binding>
   </bindings>
 </configuration>


### PR DESCRIPTION
[mod_xml_curl] Allow XML_CURL_MAX_BYTES to be configured at runtime per-binding. 

* Added "response-max-bytes" config param for mod_xml_curl
* XML_CURL_MAX_BYTES define still used as default if param omitted
* Added example configuration to module example config.