### PR TITLE
check frame->data other than packet for non-rtp frames

### DIFF
--- a/src/mod/applications/mod_conference/conference_video.c
+++ b/src/mod/applications/mod_conference/conference_video.c
@@ -4965,7 +4965,7 @@ switch_status_t conference_video_thread_callback(switch_core_session_t *session,
 	
 	switch_assert(member);
 
-	if (switch_test_flag(frame, SFF_CNG) || !frame->packet) {
+	if (switch_test_flag(frame, SFF_CNG) || !frame->data) {
 		return SWITCH_STATUS_SUCCESS;
 	}
 


### PR DESCRIPTION
This is mostly like a bug while checking the video package, as we have a non-rtp endpoint and don't have packet like rtp does.