### PR TITLE
[Core] Databases: Fix duplicate key name 'recovery3'

### DIFF
--- a/src/switch_core_sqldb.c
+++ b/src/switch_core_sqldb.c
@@ -3695,7 +3695,7 @@ switch_status_t switch_core_sqldb_start(switch_memory_pool_t *pool, switch_bool_
 	switch_cache_db_create_schema(sql_manager.dbh, "create index recovery1 on recovery(technology)", NULL);
 	switch_cache_db_create_schema(sql_manager.dbh, "create index recovery2 on recovery(profile_name)", NULL);
 	switch_cache_db_create_schema(sql_manager.dbh, "create index recovery3 on recovery(uuid)", NULL);
-	switch_cache_db_create_schema(sql_manager.dbh, "create index recovery3 on recovery(runtime_uuid)", NULL);
+	switch_cache_db_create_schema(sql_manager.dbh, "create index recovery4 on recovery(runtime_uuid)", NULL);
 
 
 


### PR DESCRIPTION
Fixes following error.

PostgreSQL:
```
Query (create index recovery3 on recovery(runtime_uuid)) returned PGRES_FATAL_ERROR
```

MySQL/MariaDB
```
(create index recovery3 on recovery(runtime_uuid)) to database: Duplicate key name 'recovery3'
```

Replicate:
- Load `mod_pgsql` or `mod_mariadb`
- Set `core-db-dsn` in `switch.conf.xml` to use postgresql,  odbc or mariadb.
- Set `auto-create-schemas` to `true` (Default)
