### PR TITLE
[mod_av] Fix record crash bug

### DIFF
--- a/src/mod/applications/mod_av/avformat.c
+++ b/src/mod/applications/mod_av/avformat.c
@@ -382,7 +382,7 @@ static int mod_avformat_alloc_output_context2(AVFormatContext **avctx, AVOutputF
 #if (LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,7,100))
 		av_strlcpy(s->filename, filename, sizeof(s->filename));
 #else
-		s->url = strdup(filename);
+		s->url = av_strdup(filename);
 		switch_assert(s->url);
 #endif
 	}


### PR DESCRIPTION
fix mod_av record crash bug
it will lead ffmpeg-4.1\libavformat\utils.c(4424): if (s->url) {
av_freep(&s->url);
}
this time freep will dump.

recommit after seven du tutorial, thank you for that