### PR TITLE
mod_callcenter: fix tracking agent external calls 

### DIFF
--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -3336,6 +3336,7 @@ SWITCH_STANDARD_APP(callcenter_track)
 	char agent_status[255];
 	char *agent_name = NULL;
 	char *sql = NULL;
+	const char *tracked_agent = NULL;
 
 	if (zstr(data)) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Missing agent name\n");
@@ -3344,6 +3345,11 @@ SWITCH_STANDARD_APP(callcenter_track)
 
 	if (cc_agent_get("status", data, agent_status, sizeof(agent_status)) != CC_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "Invalid agent %s", data);
+		return;
+	}
+
+	if ((tracked_agent = switch_channel_get_variable(channel, "cc_tracked_agent"))) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "Already tracking agent %s in this channel.", tracked_agent);
 		return;
 	}
 


### PR DESCRIPTION
we cannot track multiple agents in a single channel because in the hangup hook is used the variable cc_tracked_agent and will use the last value in this variable.

For example:
	<extension name="Track agent">
		<condition field="destination_number" expression="^1234$">
			<action application="callcenter_track" data="1000@default"/>
			<action application="callcenter_track" data="1001@default"/>
			<action application="bridge" data="user/1001@${domain_name}"/>
		</condition>
	</extension>

This will increment external_call_count for agents 1000@default and 1001@default but on hangup it will only decrease agent 1001@default.
