### PR TITLE
mod_callcenter: add delay to prevent erratic behaviour when changing state during offer

### DIFF
--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -2128,7 +2128,10 @@ static void *SWITCH_THREAD_FUNC outbound_agent_thread_run(switch_thread_t *threa
 		switch (cause) {
 			/* When we hang-up agents that did not answer in ring-all strategy */
 			case SWITCH_CAUSE_LOSE_RACE:
+				break;
+			/* originator cancel can happen when agent changes state during offering*/
 			case SWITCH_CAUSE_ORIGINATOR_CANCEL:
+				delay_next_agent_call = (h->busy_delay_time > delay_next_agent_call? h->busy_delay_time : delay_next_agent_call);
 				break;
 			/* Busy: Do Not Disturb, Circuit congestion */
 			case SWITCH_CAUSE_NORMAL_CIRCUIT_CONGESTION:


### PR DESCRIPTION
When a mod_callcenter agent changes their status while being offered a call (going from an available state to an unavailable state), an ORIGINATOR_CANCEL event happens. The invite is cancelled,  another invite happens, and it tends to repeat in a very fast loop.

This change adds a minimum interval upon receiving an ORIGINATOR_CANCEL to prevent the behaviour. 