### PR TITLE
[Core] Fix the null char in truncated value returned by switch_b64_decode

### DIFF
--- a/src/switch_utils.c
+++ b/src/switch_utils.c
@@ -26,7 +26,7 @@
  * Anthony Minessale II <anthm@freeswitch.org>
  * Juan Jose Comellas <juanjo@comellas.org>
  * Seven Du <dujinfang@gmail.com>
- *
+ * Windy Wang <xiaofengcanyuexp@163.com>
  *
  * switch_utils.c -- Compatibility and Helper Code
  *
@@ -1081,7 +1081,7 @@ SWITCH_DECLARE(switch_size_t) switch_b64_decode(const char *in, char *out, switc
 
 		while (l >= 8) {
 			op[ol++] = (char) ((b >> (l -= 8)) % 256);
-			if (ol >= olen - 2) {
+			if (ol >= olen - 1) {
 				goto end;
 			}
 		}
@@ -1089,7 +1089,7 @@ SWITCH_DECLARE(switch_size_t) switch_b64_decode(const char *in, char *out, switc
 
   end:
 
-	op[ol++] = '\0';
+	op[ol] = '\0';
 
 	return ol;
 }

--- a/src/switch_utils.c
+++ b/src/switch_utils.c
@@ -1089,7 +1089,7 @@ SWITCH_DECLARE(switch_size_t) switch_b64_decode(const char *in, char *out, switc
 
   end:
 
-	op[ol] = '\0';
+	op[ol++] = '\0';
 
 	return ol;
 }

--- a/tests/unit/switch_utils.c
+++ b/tests/unit/switch_utils.c
@@ -76,7 +76,7 @@ FST_TEST_BEGIN(b64)
     switch_size_t size = switch_b64_decode((const char *)b64_str, decoded_str, sizeof(decoded_str));
     switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "decoded_str: %s\n", decoded_str);
     fst_check_string_equals(decoded_str, str);
-    fst_check(size == 3);
+    fst_check(size == 4);
 }
 FST_TEST_END()
 

--- a/tests/unit/switch_utils.c
+++ b/tests/unit/switch_utils.c
@@ -23,7 +23,7 @@
  *
  * Contributor(s):
  * Seven Du <seven@signalwire.com>
- *
+ * Windy Wang <xiaofengcanyuexp@163.com>
  *
  * switch_utils.c -- tests switch_utils
  *
@@ -62,6 +62,24 @@ FST_TEST_BEGIN(benchmark)
     fst_check_string_equals(encoded, "%26bry%C3%A4n%23!%E6%9D%9C%E9%87%91%E6%88%BF");
 }
 FST_TEST_END()
+
+FST_TEST_BEGIN(b64)
+{
+    char *str = "ABC";
+    unsigned char b64_str[6];
+    char decoded_str[4];
+    switch_status_t status = switch_b64_encode((unsigned char *)str, strlen(str), b64_str, sizeof(b64_str));
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "b64_str: %s\n", b64_str);
+    fst_check(status == SWITCH_STATUS_SUCCESS);
+    fst_check_string_equals((const char *)b64_str, "QUJD");
+
+    switch_size_t size = switch_b64_decode((const char *)b64_str, decoded_str, sizeof(decoded_str));
+    switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "decoded_str: %s\n", decoded_str);
+    fst_check_string_equals(decoded_str, str);
+    fst_check(size == 3);
+}
+FST_TEST_END()
+
 
 FST_SUITE_END()
 


### PR DESCRIPTION
switch_b64_decode returns truncated value issue:

When `encode` "ABC" and `decode` back with a 4 bytes buffer, the value will be truncated to "AB" and the test case fails.

    chk_eq_str: 'AB' != 'ABC'

This patch fix it, and changed to return length not included the NULL char.