### PR TITLE
[api] normalized API response preamble

### DIFF
--- a/src/mod/applications/mod_avmd/mod_avmd.c
+++ b/src/mod/applications/mod_avmd/mod_avmd.c
@@ -1818,7 +1818,7 @@ SWITCH_STANDARD_API(avmd_api_main) {
 
     if (strcasecmp(command, "stop") == 0) {
         uuid_dup = switch_core_strdup(switch_core_session_get_pool(fs_session), uuid);
-        stream->write_function(stream, "+ERR, avmd has not yet been started on\n [%s] [%s]\n\n", uuid_dup, switch_channel_get_name(channel));
+        stream->write_function(stream, "-ERR, avmd has not yet been started on\n [%s] [%s]\n\n", uuid_dup, switch_channel_get_name(channel));
         switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(fs_session), SWITCH_LOG_ERROR, "Stop failed - avmd has not yet been started on channel [%s]!\n", switch_channel_get_name(channel));
         goto end;
     }
@@ -1894,9 +1894,9 @@ end:
             switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(fs_session), SWITCH_LOG_INFO, "AVMD session NOT started\n");
             if (avmd_globals.settings.report_status == 1) {
                 if ((uuid != NULL) && (channel != NULL)) {
-                    stream->write_function(stream, "+ERR\n [%s] [%s] NOT started!\n\n", uuid, switch_channel_get_name(channel));
+                    stream->write_function(stream, "-ERR\n [%s] [%s] NOT started!\n\n", uuid, switch_channel_get_name(channel));
                 } else {
-                    stream->write_function(stream, "+ERR\n AVMD session NOT started!\n\n", switch_channel_get_name(channel));
+                    stream->write_function(stream, "-ERR\n AVMD session NOT started!\n\n", switch_channel_get_name(channel));
                 }
             }
     }

--- a/src/mod/applications/mod_commands/mod_commands.c
+++ b/src/mod/applications/mod_commands/mod_commands.c
@@ -3771,7 +3771,7 @@ SWITCH_STANDARD_API(uuid_early_ok_function)
 		switch_channel_set_flag(channel, CF_EARLY_OK);
 		switch_core_session_rwunlock(xsession);
 	} else {
-		stream->write_function(stream, "-ERROR\n");
+		stream->write_function(stream, "-ERR\n");
 	}
 
 	return SWITCH_STATUS_SUCCESS;
@@ -3807,7 +3807,7 @@ SWITCH_STANDARD_API(uuid_ring_ready_function)
 	stream->write_function(stream, "-USAGE: %s\n", RING_READY_SYNTAX);
 	goto done;
  error:
-	stream->write_function(stream, "-ERROR\n");
+	stream->write_function(stream, "-ERR\n");
 	goto done;
  done:
 	switch_safe_free(mycmd);
@@ -3824,11 +3824,11 @@ SWITCH_STANDARD_API(uuid_pre_answer_function)
 		if (switch_channel_pre_answer(channel) == SWITCH_STATUS_SUCCESS) {
 			stream->write_function(stream, "+OK\n");
 		} else {
-			stream->write_function(stream, "-ERROR\n");
+			stream->write_function(stream, "-ERR\n");
 		}
 		switch_core_session_rwunlock(xsession);
 	} else {
-		stream->write_function(stream, "-ERROR\n");
+		stream->write_function(stream, "-ERR\n");
 	}
 
 	return SWITCH_STATUS_SUCCESS;
@@ -3846,10 +3846,10 @@ SWITCH_STANDARD_API(uuid_answer_function)
 		if (status == SWITCH_STATUS_SUCCESS) {
 			stream->write_function(stream, "+OK\n");
 		} else {
-			stream->write_function(stream, "-ERROR\n");
+			stream->write_function(stream, "-ERR\n");
 		}
 	} else {
-		stream->write_function(stream, "-ERROR\n");
+		stream->write_function(stream, "-ERR\n");
 	}
 
 	return SWITCH_STATUS_SUCCESS;

--- a/src/mod/applications/mod_conference/conference_api.c
+++ b/src/mod/applications/mod_conference/conference_api.c
@@ -2950,7 +2950,7 @@ switch_status_t conference_api_sub_saymember(conference_obj_t *conference, switc
 		goto done;
 	}
 
-	stream->write_function(stream, "-ERR (saymember) OK\n");
+	stream->write_function(stream, "+OK (saymember)\n");
 	if (test_eflag(member->conference, EFLAG_SPEAK_TEXT_MEMBER) &&
 		switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, CONF_EVENT_MAINT) == SWITCH_STATUS_SUCCESS) {
 		conference_member_add_event_data(member, event);

--- a/src/mod/applications/mod_curl/mod_curl.c
+++ b/src/mod/applications/mod_curl/mod_curl.c
@@ -478,7 +478,7 @@ static switch_status_t http_sendfile_test_file_open(http_sendfile_data_t *http_d
 		}
 
 		if((switch_test_flag(http_data, CSO_STREAM) || switch_test_flag(http_data, CSO_NONE)) && http_data->stream)
-			http_data->stream->write_function(http_data->stream, "-Err Unable to open file %s\n", http_data->filename_element);
+			http_data->stream->write_function(http_data->stream, "-ERR Unable to open file %s\n", http_data->filename_element);
 
 		if(switch_test_flag(http_data, CSO_NONE) && !http_data->stream)
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "curl_sendfile: Unable to open file %s\n", http_data->filename_element);

--- a/src/mod/applications/mod_distributor/mod_distributor.c
+++ b/src/mod/applications/mod_distributor/mod_distributor.c
@@ -344,7 +344,7 @@ SWITCH_STANDARD_API(distributor_function)
 		stream->write_function(stream, "%s", ret);
 		free(ret);
 	} else {
-		stream->write_function(stream, "-err");
+		stream->write_function(stream, "-ERR");
 	}
 
 	return SWITCH_STATUS_SUCCESS;
@@ -403,7 +403,7 @@ SWITCH_STANDARD_API(distributor_ctl_function)
 	if (argc > 0) {
 		if (!strcasecmp(argv[0], "reload")) {
 			if (load_config(SWITCH_TRUE) == SWITCH_STATUS_SUCCESS) {
-				stream->write_function(stream, "+ok reloaded.\n");
+				stream->write_function(stream, "+OK reloaded.\n");
 				err = NULL;
 			}
 		} else if (!strcasecmp(argv[0], "dump")) {

--- a/src/mod/applications/mod_mongo/mod_mongo.c
+++ b/src/mod/applications/mod_mongo/mod_mongo.c
@@ -177,7 +177,7 @@ SWITCH_STANDARD_API(mod_mongo_mapreduce_function)
 				/* send command and get result */
 				if (mongoc_client_command_simple(conn, db, &cmd, NULL /* read prefs */, &out, &error)) {
 					char *json_result = bson_as_json(&out, NULL);
-					stream->write_function(stream, "-OK\n%s\n", json_result);
+					stream->write_function(stream, "+OK\n%s\n", json_result);
 					bson_free(json_result);
 				} else {
 					stream->write_function(stream, "-ERR\nmongo_run_command failed!\n");
@@ -268,7 +268,7 @@ SWITCH_STANDARD_API(mod_mongo_find_n_function)
 							bson_free(json_result);
 						}
 						if (!mongoc_cursor_error(cursor, &error)) {
-							stream->write_function(stream, "-OK\n[%s]", zstr((char *)result_stream.data) ? "" :(char *)result_stream.data);
+							stream->write_function(stream, "+OK\n[%s]", zstr((char *)result_stream.data) ? "" :(char *)result_stream.data);
 						} else {
 							stream->write_function(stream, "-ERR\nquery failed: %s", error.message);
 						}
@@ -347,13 +347,13 @@ SWITCH_STANDARD_API(mod_mongo_find_one_function)
 						if (mongoc_cursor_more(cursor) && mongoc_cursor_next(cursor, &result)) {
 							char *json_result;
 							json_result = bson_as_json(result, NULL);
-							stream->write_function(stream, "-OK\n%s\n", json_result);
+							stream->write_function(stream, "+OK\n%s\n", json_result);
 							bson_free(json_result);
 						} else if (mongoc_cursor_error(cursor, &error)) {
 							stream->write_function(stream, "-ERR\nquery failed: %s\n", error.message);
 						} else {
 							/* empty set */
-							stream->write_function(stream, "-OK\n{}\n");
+							stream->write_function(stream, "+OK\n{}\n");
 						}
 					} else {
 						stream->write_function(stream, "-ERR\nquery failed!\n");

--- a/src/mod/applications/mod_snom/mod_snom.c
+++ b/src/mod/applications/mod_snom/mod_snom.c
@@ -96,7 +96,7 @@ SWITCH_STANDARD_API(snom_bind_key_api_function)
 
   err:
 
-	stream->write_function(stream, "-Error %s\n", KEY_BIND_SYNTAX);
+	stream->write_function(stream, "-ERR %s\n", KEY_BIND_SYNTAX);
 
   end:
 

--- a/src/mod/applications/mod_voicemail/mod_voicemail.c
+++ b/src/mod/applications/mod_voicemail/mod_voicemail.c
@@ -5150,7 +5150,7 @@ SWITCH_STANDARD_API(vm_fsdb_pref_greeting_set_function)
 		profile_rwunlock(profile);
 	}
 
-	stream->write_function(stream, "-OK\n");
+	stream->write_function(stream, "+OK\n");
 done:
 	switch_core_destroy_memory_pool(&pool);
 	return SWITCH_STATUS_SUCCESS;
@@ -5310,7 +5310,7 @@ SWITCH_STANDARD_API(vm_fsdb_pref_recname_set_function)
 
 	}
 	profile_rwunlock(profile);
-	stream->write_function(stream, "-OK\n");
+	stream->write_function(stream, "+OK\n");
 done:
 	switch_core_destroy_memory_pool(&pool);
 	return SWITCH_STATUS_SUCCESS;
@@ -5371,7 +5371,7 @@ SWITCH_STANDARD_API(vm_fsdb_pref_password_set_function)
 	switch_safe_free(sql);
 	profile_rwunlock(profile);
 
-	stream->write_function(stream, "-OK\n");
+	stream->write_function(stream, "+OK\n");
 done:
 	switch_core_destroy_memory_pool(&pool);
 	return SWITCH_STATUS_SUCCESS;
@@ -5503,7 +5503,7 @@ SWITCH_STANDARD_API(vm_fsdb_msg_purge_function)
 
 	profile_rwunlock(profile);
 
-	stream->write_function(stream, "-OK\n");
+	stream->write_function(stream, "+OK\n");
 
 done:
 	switch_core_destroy_memory_pool(&pool);
@@ -5554,7 +5554,7 @@ SWITCH_STANDARD_API(vm_fsdb_msg_delete_function)
 	vm_execute_sql(profile, sql, profile->mutex);
 	profile_rwunlock(profile);
 
-	stream->write_function(stream, "-OK\n");
+	stream->write_function(stream, "+OK\n");
 
 done:
 	switch_core_destroy_memory_pool(&pool);
@@ -5605,7 +5605,7 @@ SWITCH_STANDARD_API(vm_fsdb_msg_save_function)
 	vm_execute_sql(profile, sql, profile->mutex);
 	profile_rwunlock(profile);
 
-	stream->write_function(stream, "-OK\n");
+	stream->write_function(stream, "+OK\n");
 done:
 	switch_core_destroy_memory_pool(&pool);
 	return SWITCH_STATUS_SUCCESS;
@@ -5655,7 +5655,7 @@ SWITCH_STANDARD_API(vm_fsdb_msg_undelete_function)
 	vm_execute_sql(profile, sql, profile->mutex);
 	profile_rwunlock(profile);
 
-	stream->write_function(stream, "-OK\n");
+	stream->write_function(stream, "+OK\n");
 done:
 	switch_core_destroy_memory_pool(&pool);
 	return SWITCH_STATUS_SUCCESS;
@@ -5757,7 +5757,7 @@ SWITCH_STANDARD_API(vm_fsdb_auth_login_function)
 				authorized = SWITCH_TRUE;
 			}
 			if (authorized) {
-				stream->write_function(stream, "%s", "-OK");
+				stream->write_function(stream, "%s", "+OK");
 			} else {
 				stream->write_function(stream, "%s", "-ERR");
 			}
@@ -5870,7 +5870,7 @@ SWITCH_STANDARD_API(vm_fsdb_msg_forward_function)
 
 		profile_rwunlock(profile);
 	}
-	stream->write_function(stream, "-OK\n");
+	stream->write_function(stream, "+OK\n");
 done:
 	switch_core_destroy_memory_pool(&pool);
 
@@ -6101,7 +6101,7 @@ SWITCH_STANDARD_API(vm_fsdb_msg_email_function)
 
 		profile_rwunlock(profile);
 	}
-	stream->write_function(stream, "-OK\n");
+	stream->write_function(stream, "+OK\n");
 done:
 	switch_core_destroy_memory_pool(&pool);
 

--- a/src/mod/endpoints/mod_rtmp/mod_rtmp.c
+++ b/src/mod/endpoints/mod_rtmp/mod_rtmp.c
@@ -1751,7 +1751,7 @@ SWITCH_STANDARD_API(rtmp_function)
 				stream->write_function(stream, "+OK\n");
 			} else {
 				rtmp_profile_start(argv[1]);
-				stream->write_function(stream, "-OK (wasn't started, started anyways)\n");
+				stream->write_function(stream, "+OK (wasn't started, started anyways)\n");
 			}
 		} else {
 			goto usage;


### PR DESCRIPTION
Minor adjustments so API responses are more consistent: positive results always prefixed with `+OK` whereas failure messages commence with `-ERR`.