### PR TITLE
[mod_rayo] Enable -fno-common compilation

### DIFF
--- a/src/mod/event_handlers/mod_rayo/iks_helpers.h
+++ b/src/mod/event_handlers/mod_rayo/iks_helpers.h
@@ -51,8 +51,7 @@ struct xmpp_error {
 
 #undef XMPP_ERROR
 #define XMPP_ERROR(def_name, name, type) \
-	SWITCH_DECLARE(const struct xmpp_error) def_name##_val; \
-	SWITCH_DECLARE(const struct xmpp_error *) def_name;
+	extern const struct xmpp_error *def_name;
 #include "xmpp_errors.def"
 
 /* See RFC-3920 XMPP core for error definitions */


### PR DESCRIPTION
Addresses #742 with proper references to XMPP errors, previously declared via macros in [iks_helpers.c](https://github.com/signalwire/freeswitch/blob/master/src/mod/event_handlers/mod_rayo/iks_helpers.c#L34-L38)