### PR TITLE
[Core] Create x509v3 certificates

### DIFF
--- a/src/switch_core_cert.c
+++ b/src/switch_core_cert.c
@@ -392,7 +392,7 @@ static int mkcert(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int days
 
 	rsa = NULL;
 
-	X509_set_version(x, 0);
+	X509_set_version(x, 2);
 	ASN1_INTEGER_set(X509_get_serialNumber(x), serial);
 	X509_gmtime_adj(X509_get_notBefore(x), -(long)60*60*24*7);
 	X509_gmtime_adj(X509_get_notAfter(x), (long)60*60*24*days);


### PR DESCRIPTION
following the advice from
  https://bugs.chromium.org/p/chromium/issues/detail?id=1123946#c12
since boringssl in recent versions enforces x509v3 certificates
when using extensions like subjectAltName