### PR TITLE
[mod_dptools] allow inline dialplan to proceed to next dialplan handler

### DIFF
--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -53,6 +53,7 @@ SWITCH_STANDARD_DIALPLAN(inline_dialplan_hunt)
 	char *lbuf;
 	char *target = arg;
 	char delim = ',';
+	int count = 0;
 
 	if (!caller_profile) {
 		caller_profile = switch_channel_get_caller_profile(channel);
@@ -92,13 +93,19 @@ SWITCH_STANDARD_DIALPLAN(inline_dialplan_hunt)
 			app++;
 		}
 
-		switch_caller_extension_add_application(session, extension, app, data);
+		if (!zstr(app) && !zstr(data)) {
+			switch_caller_extension_add_application(session, extension, app, data);
+			count++;
+		}
 	}
 
-	caller_profile->destination_number = (char *) caller_profile->rdnis;
-	caller_profile->rdnis = SWITCH_BLANK_STRING;
-
-	return extension;
+	if (count) {
+		caller_profile->destination_number = (char *) caller_profile->rdnis;
+		caller_profile->rdnis = SWITCH_BLANK_STRING;
+		return extension;
+	} else {
+		return NULL;
+	}
 }
 
 struct action_binding {

--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -93,7 +93,7 @@ SWITCH_STANDARD_DIALPLAN(inline_dialplan_hunt)
 			app++;
 		}
 
-		if (!zstr(app) && !zstr(data)) {
+		if (!zstr(app)) {
 			switch_caller_extension_add_application(session, extension, app, data);
 			count++;
 		}


### PR DESCRIPTION
support for verto.conf.xml
<param name="dialplan" value="inline,XML:$${conf_dir}/autoload_configs/verto.dialplan.xml,XML"/>