### PR TITLE
[mod_commands]: add uuid_speak api command

### DIFF
--- a/src/mod/applications/mod_commands/Makefile.am
+++ b/src/mod/applications/mod_commands/Makefile.am
@@ -6,3 +6,11 @@ mod_commands_la_SOURCES  = mod_commands.c
 mod_commands_la_CFLAGS   = $(AM_CFLAGS)
 mod_commands_la_LIBADD   = $(switch_builddir)/libfreeswitch.la
 mod_commands_la_LDFLAGS  = -avoid-version -module -no-undefined -shared
+
+noinst_PROGRAMS = test/test_mod_commands
+
+test_test_mod_commands_SOURCES = test/test_mod_commands.c
+test_test_mod_commands_CFLAGS = $(AM_CFLAGS) -I. -DSWITCH_TEST_BASE_DIR_FOR_CONF=\"${abs_builddir}/test\" -DSWITCH_TEST_BASE_DIR_OVERRIDE=\"${abs_builddir}/test\"
+test_test_mod_commands_LDFLAGS = $(AM_LDFLAGS) -avoid-version -no-undefined $(freeswitch_LDFLAGS) $(switch_builddir)/libfreeswitch.la $(CORE_LIBS) $(APR_LIBS)
+
+TESTS = $(noinst_PROGRAMS)

--- a/src/mod/applications/mod_commands/test/conf/freeswitch.xml
+++ b/src/mod/applications/mod_commands/test/conf/freeswitch.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<document type="freeswitch/xml">
+
+  <section name="configuration" description="Various Configuration">
+    <configuration name="modules.conf" description="Modules">
+      <modules>
+        <load module="mod_console"/>
+        <load module="mod_tone_stream"/>
+        <load module="mod_sndfile"/>
+        <load module="mod_commands"/>
+        <load module="mod_dptools"/>
+        <load module="mod_test"/>
+        <load module="mod_loopback"/>
+      </modules>
+    </configuration>
+
+    <configuration name="console.conf" description="Console Logger">
+      <mappings>
+        <map name="all" value="console,debug,info,notice,warning,err,crit,alert"/>
+      </mappings>
+      <settings>
+        <param name="colorize" value="true"/>
+        <param name="loglevel" value="debug"/>
+      </settings>
+    </configuration>
+
+    <configuration name="timezones.conf" description="Timezones">
+      <timezones>
+          <zone name="GMT" value="GMT0" />
+      </timezones>
+    </configuration>
+  </section>
+
+  <section name="dialplan" description="Regex/XML Dialplan">
+    <context name="default">
+      <extension name="sample">
+        <condition>
+          <action application="info"/>
+        </condition>
+      </extension>
+    </context>
+  </section>
+</document>

--- a/src/mod/applications/mod_commands/test/test_mod_commands.c
+++ b/src/mod/applications/mod_commands/test/test_mod_commands.c
@@ -1,0 +1,96 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ * Copyright (C) 2005-2018, Anthony Minessale II <anthm@freeswitch.org>
+ *
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * The Initial Developer of the Original Code is
+ * Hailin Zhou <zhouhailin555@aliyun.com>
+ * Portions created by the Initial Developer are Copyright (C)
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ *
+ * test_mod_commands -- mod_commands test
+ *
+ */
+
+#include <switch.h>
+#include <test/switch_test.h>
+#include <stdlib.h>
+
+
+FST_CORE_BEGIN("conf")
+
+FST_MODULE_BEGIN(mod_commands, mod_commands_test)
+
+FST_SETUP_BEGIN()
+{
+	fst_requires_module("mod_commands");
+	fst_requires_module("mod_tone_stream");
+	fst_requires_module("mod_sndfile");
+	fst_requires_module("mod_dptools");
+	fst_requires_module("mod_test");
+	fst_requires_module("mod_loopback");
+}
+FST_SETUP_END()
+
+FST_TEARDOWN_BEGIN()
+{
+}
+FST_TEARDOWN_END()
+
+
+FST_SESSION_BEGIN(uuid_speak_test)
+{
+	switch_stream_handle_t stream = { 0 };
+
+	SWITCH_STANDARD_STREAM(stream);
+	
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "uuid_speak %s test:laihu-tts|siqi|'Hello World'\n", switch_core_session_get_uuid(fst_session));
+	switch_api_execute("uuid_speak", switch_core_session_sprintf(fst_session, "%s test:laihu-tts|siqi|'Hello World'", switch_core_session_get_uuid(fst_session)), NULL, &stream);
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "uuid_speak %s test:laihu-tts||'Hello World'\n", switch_core_session_get_uuid(fst_session));
+	switch_api_execute("uuid_speak", switch_core_session_sprintf(fst_session, "%s test:laihu-tts||'Hello World'", switch_core_session_get_uuid(fst_session)), NULL, &stream);
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "uuid_setvar %s tts_engine test:laihu-tts\n", switch_core_session_get_uuid(fst_session));
+	switch_api_execute("uuid_setvar", switch_core_session_sprintf(fst_session, "%s tts_engine test:laihu-tts", switch_core_session_get_uuid(fst_session)), NULL, &stream);
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "uuid_speak %s 'Hello World'\n", switch_core_session_get_uuid(fst_session));
+	switch_api_execute("uuid_speak", switch_core_session_sprintf(fst_session, "%s 'Hello World'", switch_core_session_get_uuid(fst_session)), NULL, &stream);
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "uuid_setvar %s tts_voice siqi\n", switch_core_session_get_uuid(fst_session));
+	switch_api_execute("uuid_setvar", switch_core_session_sprintf(fst_session, "%s tts_voice siqi", switch_core_session_get_uuid(fst_session)), NULL, &stream);
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "uuid_speak %s 'Hello World'\n", switch_core_session_get_uuid(fst_session));
+	switch_api_execute("uuid_speak", switch_core_session_sprintf(fst_session, "%s 'Hello World'", switch_core_session_get_uuid(fst_session)), NULL, &stream);
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "uuid_speak\n");
+	switch_api_execute("uuid_speak", NULL, NULL, &stream);
+
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "uuid_speak %s\n", switch_core_session_get_uuid(fst_session));
+	switch_api_execute("uuid_speak", switch_core_session_sprintf(fst_session, "%s", switch_core_session_get_uuid(fst_session)), NULL, &stream);
+
+	if (stream.data) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "LUA DATA: %s\n", (char *)stream.data);
+		fst_check(strstr(stream.data, "+OK") == stream.data);
+		free(stream.data);
+	}
+}
+FST_SESSION_END()
+
+
+FST_MODULE_END()
+
+FST_CORE_END()

--- a/src/mod/applications/mod_test/mod_test.c
+++ b/src/mod/applications/mod_test/mod_test.c
@@ -360,9 +360,48 @@ static void test_asr_text_param(switch_asr_handle_t *ah, char *param, const char
 	}
 }
 
+
+
+static switch_status_t test_speech_open(switch_speech_handle_t *sh, const char *voice_name, int rate, int channels, switch_speech_flag_t *flags)
+{
+	return SWITCH_STATUS_SUCCESS;
+}
+
+static switch_status_t test_speech_close(switch_speech_handle_t *sh, switch_speech_flag_t *flags)
+{
+	return SWITCH_STATUS_SUCCESS;
+}
+
+static switch_status_t test_speech_feed_tts(switch_speech_handle_t *sh, char *text, switch_speech_flag_t *flags)
+{
+	return SWITCH_STATUS_SUCCESS;
+}
+
+static switch_status_t test_speech_read_tts(switch_speech_handle_t *sh, void *data, switch_size_t *datalen, switch_speech_flag_t *flags)
+{
+	return SWITCH_STATUS_FALSE;
+}
+
+static void test_speech_flush_tts(switch_speech_handle_t *sh)
+{
+}
+
+static void test_speech_text_param_tts(switch_speech_handle_t *sh, char *param, const char *val)
+{
+}
+
+static void test_speech_numeric_param_tts(switch_speech_handle_t *sh, char *param, int val)
+{
+}
+
+static void test_speech_float_param_tts(switch_speech_handle_t *sh, char *param, double val)
+{
+}
+
 SWITCH_MODULE_LOAD_FUNCTION(mod_test_load)
 {
 	switch_asr_interface_t *asr_interface;
+	switch_speech_interface_t *speech_interface = NULL;
 
 	*module_interface = switch_loadable_module_create_module_interface(pool, modname);
 
@@ -379,6 +418,17 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_test_load)
 	asr_interface->asr_get_results = test_asr_get_results;
 	asr_interface->asr_start_input_timers = test_asr_start_input_timers;
 	asr_interface->asr_text_param = test_asr_text_param;
+
+	speech_interface = switch_loadable_module_create_interface(*module_interface, SWITCH_SPEECH_INTERFACE);
+	speech_interface->interface_name = "test";
+	speech_interface->speech_open = test_speech_open;
+	speech_interface->speech_close = test_speech_close;
+	speech_interface->speech_feed_tts = test_speech_feed_tts;
+	speech_interface->speech_read_tts = test_speech_read_tts;
+	speech_interface->speech_flush_tts = test_speech_flush_tts;
+	speech_interface->speech_text_param_tts = test_speech_text_param_tts;
+	speech_interface->speech_numeric_param_tts = test_speech_numeric_param_tts;
+	speech_interface->speech_float_param_tts = test_speech_float_param_tts;
 
 	return SWITCH_STATUS_SUCCESS;
 }


### PR DESCRIPTION
add uuid_speak command api, syntax `<uuid> [engine|[voice|]]<text>`

example
`
uuid_speak 74027e41-7106-4360-bd2e-c28219ae3f19  unimrcp:ali-tts|siqi|'Hello World'
uuid_speak 74027e41-7106-4360-bd2e-c28219ae3f19  unimrcp:ali-tts||'Hello World'

uuid_setvar 74027e41-7106-4360-bd2e-c28219ae3f19 tts_engine unimrcp:ali-tts
uuid_speak 74027e41-7106-4360-bd2e-c28219ae3f19 'Hello World'

uuid_setvar 74027e41-7106-4360-bd2e-c28219ae3f19 tts_voice siqi
uuid_speak 74027e41-7106-4360-bd2e-c28219ae3f19 'Hello World'
`
