### PR TITLE
[mod_sofia] Remove 'precondition' from 'Supported:' w/ 100rel

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -3165,7 +3165,7 @@ void *SWITCH_THREAD_FUNC sofia_profile_thread_run(switch_thread_t *thread, void 
 		goto end;
 	}
 
-	supported = switch_core_sprintf(profile->pool, "%s%s%spath, replaces", use_100rel ? "precondition, 100rel, " : "", use_timer ? "timer, " : "", use_rfc_5626 ? "outbound, " : "");
+	supported = switch_core_sprintf(profile->pool, "%s%s%spath, replaces", use_100rel ? "100rel, " : "", use_timer ? "timer, " : "", use_rfc_5626 ? "outbound, " : "");
 
 	if (sofia_test_pflag(profile, PFLAG_AUTO_NAT) && switch_nat_get_type()) {
 		if ( (! sofia_test_pflag(profile, PFLAG_TLS) || ! profile->tls_only) && switch_nat_add_mapping(profile->sip_port, SWITCH_NAT_UDP, NULL, SWITCH_FALSE) == SWITCH_STATUS_SUCCESS) {


### PR DESCRIPTION
This PR removes the "precondition" option from Supported: header when 100rel mode is enabled, addressing #904 

comparing RFC3312 and the freeswitch codebase, I see no support for the mechanisms that "precondition" is intended to support (eg. `a=des, a=curr`), in my opinion it makes sense to remove it until such a time that rfc3312 is supported

In more concrete terms - freeswitch (or it's included modules) do not maintain a precondition table which is a "MUST" for  RFC3312 "precondition" functionality (there are probably other unsatisfied MUSTs, that's just the first one I've found: https://tools.ietf.org/html/rfc3312#section-5.1)