### PR TITLE
Fixed websocket write memory overbounds when received data length is greater than the buffer length(default 64k)

### DIFF
--- a/libs/sofia-sip/libsofia-sip-ua/tport/ws.c
+++ b/libs/sofia-sip/libsofia-sip-ua/tport/ws.c
@@ -649,6 +649,8 @@ int ws_init(wsh_t *wsh, ws_socket_t sock, SSL_CTX *ssl_ctx, int close_sock, int 
 
 	wsh->buffer = malloc(wsh->buflen);
 	wsh->bbuffer = malloc(wsh->bbuflen);
+	/* reserve 1 Byte for write '\0' */
+	wsh->bbuflen -= 1;
 	//printf("init %p %ld\n", (void *) wsh->bbuffer, wsh->bbuflen);
 	//memset(wsh->buffer, 0, wsh->buflen);
 	//memset(wsh->bbuffer, 0, wsh->bbuflen);
@@ -909,7 +911,8 @@ ssize_t ws_read_frame(wsh_t *wsh, ws_opcode_t *oc, uint8_t **data)
 
 				wsh->bbuflen = need + blen + wsh->rplen;
 
-				if ((tmp = realloc(wsh->bbuffer, wsh->bbuflen))) {
+				/* reserve 1 Byte for write '\0' */
+				if ((tmp = realloc(wsh->bbuffer, wsh->bbuflen + 1))) {
 					wsh->bbuffer = tmp;
 				} else {
 					abort();
@@ -941,7 +944,7 @@ ssize_t ws_read_frame(wsh_t *wsh, ws_opcode_t *oc, uint8_t **data)
 			if (mask && maskp) {
 				ssize_t i;
 
-				for (i = 0; i < wsh->datalen; i++) {
+				for (i = 0; i < wsh->rplen; i++) {
 					wsh->body[i] ^= maskp[i % 4];
 				}
 			}

--- a/src/mod/endpoints/mod_verto/ws.c
+++ b/src/mod/endpoints/mod_verto/ws.c
@@ -655,6 +655,8 @@ int ws_init(wsh_t *wsh, ws_socket_t sock, SSL_CTX *ssl_ctx, int close_sock, int 
 
 	wsh->buffer = malloc(wsh->buflen);
 	wsh->bbuffer = malloc(wsh->bbuflen);
+	/* reserve 1 Byte for write '\0' */
+	wsh->bbuflen -= 1;
 	//printf("init %p %ld\n", (void *) wsh->bbuffer, wsh->bbuflen);
 	//memset(wsh->buffer, 0, wsh->buflen);
 	//memset(wsh->bbuffer, 0, wsh->bbuflen);
@@ -928,7 +930,8 @@ ssize_t ws_read_frame(wsh_t *wsh, ws_opcode_t *oc, uint8_t **data)
 
 				wsh->bbuflen = need + blen + wsh->rplen;
 
-				if ((tmp = realloc(wsh->bbuffer, wsh->bbuflen))) {
+				/* reserve 1 Byte for write '\0' */
+				if ((tmp = realloc(wsh->bbuffer, wsh->bbuflen + 1))) {
 					wsh->bbuffer = tmp;
 				} else {
 					abort();
@@ -960,7 +963,7 @@ ssize_t ws_read_frame(wsh_t *wsh, ws_opcode_t *oc, uint8_t **data)
 			if (mask && maskp) {
 				ssize_t i;
 
-				for (i = 0; i < wsh->datalen; i++) {
+				for (i = 0; i < wsh->rplen; i++) {
 					wsh->body[i] ^= maskp[i % 4];
 				}
 			}

--- a/src/mod/xml_int/mod_xml_rpc/ws.c
+++ b/src/mod/xml_int/mod_xml_rpc/ws.c
@@ -339,7 +339,8 @@ wsh_t * ws_init(ws_tsession_t *tsession)
 
 	memset(wsh, 0, sizeof(*wsh));
 	wsh->tsession = tsession;
-	wsh->buflen = sizeof(wsh->buffer);
+	/* reserve 1 Byte for write '\0' */
+	wsh->buflen = sizeof(wsh->buffer) - 1;
 
 	return wsh;
 }
@@ -510,7 +511,7 @@ issize_t ws_read_frame(wsh_t *wsh, ws_opcode_t *oc, uint8_t **data)
 			if (mask && maskp) {
 				issize_t i;
 
-				for (i = 0; i < wsh->datalen; i++) {
+				for (i = 0; i < wsh->rplen; i++) {
 					wsh->payload[i] ^= maskp[i % 4];
 				}
 			}


### PR DESCRIPTION
Fixed websocket write memory overbounds when received data length is greater than the buffer length(default 64k).
Websocket memory overbounds occur when:
1. websocket all data length more than wsh->bbuffer length(in libs/sofia-sip/libsofia-sip-ua/tport/ws.c,src/mod/endpoints/mod_verto/ws.c) 
2. websocket double head data  add playload date length more than wsh->bbuffer (in libs/sofia-sip/libsofia-sip-ua/tport/ws.c,src/mod/endpoints/mod_verto/ws.c) or wsh->buffer(in src/mod/xml_int/mod_xml_rpc/ws.c)。
The reason for the above phenomenon is the length error of the mask operation。