### PR TITLE
[switch] issue #885. fix typo in strcasecmp in switch_xml.c

### DIFF
--- a/src/switch_xml.c
+++ b/src/switch_xml.c
@@ -443,7 +443,7 @@ SWITCH_DECLARE(switch_xml_t) switch_xml_find_child_multi(switch_xml_t node, cons
 				if (aname) {
 					if (*vals[x] == '!') {
 						const char *sval = vals[x] + 1;
-						if (strcasecmp(aname, sval)) {
+						if (!strcasecmp(aname, sval)) {
 							goto done;
 						}
 					} else {


### PR DESCRIPTION
obviously it's a type.
without an exclamation mark, it returns true for different values.
for example `user_exists id ! ${domain}` returns true
I've described this in issue 885.