### PR TITLE
[build] fix compilation under musl 1.2

### DIFF
--- a/src/include/switch_platform.h
+++ b/src/include/switch_platform.h
@@ -270,7 +270,11 @@ typedef intptr_t switch_ssize_t;
 #if defined(__FreeBSD__) && SIZEOF_VOIDP == 4
 #define TIME_T_FMT "d"
 #else
+#if __USE_TIME_BITS64
+#define TIME_T_FMT SWITCH_INT64_T_FMT
+#else
 #define TIME_T_FMT "ld"
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
musl 1.2 defaults to 64-bit time_t, causing a compile failure under 32-bit platforms.