### PR TITLE
[mod_conference] add waiting-sound to be played for wait-mod

### DIFF
--- a/conf/insideout/autoload_configs/conference.conf.xml
+++ b/conf/insideout/autoload_configs/conference.conf.xml
@@ -63,6 +63,8 @@
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <!-- File to play if you are alone in the conference -->
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <!-- File to play if you are waiting for the moderator to join -->
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <!-- File to play endlessly (nobody will ever be able to talk) -->
       <!--<param name="perpetual-sound" value="perpetual.wav"/>-->
       <!-- File to play when you're alone (music on hold)-->
@@ -110,6 +112,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -135,6 +138,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -160,6 +164,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>

--- a/conf/testing/autoload_configs/conference.conf.xml
+++ b/conf/testing/autoload_configs/conference.conf.xml
@@ -93,6 +93,8 @@
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <!-- File to play if you are alone in the conference -->
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <!-- File to play if you are waiting for the moderator to join -->
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <!-- File to play endlessly (nobody will ever be able to talk) -->
       <!-- <param name="perpetual-sound" value="perpetual.wav"/> -->
       <!-- File to play when you're alone (music on hold)-->
@@ -156,6 +158,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -181,6 +184,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -220,6 +224,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -258,6 +263,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="local_stream://video"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -293,6 +299,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="local_stream://video"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -325,6 +332,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="local_stream://video"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -358,6 +366,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="local_stream://video"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -391,6 +400,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="local_stream://video_chime"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -423,6 +433,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="local_stream://video_chime"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -456,6 +467,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
       <param name="kicked-sound" value="conference/conf-kicked.wav"/>

--- a/conf/vanilla/autoload_configs/conference.conf.xml
+++ b/conf/vanilla/autoload_configs/conference.conf.xml
@@ -74,6 +74,8 @@
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <!-- File to play if you are alone in the conference -->
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <!-- File to play if you are waiting for the moderator to join -->
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <!-- File to play endlessly (nobody will ever be able to talk) -->
       <!-- <param name="perpetual-sound" value="perpetual.wav"/> -->
       <!-- File to play when you're alone (music on hold)-->
@@ -137,6 +139,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -162,6 +165,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -201,6 +205,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -238,6 +243,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -274,6 +280,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -309,6 +316,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -344,6 +352,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>

--- a/src/mod/applications/mod_conference/conf/autoload_configs/conference.conf.xml
+++ b/src/mod/applications/mod_conference/conf/autoload_configs/conference.conf.xml
@@ -80,6 +80,8 @@
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <!-- File to play if you are alone in the conference -->
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <!-- File to play if you are waiting for the moderator to join -->
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <!-- File to play endlessly (nobody will ever be able to talk) -->
       <!--<param name="perpetual-sound" value="perpetual.wav"/>-->
       <!-- File to play when you're alone (music on hold)-->
@@ -143,6 +145,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -168,6 +171,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
@@ -193,6 +197,7 @@
       <param name="muted-sound" value="conference/conf-muted.wav"/>
       <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
       <param name="alone-sound" value="conference/conf-alone.wav"/>
+      <param name="waiting-sound" value="conference/conf-conference_will_start_shortly.wav"/>
       <param name="moh-sound" value="$${hold_music}"/>
       <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
       <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>

--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -907,12 +907,16 @@ switch_status_t conference_member_add(conference_obj_t *conference, conference_m
 				if (conference->count >= conference->announce_count && conference->announce_count > 1) {
 					switch_snprintf(msg, sizeof(msg), "There are %d callers", conference->count);
 					conference_member_say(member, msg, CONF_DEFAULT_LEADIN);
-				} else if (conference->count == 1 && !conference->perpetual_sound && !conference_utils_test_flag(conference, CFLAG_WAIT_MOD)) {
+				} else if (conference->count == 1 && !conference->perpetual_sound) {
 					/* as long as its not a bridge_to conference, announce if person is alone */
 					if (!conference_utils_test_flag(conference, CFLAG_BRIDGE_TO)) {
-						if (conference->alone_sound  && !conference_utils_member_test_flag(member, MFLAG_GHOST)) {
+						if (conference->alone_sound && !conference_utils_test_flag(conference, CFLAG_WAIT_MOD) && !conference_utils_member_test_flag(member, MFLAG_GHOST)) {
 							conference_file_stop(conference, FILE_STOP_ASYNC);
 							conference_file_play(conference, conference->alone_sound, CONF_DEFAULT_LEADIN,
+												 switch_core_session_get_channel(member->session), 0);
+						} else if (conference->waiting_sound && conference_utils_test_flag(conference, CFLAG_WAIT_MOD) && !conference_utils_member_test_flag(member, MFLAG_GHOST)) {
+							conference_file_stop(conference, FILE_STOP_ASYNC);
+							conference_file_play(conference, conference->waiting_sound, CONF_DEFAULT_LEADIN,
 												 switch_core_session_get_channel(member->session), 0);
 						} else {
 							switch_snprintf(msg, sizeof(msg), "You are currently the only person in this conference.");

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -2689,6 +2689,7 @@ conference_obj_t *conference_new(char *name, conference_xml_cfg_t cfg, switch_co
 	char *sound_prefix = NULL;
 	char *exit_sound = NULL;
 	char *alone_sound = NULL;
+	char *waiting_sound = NULL;
 	char *muted_sound = NULL;
 	char *mute_detect_sound = NULL;
 	char *unmuted_sound = NULL;
@@ -2940,6 +2941,8 @@ conference_obj_t *conference_new(char *name, conference_xml_cfg_t cfg, switch_co
 				exit_sound = val;
 			} else if (!strcasecmp(var, "alone-sound") && !zstr(val)) {
 				alone_sound = val;
+			} else if (!strcasecmp(var, "waiting-sound") && !zstr(val)) {
+				waiting_sound = val;
 			} else if (!strcasecmp(var, "perpetual-sound") && !zstr(val)) {
 				perpetual_sound = val;
 			} else if (!strcasecmp(var, "moh-sound") && !zstr(val)) {
@@ -3481,6 +3484,9 @@ conference_obj_t *conference_new(char *name, conference_xml_cfg_t cfg, switch_co
 
 	if (!zstr(alone_sound)) {
 		conference->alone_sound = switch_core_strdup(conference->pool, alone_sound);
+	}
+	if (!zstr(waiting_sound)) {
+		conference->waiting_sound = switch_core_strdup(conference->pool, waiting_sound);
 	}
 
 	if (!zstr(locked_sound)) {

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -606,6 +606,7 @@ typedef struct conference_obj {
 	char *enter_sound;
 	char *exit_sound;
 	char *alone_sound;
+	char *waiting_sound;
 	char *perpetual_sound;
 	char *moh_sound;
 	char *tmp_moh_sound;


### PR DESCRIPTION
`alone-sound` is not played with `wait-mod` is enabled.

This adds a new variable, `waiting-sound` to be played entry when wait-mod is enabled and the conference status is still waiting.