### PR TITLE
[mod_spandsp] Fix two white-space errors

### DIFF
--- a/src/mod/applications/mod_spandsp/udptl.c
+++ b/src/mod/applications/mod_spandsp/udptl.c
@@ -207,8 +207,8 @@ int udptl_rx_packet(udptl_state_t *s, const uint8_t buf[], int len)
 	/* Save the new packet. Pure redundancy mode won't use this, but some systems will switch
 	   into FEC mode after sending some redundant packets. */
 	x = seq_no & UDPTL_BUF_MASK;
-    if (msg_len > 0)
-    	memcpy(s->rx[x].buf, msg, msg_len);
+	if (msg_len > 0)
+		memcpy(s->rx[x].buf, msg, msg_len);
 	s->rx[x].buf_len = msg_len;
 	s->rx[x].fec_len[0] = 0;
 	s->rx[x].fec_span = 0;
@@ -296,8 +296,8 @@ int udptl_rx_packet(udptl_state_t *s, const uint8_t buf[], int len)
 				return -1;
 
 			/* Save the new FEC data */
-            if (s->rx[x].fec_len[i])
-    			memcpy(s->rx[x].fec[i], data, s->rx[x].fec_len[i]);
+			if (s->rx[x].fec_len[i])
+				memcpy(s->rx[x].fec[i], data, s->rx[x].fec_len[i]);
 #if 0
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "FEC: ");
 			for (j = 0; j < s->rx[x].fec_len[i]; j++)


### PR DESCRIPTION
Seven years ago, commit eee96c6 introduced two white-space errors. The
compiler Clang 10 errors: misleading indentation; statement is not
part of the previous 'if'. Now, Clang compiles successfully.