### PR TITLE
fix core dump on S3-authenticated HTTP GET

### DIFF
--- a/src/mod/applications/mod_http_cache/mod_http_cache.c
+++ b/src/mod/applications/mod_http_cache/mod_http_cache.c
@@ -1099,6 +1099,8 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 	long httpRes = 0;
 	int start_time_ms = switch_time_now() / 1000;
 	switch_CURLcode curl_status = CURLE_UNKNOWN_OPTION;
+	char *query_string = NULL;
+	char *full_url = url->url;
 
 	/* set up HTTP GET */
 	get_data.fd = 0;
@@ -1110,7 +1112,11 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 	}
 
 	if (profile && profile->append_headers_ptr) {
-		headers = profile->append_headers_ptr(profile, headers, "GET", 0, "", url->url, 0, NULL);
+		headers = profile->append_headers_ptr(profile, headers, "GET", 0, "", url->url, 0, &query_string);
+		if (query_string) {
+			full_url = switch_mprintf("%s?%s", url->url, query_string);
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Full URL: %s\n", full_url);
+		}
 	}
 
 	curl_handle = switch_curl_easy_init();
@@ -1123,7 +1129,7 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 		if (headers) {
 			switch_curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
 		}
-		switch_curl_easy_setopt(curl_handle, CURLOPT_URL, get_data.url->url);
+		switch_curl_easy_setopt(curl_handle, CURLOPT_URL, full_url);
 		switch_curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, get_file_callback);
 		switch_curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *) &get_data);
 		switch_curl_easy_setopt(curl_handle, CURLOPT_HEADERFUNCTION, get_header_callback);
@@ -1177,6 +1183,11 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 	}
 
 done:
+	if (query_string)
+	{
+		switch_safe_free(query_string);
+		switch_safe_free(full_url);
+	}
 
 	if (headers) {
 		switch_curl_slist_free_all(headers);


### PR DESCRIPTION
FS-9676 (https://github.com/signalwire/freeswitch/pull/65/files/7ad77d8a3ca6954a32d3aaf6bacbdbba189fd46e) was only partially merged; looks like you intended to not merge portions of it due to it containing an unrelated feature request, but part of the necessary code was also missed.

The result is that master is core dumping when attempting to authenticate to S3 on an HTTP GET through mod_http_cache.

This PR incorporates the rest of the original S3 v4 authentication code (without reintroducing the other feature you intended to ignore)