### PR TITLE
[mod_commands]: Add uuid_speak api command

### DIFF
--- a/src/mod/applications/mod_commands/mod_commands.c
+++ b/src/mod/applications/mod_commands/mod_commands.c
@@ -6439,7 +6439,7 @@ SWITCH_STANDARD_API(uuid_dump_function)
 	return SWITCH_STATUS_SUCCESS;
 }
 
-#define SPEAK_SYNTAX "<uuid> <engine>|[voice]|<text>[|timer_name]"
+#define SPEAK_SYNTAX "<uuid> <engine>|[voice]|<text>"
 SWITCH_STANDARD_API(uuid_speak_function)
 {
 	switch_status_t status = SWITCH_STATUS_FALSE;


### PR DESCRIPTION
add uuid_speak api command, use same as to speak of dptools.

`
uuid_speak <uuid> <engine>|<voice>|<text>|[timer_name]
`

uuid_speak 7468bc94-659b-4fdd-b488-de42c90754f4 flite|kal|FreeSWITCH is awesome
uuid_speak 7468bc94-659b-4fdd-b488-de42c90754f4 unimrcp:ali-tts||{speech-language=zh-CN,kill-on-barge-in=true}'Hello World'



