### PR TITLE
[mod_v8] Fix C++ compile warning

### DIFF
--- a/src/mod/languages/mod_v8/mod_v8.cpp
+++ b/src/mod/languages/mod_v8/mod_v8.cpp
@@ -1242,7 +1242,8 @@ inline static void stream_write_safe_d(switch_stream_handle_t *stream, const cha
 SWITCH_STANDARD_API(process_status_function)
 {
 	char *mydata = NULL, *argv[3] = { 0 };
-	char *as = NULL, *output_text = NULL, *delim = ",";	
+	const char *as = NULL, *delim = ",";
+	char *output_text = NULL;
 	cJSON *json = NULL, *row;
 	switch_xml_t xml = NULL, xml_row, xml_field;
 	int rows = 0, f_off = 0, count = 0;


### PR DESCRIPTION
mod_v8.cpp: In function ‘switch_status_t process_status_function(const char*, switch_core_session_t*, switch_stream_handle_t*)’:
mod_v8.cpp:1245:52: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
     char *as = NULL, *output_text = NULL, *delim = ",";
                                                    ^~~
mod_v8.cpp:1263:8: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
   as = "plain";
        ^~~~~~~