### PR TITLE
[Verto Communicator] Update adapter-js to latest version

### DIFF
--- a/html5/verto/verto_communicator/bower.json
+++ b/html5/verto/verto_communicator/bower.json
@@ -46,7 +46,8 @@
     "bootstrap-material-design": "~0.3.0",
     "angular-translate": "~2.10.0",
     "angular-translate-loader-static-files": "~2.10.0",
-    "angular-click-outside": "~2.9.2"
+    "angular-click-outside": "~2.9.2",
+    "webrtc-adapter": "webrtcHacks/adapter"
   },
   "resolutions": {
     "angular": "~1.3.15",

--- a/html5/verto/verto_communicator/src/index.html
+++ b/html5/verto/verto_communicator/src/index.html
@@ -108,7 +108,7 @@
     <script type="text/javascript" src="../js/src/jquery.jsonrpcclient.js"></script>
     <script type="text/javascript" src="../js/src/jquery.FSRTC.js"></script>
     <script type="text/javascript" src="../js/src/jquery.verto.js"></script>
-    <script type="text/javascript" src="../js/src/vendor/adapter-latest.js"></script>
+    <script type="text/javascript" src="bower_components/webrtc-adapter/release/adapter.js"></script>
 
     <script type="text/javascript" src="js/3rd-party/getScreenId.js"></script>
     <script type="text/javascript" src="js/3rd-party/md5.min.js"></script>


### PR DESCRIPTION
Some browsers start to comply on RFC and stop receiving callbacks for some WebRTC functions. The adapter-js now shims those callbacks behavior to work as promise underneath the library.