### PR TITLE
src/mod/applications/mod_cv/mod_cv.cpp: fix build with opencv 3.4.9

### DIFF
--- a/src/mod/applications/mod_cv/mod_cv.cpp
+++ b/src/mod/applications/mod_cv/mod_cv.cpp
@@ -690,7 +690,7 @@ void detectAndDraw(cv_context_t *context)
 		//printf("WTF %d\n", object_neighbors);
         //cout << "Detected " << object_neighbors << " object neighbors" << endl;
         const int rect_height = cvRound((float)img.rows * object_neighbors / max_neighbors);
-        CvScalar col = CV_RGB((float)255 * object_neighbors / max_neighbors, 0, 0);
+        CvScalar col = cvScalar(0, 0, (float)255 * object_neighbors / max_neighbors, 0);
         rectangle(img, cvPoint(0, img.rows), cvPoint(img.cols/10, img.rows - rect_height), col, -1);
 
         parse_stats(&context->nestDetected, nestedObjects.size(), context->skip);


### PR DESCRIPTION
Use `cvScalar` instead of `CV_RGB` to avoid the following build failure with opencv 3.4.9:

```
mod_cv.cpp:693:24: error: conversion from ‘cv::Scalar {aka cv::Scalar_<double>}’ to non-scalar type ‘CvScalar’ requested
         CvScalar col = CV_RGB((float)255 * object_neighbors / max_neighbors, 0, 0);
                        ^
```

Indeed, `CV_RGB` is defined as `cv::Scalar` instead of `cvScalar` since version 3.4.2 and
https://github.com/opencv/opencv/commit/7f9253ea0a9fe2635926379420002dbf0c3fce0f

It should be noted that CV_RGB(r,g,b) = cvScalar(b,g,r,0)

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>