### PR TITLE
[mod_opusfile] fix compiling write file support

### DIFF
--- a/src/mod/formats/mod_opusfile/Makefile.am
+++ b/src/mod/formats/mod_opusfile/Makefile.am
@@ -4,15 +4,16 @@ MODNAME=mod_opusfile
 noinst_LTLIBRARIES = libopusfilemod.la
 
 libopusfilemod_la_SOURCES  = mod_opusfile.c
-libopusfilemod_la_CFLAGS   = $(AM_CFLAGS) $(freeswitch_LDFLAGS) $(OPUSFILE_DECODE_CFLAGS)
+libopusfilemod_la_CFLAGS   = $(AM_CFLAGS) $(freeswitch_LDFLAGS)
 
 mod_LTLIBRARIES = mod_opusfile.la
 mod_opusfile_la_SOURCES  =
-mod_opusfile_la_CFLAGS   = $(AM_CFLAGS) $(freeswitch_LDFLAGS) $(OPUSFILE_DECODE_CFLAGS)
+mod_opusfile_la_CFLAGS   = $(AM_CFLAGS) $(freeswitch_LDFLAGS)
 mod_opusfile_la_LIBADD   = libopusfilemod.la $(switch_builddir)/libfreeswitch.la
 mod_opusfile_la_LDFLAGS  = -avoid-version -module -no-undefined -shared
 
 if HAVE_OPUSFILE_DECODE
+libopusfilemod_la_CFLAGS += $(OPUSFILE_DECODE_CFLAGS)
 mod_opusfile_la_CFLAGS += $(OPUSFILE_DECODE_CFLAGS)
 mod_opusfile_la_LIBADD += $(OPUSFILE_DECODE_LIBS)
 
@@ -28,6 +29,7 @@ TESTS = $(noinst_PROGRAMS)
 endif
 
 if HAVE_OPUSFILE_ENCODE
+libopusfilemod_la_CFLAGS += $(OPUSFILE_ENCODE_CFLAGS) -DHAVE_OPUSFILE_ENCODE
 mod_opusfile_la_CFLAGS += $(OPUSFILE_ENCODE_CFLAGS) -DHAVE_OPUSFILE_ENCODE
 mod_opusfile_la_LIBADD += $(OPUSFILE_ENCODE_LIBS)
 endif


### PR DESCRIPTION
fix #718 : honor $OPUSFILE_ENCODE_CFLAGS and -DHAVE_OPUSFILE_ENCODE when compiling mod_opusfile.c