### PR TITLE
[mod_httapi] Update cache file if the extension changes

### DIFF
--- a/src/mod/applications/mod_httapi/mod_httapi.c
+++ b/src/mod/applications/mod_httapi/mod_httapi.c
@@ -2813,13 +2813,18 @@ static switch_status_t locate_url_file(http_file_context_t *context, const char 
 			}
 		}
 
-		if (zstr(ext) && headers && (ct = switch_event_get_header(headers, "content-type"))) {
+		if (headers && (ct = switch_event_get_header(headers, "content-type"))) {
 			newext = switch_core_mime_type2ext(ct);
 		}
 
-		if (newext) {
+		if (newext && (zstr(ext) || strcmp(ext, newext) != 0)) {
+			/*
+			 * HTTP Request has returned the file with a different extension
+			 * Update the cache_file path and delete the original file
+			 */
 			ext = newext;
-			context->cache_file = switch_core_sprintf(context->pool, "%s.%s", context->cache_file, newext);
+			unlink(context->cache_file);
+			context->cache_file = switch_core_sprintf(context->pool, "%s.%s", context->cache_file_base, newext);
 		}
 
 


### PR DESCRIPTION
If a HTTP request changes the extension (by using Content-Type header) of the existing cached file,
remove the existing cached file, and allow the new one to save with the correct extension.

I have an HTTP endpoint that can update the response between requests to it. We use this by sending the codec of the call in the URL, and converting the file in the background for the next call.

I've setup an example endpoint that returns a mp3 or wav at random, and tested this by calling playback with the URL:

```
> curl -I https://giggsey.com/freeswitch-test/
HTTP/2 200 
content-type: audio/x-wav
content-length: 83634
cache-control: max-age=2, public
date: Thu, 27 Aug 2020 08:11:58 GMT
last-modified: Thu, 27 Aug 2020 07:23:43 GMT

> curl -I https://giggsey.com/freeswitch-test/
content-type: audio/mpeg
content-length: 8100
cache-control: max-age=2, public
date: Thu, 27 Aug 2020 08:11:57 GMT
last-modified: Thu, 27 Aug 2020 07:23:49 GMT
accept-ranges: bytes
```


#### Before
Gets wav first, then the mp3
```
EXECUTE [depth=0] sofia/internal/1001@10.13.37.161:5060 playback(https://giggsey.com/freeswitch-test/)
2020-08-27 08:42:15.032490 [DEBUG] mod_httapi.c:2657 caching: url:https://giggsey.com/freeswitch-test/ to /usr/local/freeswitch/storage/http_file_cache/a63d3656763b379c84733d3a0e03f350.wav (83634 bytes)
2020-08-27 08:42:15.032490 [DEBUG] switch_ivr_play_say.c:1488 Codec Activated L16@16000hz 1 channels 20ms
2020-08-27 08:42:15.092375 [DEBUG] switch_rtp.c:7759 Correct audio ip/port confirmed.
2020-08-27 08:42:15.332529 [DEBUG] sofia.c:7326 Channel sofia/internal/1001@10.13.37.161:5060 entering state [ready][200]
2020-08-27 08:42:17.632477 [DEBUG] switch_ivr_play_say.c:1933 done playing file https://giggsey.com/freeswitch-test/


EXECUTE [depth=0] sofia/internal/1001@10.13.37.161:5060 playback(https://giggsey.com/freeswitch-test/)
2020-08-27 08:42:20.552541 [DEBUG] mod_httapi.c:2657 caching: url:https://giggsey.com/freeswitch-test/ to /usr/local/freeswitch/storage/http_file_cache/a63d3656763b379c84733d3a0e03f350.wav (8100 bytes)
2020-08-27 08:42:20.552541 [WARNING] mod_sndfile.c:281 Error Opening File [/usr/local/freeswitch/storage/http_file_cache/a63d3656763b379c84733d3a0e03f350.wav] [File contains data in an unknown format.]
2020-08-27 08:42:20.552541 [ERR] mod_httapi.c:3005 Invalid cache file /usr/local/freeswitch/storage/http_file_cache/a63d3656763b379c84733d3a0e03f350.wav opening url giggsey.com/freeswitch-test/ Discarding file.
```

#### After
Gets wav first, then mp3
```
EXECUTE [depth=0] sofia/internal/1001@10.13.37.161:5060 playback(https://giggsey.com/freeswitch-test/)
2020-08-27 12:54:56.015655 [DEBUG] mod_httapi.c:2657 caching: url:https://giggsey.com/freeswitch-test/ to /usr/local/freeswitch/storage/http_file_cache/a63d3656763b379c84733d3a0e03f350.wav (83634 bytes)
2020-08-27 12:54:56.015655 [DEBUG] switch_ivr_play_say.c:1488 Codec Activated L16@16000hz 1 channels 20ms
2020-08-27 12:54:56.015655 [DEBUG] sofia.c:7326 Channel sofia/internal/1001@10.13.37.161:5060 entering state [ready][200]
2020-08-27 12:54:56.055549 [DEBUG] switch_rtp.c:7759 Correct audio ip/port confirmed.
2020-08-27 12:54:58.615606 [DEBUG] switch_ivr_play_say.c:1933 done playing file https://giggsey.com/freeswitch-test/


EXECUTE [depth=0] sofia/internal/1001@10.13.37.161:5060 playback(https://giggsey.com/freeswitch-test/)
2020-08-27 12:55:07.015644 [DEBUG] mod_httapi.c:2657 caching: url:https://giggsey.com/freeswitch-test/ to /usr/local/freeswitch/storage/http_file_cache/a63d3656763b379c84733d3a0e03f350.mp3 (8100 bytes)
2020-08-27 12:55:07.015644 [DEBUG] switch_ivr_play_say.c:1488 Codec Activated L16@16000hz 1 channels 20ms
2020-08-27 12:55:09.695607 [DEBUG] switch_ivr_play_say.c:1933 done playing file https://giggsey.com/freeswitch-test/
```