### PR TITLE
Added variable sip_contact_host to change the host part in the Contact header in INVITE requests

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -1270,7 +1270,24 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 
 		if (zstr(tech_pvt->invite_contact)) {
 			const char *contact;
-			if ((contact = switch_channel_get_variable(channel, "sip_contact_user"))) {
+			const char *contactHost;
+			if ((contact = switch_channel_get_variable(channel, "sip_contact_user")) && (contactHost = switch_channel_get_variable(channel, "sip_contact_host"))) {
+                                if (sofia_glue_transport_has_tls(tech_pvt->transport)) {
+                                        tech_pvt->invite_contact = switch_core_session_sprintf(session, "sip:%s@%s:%d", contact,
+                                                                                                                                                   contactHost, tech_pvt->profile->tls_sip_port);
+                                } else {
+                                        tech_pvt->invite_contact = switch_core_session_sprintf(session, "sip:%s@%s:%d", contact,
+                                                                                                                                                   contactHost, tech_pvt->profile->extsipport);
+                                }
+                        } else if ((contactHost = switch_channel_get_variable(channel, "sip_contact_host"))) {
+				if (sofia_glue_transport_has_tls(tech_pvt->transport)) {
+                                        tech_pvt->invite_contact = switch_core_session_sprintf(session, "sip:mod_sofia@%s:%d", contactHost,
+                                                                                                                                                   tech_pvt->profile->tls_sip_port);
+                                } else {
+                                        tech_pvt->invite_contact = switch_core_session_sprintf(session, "sip:mod_sofia@%s:%d", contactHost,
+                                                                                                                                                   tech_pvt->profile->extsipport);
+                                }
+			} else if ((contact = switch_channel_get_variable(channel, "sip_contact_user"))) {
 				char *ip_addr = tech_pvt->profile->sipip;
 				char *ipv6;
 


### PR DESCRIPTION
Some providers like Microsoft Teams require set the host part in the "Contact" header with the required value for auth the INVITE request, with this pull request we can change the contact host part of that header.

This is useful for multitenant scenarios.