### PR TITLE
[core] Fix ICE candidate priorities

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8425,7 +8425,7 @@ static void gen_ice(switch_core_session_t *session, switch_media_type_t type, co
 
 	if (!engine->ice_out.cands[0][0].component_id) {
 		engine->ice_out.cands[0][0].component_id = 1;
-		engine->ice_out.cands[0][0].priority = (2^24)*126 + (2^8)*65535 + (2^0)*(256 - engine->ice_out.cands[0][0].component_id);
+		engine->ice_out.cands[0][0].priority = (1<<24)*126 + (1<<8)*65535 + (1<<0)*(256 - engine->ice_out.cands[0][0].component_id);
 	}
 
 	if (!zstr(ip)) {
@@ -9921,12 +9921,8 @@ static void generate_m(switch_core_session_t *session, char *buf, size_t buflen,
 		char tmp1[11] = "";
 		char tmp2[11] = "";
 		char tmp3[11] = "";
-		uint32_t c1 = (2^24)*126 + (2^8)*65535 + (2^0)*(256 - 1);
+		uint32_t c1 = (1<<24)*126 + (1<<8)*65535 + (1<<0)*(256 - 1);
 		uint32_t c2 = c1 - 1;
-
-		//uint32_t c2 = (2^24)*126 + (2^8)*65535 + (2^0)*(256 - 2);
-		//uint32_t c3 = (2^24)*126 + (2^8)*65534 + (2^0)*(256 - 1);
-		//uint32_t c4 = (2^24)*126 + (2^8)*65534 + (2^0)*(256 - 2);
 		ice_t *ice_out;
 
 		tmp1[10] = '\0';
@@ -10673,11 +10669,7 @@ SWITCH_DECLARE(void) switch_core_media_gen_local_sdp(switch_core_session_t *sess
 			char tmp1[11] = "";
 			char tmp2[11] = "";
 			char tmp3[11] = "";
-			uint32_t c1 = (2^24)*126 + (2^8)*65535 + (2^0)*(256 - 1);
-			//uint32_t c2 = (2^24)*126 + (2^8)*65535 + (2^0)*(256 - 2);
-			//uint32_t c3 = (2^24)*126 + (2^8)*65534 + (2^0)*(256 - 1);
-			//uint32_t c4 = (2^24)*126 + (2^8)*65534 + (2^0)*(256 - 2);
-
+			uint32_t c1 = (1<<24)*126 + (1<<8)*65535 + (1<<0)*(256 - 1);
 			uint32_t c2 = c1 - 1;
 			uint32_t c3 = c1 - 2;
 			uint32_t c4 = c1 - 3;
@@ -11215,11 +11207,7 @@ SWITCH_DECLARE(void) switch_core_media_gen_local_sdp(switch_core_session_t *sess
 					char tmp1[11] = "";
 					char tmp2[11] = "";
 					char tmp3[11] = "";
-					uint32_t c1 = (2^24)*126 + (2^8)*65535 + (2^0)*(256 - 1);
-					//uint32_t c2 = (2^24)*126 + (2^8)*65535 + (2^0)*(256 - 2);
-					//uint32_t c3 = (2^24)*126 + (2^8)*65534 + (2^0)*(256 - 1);
-					//uint32_t c4 = (2^24)*126 + (2^8)*65534 + (2^0)*(256 - 2);
-
+					uint32_t c1 = (1<<24)*126 + (1<<8)*65535 + (1<<0)*(256 - 1);
 					uint32_t c2 = c1 - 1;
 					uint32_t c3 = c1 - 2;
 					uint32_t c4 = c1 - 3;
@@ -11584,11 +11572,7 @@ SWITCH_DECLARE(void) switch_core_media_gen_local_sdp(switch_core_session_t *sess
 				if (t_engine->ice_out.cands[0][0].ready) {
 					char tmp1[11] = "";
 					char tmp2[11] = "";
-					uint32_t c1 = (2^24)*126 + (2^8)*65535 + (2^0)*(256 - 1);
-					//uint32_t c2 = (2^24)*126 + (2^8)*65535 + (2^0)*(256 - 2);
-					//uint32_t c3 = (2^24)*126 + (2^8)*65534 + (2^0)*(256 - 1);
-					//uint32_t c4 = (2^24)*126 + (2^8)*65534 + (2^0)*(256 - 2);
-
+					uint32_t c1 = (1<<24)*126 + (1<<8)*65535 + (1<<0)*(256 - 1);
 					uint32_t c2 = c1 - 1;
 					uint32_t c3 = c1 - 2;
 					uint32_t c4 = c1 - 3;


### PR DESCRIPTION
Seven years ago, commit cb076e6 used xor as pow. The compiler Clang 10
errors about this copy-paste-error from RFC 5245 section 4.1.2.1. Now,
Clang compiles successfully.