### PR TITLE
[mod_sofia] Fix crash when proxy INFO without body

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -9615,7 +9615,7 @@ switch_status_t sofia_proxy_sip_i_message(nua_t *nua, sofia_profile_t *profile, 
 
 			other_tech_pvt = (private_object_t *) switch_core_session_get_private(other_session);
 
-			if (sip && sip->sip_content_type->c_type && sip->sip_content_type->c_subtype) {
+			if (sip && sip->sip_content_type && sip->sip_content_type->c_type && sip->sip_content_type->c_subtype) {
 				ct = sip->sip_content_type->c_type;
 			}
 
@@ -9658,11 +9658,11 @@ switch_status_t sofia_proxy_sip_i_info(nua_t *nua, sofia_profile_t *profile, nua
 
 			other_tech_pvt = (private_object_t *) switch_core_session_get_private(other_session);
 
-			if (sip && sip->sip_content_type->c_type && sip->sip_content_type->c_subtype) {
+			if (sip && sip->sip_content_type && sip->sip_content_type->c_type && sip->sip_content_type->c_subtype) {
 				ct = sip->sip_content_type->c_type;
 			}
 
-			if (sip && sip->sip_content_type->c_type && !strncasecmp(sip->sip_content_type->c_type, "application", 11) && !strcasecmp(sip->sip_content_type->c_subtype, "media_control+xml")) {
+			if (sip && sip->sip_content_type && sip->sip_content_type->c_type && !strncasecmp(sip->sip_content_type->c_type, "application", 11) && !strcasecmp(sip->sip_content_type->c_subtype, "media_control+xml")) {
 				if (switch_channel_test_flag(channel, CF_VIDEO)) {
 					switch_core_media_gen_key_frame(session);
 					switch_channel_set_flag(channel, CF_VIDEO_REFRESH_REQ);


### PR DESCRIPTION
FS crashes when proxies INFO without a body.

In sip_profile parameter `proxy-info=true`

Example of INFO sent via sipp
```
INFO sip:STAS@127.0.0.1:11000;transport=UDP SIP/2.0
      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
      Route: <sip:192.168.0.34:5063;lr>
      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
      To: [service] <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
      Call-ID: [call_id]
      CSeq: 2 INFO
      Contact: sip:sipp@[local_ip]:[local_port]
      Max-Forwards: 70
```
