### PR TITLE
[mod_silk] switch_silk_decode: Fix invalid condition for return code from switch_jb_peek_frame().

### DIFF
--- a/src/mod/codecs/mod_silk/mod_silk.c
+++ b/src/mod/codecs/mod_silk/mod_silk.c
@@ -352,7 +352,7 @@ static switch_status_t switch_silk_decode(switch_codec_t *codec,
 			frame.buflen = sizeof(buf);
 
 			for (i = 1; i <= MAX_LBRR_DELAY; i++) {
-				if (switch_jb_peek_frame(jb, codec->cur_frame->timestamp, 0, (uint16_t)i, &frame)) {
+				if (switch_jb_peek_frame(jb, codec->cur_frame->timestamp, 0, (uint16_t)i, &frame) == SWITCH_STATUS_SUCCESS) {
 					SKP_Silk_SDK_search_for_LBRR(frame.data, (const int)frame.datalen, i, (SKP_uint8*) &context->recbuff, &context->reclen);
 
 					if (context->reclen) {


### PR DESCRIPTION
Hi,
The return code from `switch_jb_peek_frame()` is `SWITCH_STATUS_SUCCESS(0)` or `SWITCH_STATUS_FALSE(1)`, it's incorrectly used in `switch_silk_decode()`. 
Please review and commit this change, thanks.