### PR TITLE
[mod_silk] Fix mod_silk always init with maxaveragebitrate=20000

### DIFF
--- a/src/mod/codecs/mod_silk/mod_silk.c
+++ b/src/mod/codecs/mod_silk/mod_silk.c
@@ -175,6 +175,11 @@ static switch_status_t switch_silk_init(switch_codec_t *codec,
 	}
 
 	memset(&codec_fmtp, '\0', sizeof(struct switch_codec_fmtp));
+	codec_fmtp.actual_samples_per_second = codec->implementation->actual_samples_per_second;
+	codec_fmtp.bits_per_second = codec->implementation->bits_per_second;
+	codec_fmtp.microseconds_per_packet = codec->implementation->microseconds_per_packet;
+	codec_fmtp.stereo = codec->implementation->number_of_channels > 1;
+
 	codec_fmtp.private_info = &silk_codec_settings;
 	switch_silk_fmtp_parse(codec->fmtp_in, &codec_fmtp);
 


### PR DESCRIPTION
Hi, I try enable mod_silk in FS and find SILK always has maxaveragebitrate=20000, it cause from the `switch_silk_fmtp_parse()` will seek maxaveragebitrate according the `codec_fmtp.actual_samples_per_second` but it's 0. 
The solution is, init the `actual_samples_per_second before` before calling `switch_silk_fmtp_parse()`. 
Please review the changes. Thanks.