### PR TITLE
[Core] switch_core_media: Correct srtp_remote_audio_crypto_key variable

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -1637,8 +1637,9 @@ static void switch_core_session_get_recovery_crypto_key(switch_core_session_t *s
 	} else return;
 
 	if ((tmp = switch_channel_get_variable(session->channel, keyvar))) {
-		if ((tmp = switch_channel_get_variable(session->channel, ctypevar))) {
-			engine->crypto_type = switch_core_media_crypto_str2type(tmp);
+		const char *ct;
+		if ((ct = switch_channel_get_variable(session->channel, ctypevar))) {
+			engine->crypto_type = switch_core_media_crypto_str2type(ct);
 		}
 
 		engine->ssec[engine->crypto_type].remote_crypto_key = switch_core_session_strdup(session, tmp);


### PR DESCRIPTION
Fix [switch_core_media.c]: Store correct value in srtp_remote_audio_crypto_key channel variable