### PR TITLE
[mod_avmd, esl/python] Two build fixups

### DIFF
--- a/libs/esl/python/python-config
+++ b/libs/esl/python/python-config
@@ -1,5 +1,6 @@
-#! /usr/bin/python2.5
+#!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 import os
 import getopt
@@ -9,8 +10,7 @@ valid_opts = ['prefix', 'exec-prefix', 'includes', 'libs', 'cflags',
               'ldflags', 'help']
 
 def exit_with_usage(code=1):
-    print >>sys.stderr, "Usage: %s [%s]" % (sys.argv[0], 
-                                            '|'.join('--'+opt for opt in valid_opts))
+    print("Usage: %s [%s]" % (sys.argv[0], '|'.join('--'+opt for opt in valid_opts)), file=sys.stderr)
     sys.exit(code)
 
 try:
@@ -30,17 +30,17 @@ if opt == '--help':
     exit_with_usage(0)
 
 elif opt == '--prefix':
-    print sysconfig.PREFIX
+    print(sysconfig.PREFIX)
 
 elif opt == '--exec-prefix':
-    print sysconfig.EXEC_PREFIX
+    print(sysconfig.EXEC_PREFIX)
 
 elif opt in ('--includes', '--cflags'):
     flags = ['-I' + sysconfig.get_python_inc(),
              '-I' + sysconfig.get_python_inc(plat_specific=True)]
     if opt == '--cflags':
         flags.extend(getvar('CFLAGS').split())
-    print ' '.join(flags)
+    print(' '.join(flags))
 
 elif opt in ('--libs', '--ldflags'):
     libs = getvar('LIBS').split() + getvar('SYSLIBS').split()
@@ -49,5 +49,5 @@ elif opt in ('--libs', '--ldflags'):
     # shared library in prefix/lib/.
     if opt == '--ldflags' and not getvar('Py_ENABLE_SHARED'):
         libs.insert(0, '-L' + getvar('LIBPL'))
-    print ' '.join(libs)
+    print(' '.join(libs))
 

--- a/src/mod/applications/mod_avmd/mod_avmd.c
+++ b/src/mod/applications/mod_avmd/mod_avmd.c
@@ -1343,8 +1343,10 @@ static switch_status_t avmd_parse_cmd_data(avmd_session_t *s, const char *cmd_da
                 switch_assert(argv[idx]);
                 status = avmd_parse_cmd_data_one_entry(argv[idx], &settings);
                 if (status != SWITCH_STATUS_SUCCESS) {
-                    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(s->session), SWITCH_LOG_ERROR,
+                    if (argv[idx]) {
+                        switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(s->session), SWITCH_LOG_ERROR,
                             "Error parsing option [%d] [%s]\n", idx + 1, argv[idx]);    /* idx + 1 to report option 0 as 1 for users convenience */
+                    }
                     switch (status)
                     {
                         case SWITCH_STATUS_TERM:


### PR DESCRIPTION
Adds 2 small fixups for building `mod_avmd` and `esl/python` with current build tooling from Fedora 32.