### PR TITLE
[mod_av] Update error message

### DIFF
--- a/src/mod/applications/mod_av/Makefile.am
+++ b/src/mod/applications/mod_av/Makefile.am
@@ -36,5 +36,5 @@ else
 install: error
 all: error
 error:
-	$(error You must install libavformat-dev to build mod_av)
+	$(error You must install libavformat-dev and libswscale-dev to build mod_av)
 endif


### PR DESCRIPTION
Five years ago, commit b29174e added the scale/conversion library of
FFmpeg. However, that library is not part of libavformat-dev and added
an additional requirement. That was not reflected in the error message,
when FFmpeg libraries are missing.