### PR TITLE
926: fixes mod_http_cache has a segfault and freeswitch crashes

### DIFF
--- a/src/mod/applications/mod_http_cache/aws.c
+++ b/src/mod/applications/mod_http_cache/aws.c
@@ -290,6 +290,7 @@ SWITCH_MOD_DECLARE(switch_curl_slist_t *) aws_s3_append_headers(
 #if defined(HAVE_OPENSSL)
 	switch_aws_s3_profile aws_s3_profile;
 	char* url_dup;
+	char* query_params;
 
 	// Get bucket and object name from url
 	switch_strdup(url_dup, url);
@@ -311,9 +312,11 @@ SWITCH_MOD_DECLARE(switch_curl_slist_t *) aws_s3_append_headers(
 	aws_s3_profile.verb = verb;
 	aws_s3_profile.expires = profile->expires;
 
-	*query_string = aws_s3_authentication_create(&aws_s3_profile);
+	query_params = aws_s3_authentication_create(&aws_s3_profile);
+    *query_string = query_params;
 
 	switch_safe_free(url_dup);
+
 #endif
 	return headers;
 }

--- a/src/mod/applications/mod_http_cache/mod_http_cache.c
+++ b/src/mod/applications/mod_http_cache/mod_http_cache.c
@@ -1099,6 +1099,8 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 	long httpRes = 0;
 	int start_time_ms = switch_time_now() / 1000;
 	switch_CURLcode curl_status = CURLE_UNKNOWN_OPTION;
+	char *query_string = NULL;
+    char *full_url = NULL;
 
 	/* set up HTTP GET */
 	get_data.fd = 0;
@@ -1110,7 +1112,14 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 	}
 
 	if (profile && profile->append_headers_ptr) {
-		headers = profile->append_headers_ptr(profile, headers, "GET", 0, "", url->url, 0, NULL);
+    	headers = profile->append_headers_ptr(profile, headers, "GET", 0, "", url->url, 0, &query_string);
+    }
+
+	if (query_string) {
+		full_url = switch_mprintf("%s?%s", url->url, query_string);
+        free(query_string);
+    } else {
+        switch_strdup(full_url, url->url);
 	}
 
 	curl_handle = switch_curl_easy_init();
@@ -1123,7 +1132,7 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 		if (headers) {
 			switch_curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
 		}
-		switch_curl_easy_setopt(curl_handle, CURLOPT_URL, get_data.url->url);
+		switch_curl_easy_setopt(curl_handle, CURLOPT_URL, full_url);
 		switch_curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, get_file_callback);
 		switch_curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *) &get_data);
 		switch_curl_easy_setopt(curl_handle, CURLOPT_HEADERFUNCTION, get_header_callback);
@@ -1178,6 +1187,7 @@ static switch_status_t http_get(url_cache_t *cache, http_profile_t *profile, cac
 
 done:
 
+	switch_safe_free(full_url);
 	if (headers) {
 		switch_curl_slist_free_all(headers);
 	}


### PR DESCRIPTION
* Fixes segfault from https://github.com/signalwire/freeswitch/issues/926
* added query params to http_get, 
**  They are needed because headers are not being computed and, but query params are computed in aws.c


AC
compiled the project using `make && make install` and restarted freeswitch and run a http_get to get a file from S3, the download was successful.
