### PR TITLE
[mod_conference] don't auto-record if waiting on moderator

### DIFF
--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -422,7 +422,7 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 		}
 
 		/* Start auto recording if there's the minimum number of required participants. */
-		if (conference->auto_record && !conference->auto_recording && (conference->count >= conference->min_recording_participants)) {
+		if (conference->auto_record && !conference->auto_recording && !conference_utils_test_flag(conference, CFLAG_WAIT_MOD) && (conference->count >= conference->min_recording_participants)) {
 			conference->auto_recording++;
 			conference->record_count++;
 			imember = conference->members;


### PR DESCRIPTION
The conference option `wait-mod` means there's only music on hold until a moderator joins.
This flag, `CFLAG_WAIT_MOD` is cleared when the moderator joins (https://github.com/signalwire/freeswitch/blob/15ad4c23e259c1c2dff58f89e9124e5f36dd2e94/src/mod/applications/mod_conference/conference_member.c#L871-L873)

This patch adds checking that flag before beginning auto-record.

Requested in #585