### PR TITLE
[Configuration] sip_profiles: Use $${external_sip_ip} for ext-sip-ip, $${external_rtp_ip} for ext-rtp-ip

### DIFF
--- a/conf/vanilla/sip_profiles/external.xml
+++ b/conf/vanilla/sip_profiles/external.xml
@@ -64,7 +64,7 @@
     <param name="rtp-ip" value="$${local_ip_v4}"/>
     <param name="sip-ip" value="$${local_ip_v4}"/>
     <param name="ext-rtp-ip" value="$${external_rtp_ip}"/>
-    <param name="ext-sip-ip" value="$${external_rtp_ip}"/>
+    <param name="ext-sip-ip" value="$${external_sip_ip}"/>
     <param name="rtp-timeout-sec" value="300"/>
     <param name="rtp-hold-timeout-sec" value="1800"/>
     <!--<param name="enable-3pcc" value="true"/>-->

--- a/conf/vanilla/sip_profiles/internal.xml
+++ b/conf/vanilla/sip_profiles/internal.xml
@@ -282,7 +282,7 @@
          auto-nat              - Use ip learned from NAT-PMP or UPNP
     -->
     <param name="ext-rtp-ip" value="$${external_rtp_ip}"/>
-    <param name="ext-sip-ip" value="$${external_rtp_ip}"/>
+    <param name="ext-sip-ip" value="$${external_sip_ip}"/>
 
     <!-- rtp inactivity timeout -->
     <param name="rtp-timeout-sec" value="300"/>


### PR DESCRIPTION
<param name="ext-sip-ip" value="$${external_rtp_ip}"/>  in files internal.xml and external.xml,but it maybe is $${external_sip_ip}
