### PR TITLE
mod_verto: add to login event id and domain values

### DIFF
--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -882,6 +882,12 @@ static void login_fire_custom_event(jsock_t *jsock, cJSON *params, int success, 
 				switch_event_add_header_string(s_event, SWITCH_STACK_BOTTOM, "verto_sessid", cJSON_GetObjectCstr(params, "sessid"));
 			}
 		}
+		if (jsock->id) {
+			switch_event_add_header_string(s_event, SWITCH_STACK_BOTTOM, "verto_id", jsock->id);
+		}
+		if (jsock->domain) {
+			switch_event_add_header_string(s_event, SWITCH_STACK_BOTTOM, "verto_domain", jsock->domain);
+		}
 		switch_event_add_header(s_event, SWITCH_STACK_BOTTOM, "verto_success", "%d", success);
 		switch_event_add_header_string(s_event, SWITCH_STACK_BOTTOM, "verto_result_txt", result_txt);
 		switch_event_fire(&s_event);


### PR DESCRIPTION
add new values id and domain to verto login event. If we force the registered domain the domain in login (right side of %40 ) is no correct.

before:
```
 Event-Subclass: verto%3A%3Alogin
Event-Name: CUSTOM
Core-UUID: b12f9214-0e77-412c-ba6d-3ca32dadeed9
FreeSWITCH-Hostname: pcdeb
FreeSWITCH-Switchname: pcdeb
FreeSWITCH-IPv4: 192.168.1.84
FreeSWITCH-IPv6: %3A%3A1
Event-Date-Local: 2020-05-05%2001%3A15%3A17
Event-Date-GMT: Mon,%2004%20May%202020%2023%3A15%3A17%20GMT
Event-Date-Timestamp: 1588634117853890
Event-Calling-File: mod_verto.c
Event-Calling-Function: login_fire_custom_event
Event-Calling-Line-Number: 876
Event-Sequence: 1541
verto_profile_name: lan
verto_client_address: 192.168.1.66%3A63378
verto_login: 1008%40192.168.1.84
verto_sessid: 38fea855-4b6d-0021-d5dd-16301b4c7472
verto_success: 1
verto_result_txt: Logged%20in
```

After:
```
 Event-Subclass: verto%3A%3Alogin
Event-Name: CUSTOM
Core-UUID: b12f9214-0e77-412c-ba6d-3ca32dadeed9
FreeSWITCH-Hostname: pcdeb
FreeSWITCH-Switchname: pcdeb
FreeSWITCH-IPv4: 192.168.1.84
FreeSWITCH-IPv6: %3A%3A1
Event-Date-Local: 2020-05-05%2001%3A15%3A17
Event-Date-GMT: Mon,%2004%20May%202020%2023%3A15%3A17%20GMT
Event-Date-Timestamp: 1588634117853890
Event-Calling-File: mod_verto.c
Event-Calling-Function: login_fire_custom_event
Event-Calling-Line-Number: 876
Event-Sequence: 1541
verto_profile_name: lan
verto_client_address: 192.168.1.66%3A63378
verto_login: 1008%40192.168.1.84
verto_sessid: 38fea855-4b6d-0021-d5dd-16301b4c7472
verto_id: 1008
verto_domain: lab.com
verto_success: 1
verto_result_txt: Logged%20in
```