### PR TITLE
Support for mDNS candidate SDP and resolve mdns if config have option

### DIFF
--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -197,6 +197,10 @@ SWITCH_DECLARE(void) switch_rtp_shutdown(void);
 */
 SWITCH_DECLARE(switch_port_t) switch_rtp_set_start_port(switch_port_t port);
 
+SWITCH_DECLARE(void) switch_rtp_set_resolve_ice(void);
+
+SWITCH_DECLARE(int) switch_rtp_has_resolve_ice(void);
+
 SWITCH_DECLARE(switch_status_t) switch_rtp_set_ssrc(switch_rtp_t *rtp_session, uint32_t ssrc);
 SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_ssrc(switch_rtp_t *rtp_session, uint32_t ssrc);
 

--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -2320,6 +2320,8 @@ static void switch_load_core_config(const char *file)
 					} else {
 						runtime.timer_affinity = atoi(val);
 					}
+				} else if (!strcasecmp(var, "ice-resolve-candidate") && switch_true(val)) {
+					switch_rtp_set_resolve_ice();
 				} else if (!strcasecmp(var, "rtp-start-port") && !zstr(val)) {
 					switch_rtp_set_start_port((switch_port_t) atoi(val));
 				} else if (!strcasecmp(var, "rtp-end-port") && !zstr(val)) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -88,6 +88,7 @@ static const switch_payload_t INVALID_PT = 255;
 								 * characters when receiving." */
 
 static switch_port_t START_PORT = RTP_START_PORT;
+static int ice_resolve_candidate = 0;
 static switch_port_t END_PORT = RTP_END_PORT;
 static switch_mutex_t *port_lock = NULL;
 static switch_size_t do_flush(switch_rtp_t *rtp_session, int force, switch_size_t bytes_in);
@@ -2552,6 +2553,15 @@ SWITCH_DECLARE(switch_port_t) switch_rtp_set_end_port(switch_port_t port)
 		}
 	}
 	return END_PORT;
+}
+
+SWITCH_DECLARE(void) switch_rtp_set_resolve_ice()
+{
+	ice_resolve_candidate = 1;
+}
+
+SWITCH_DECLARE(int) switch_rtp_has_resolve_ice(void) {
+	return ice_resolve_candidate;
 }
 
 SWITCH_DECLARE(void) switch_rtp_release_port(const char *ip, switch_port_t port)


### PR DESCRIPTION
Webrtc is pushing mDNS support for private IP leak. So if the SDP candidate have mDNS then freeswitch breaking the call saying INCOMPATIBLE_DESTINATION. 

mDNS : https://bloggeek.me/psa-mdns-and-local-ice-candidates-are-coming/ 

Candidate in SDP offer 

> a=candidate:4096337158 1 udp 2113937151 39330519-b9d7-4d00-9f7d-d1d22137d6de.local 49433 typ host generation 0 network-cost 999
a=candidate:4096337158 2 udp 2113937150 39330519-b9d7-4d00-9f7d-d1d22137d6de.local 55970 typ host generation 0 network-cost 999
a=candidate:842163049 2 udp 1677729534 206.15.76.98 9496 typ srflx raddr 0.0.0.0 rport 0 generation 0 network-cost 999
a=candidate:842163049 1 udp 1677729535 206.15.76.98 1421 typ srflx raddr 0.0.0.0 rport 0 generation 0 network-cost 999

Freeswitch log Error

> [DEBUG] switch_core_media.c:6878 AUDIO RTP [sofia/lv_sip/528945@acd.stg4.livevox.com] 10.111.21.219 port 17682 -> 39330519-b9d7-4d00-9f7d-d1d22137d6de.local port 49433 codec: 111 ms: 20317393ca-bad4-11e9-9b3d-a72334737892 
[DEBUG] switch_core_media.c:6878 AUDIO RTP [sofia/lv_sip/528945@acd.stg4.livevox.com] 10.111.21.219 port 17682 -> 39330519-b9d7-4d00-9f7d-d1d22137d6de.local port 49433 codec: 111 ms: 20317393ca-bad4-11e9-9b3d-a72334737892 
[DEBUG] switch_rtp.c:4150 Starting timer [soft] 960 bytes per 20ms317393ca-bad4-11e9-9b3d-a72334737892 2019-08-09 14:33:33.717009 
[ERR] switch_core_media.c:7567 AUDIO RTP REPORTS ERROR: [Remote Address Error!]317393ca-bad4-11e9-9b3d-a72334737892 2019-08-09 14:33:33.717009 
[NOTICE] switch_core_media.c:7568 Hangup sofia/lv_sip/528945@acd.stg4.livevox.com [CS_EXECUTE] [INCOMPATIBLE_DESTINATION]

Created a patch, which will try to check if the candidate is an IP address. If it is not IP address, then it will check a new config option ice-resolve-candidate set or not. If the flag is set then will try to resolve the mDNS or just drop the candidate and try the other one. 

The new flag option  **ice-resolve-candidate** in switch.conf.xml to resolve the candidate. 

**<param name="ice-resolve-candidate" value="1" />**


Can you please review this PR ?. 
