### PR TITLE
[configuration] Copy TLS ciphers from vars.xml even in Vanilla External

### DIFF
--- a/conf/vanilla/sip_profiles/external.xml
+++ b/conf/vanilla/sip_profiles/external.xml
@@ -92,5 +92,7 @@
     <param name="tls-verify-in-subjects" value=""/>
     <!-- TLS version ("sslv23" (default), "tlsv1"). NOTE: Phones may not work with TLSv1 -->
     <param name="tls-version" value="$${sip_tls_version}"/>
+    <!-- TLS ciphers default: ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH -->
+    <param name="tls-ciphers" value="$${sip_tls_ciphers}"/>
   </settings>
 </profile>


### PR DESCRIPTION
Previously, the configuration file vars.xml set the TLS Cipher Suites only for internal SIP profiles. External SIP profiles used the 'DEFAULT' set of the underlying OpenSSL. Now, external SIP profiles copy to the general setting of vars.xml as well. Of course, you can overwrite this anytime, for example, to use different sets for internal and external.