### PR TITLE
Fix [switch_core_media.c]: SRTP media crypto keys are not working

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -1761,7 +1761,7 @@ static void switch_core_session_parse_crypto_prefs(switch_core_session_t *sessio
 			int ok = 0;
 
 			for (j = 0; j < CRYPTO_INVALID; j++) {
-				if (!strcasecmp(fields[i], SUITES[j].name)) {
+				if (!strcasecmp(fields[i], SUITES[j].name) || !strcasecmp(fields[i], SUITES[j].alias)) {
 					smh->crypto_suite_order[k++] = SUITES[j].type;
 					ok++;
 					break;


### PR DESCRIPTION
Comparing the user given cypto type string to both name and alias of the default crypto suites supported by the system.