### PR TITLE
[mod_commands]: add uuid_detect_speech api command

### DIFF
--- a/src/mod/applications/mod_commands/mod_commands.c
+++ b/src/mod/applications/mod_commands/mod_commands.c
@@ -4344,7 +4344,7 @@ SWITCH_STANDARD_API(uuid_detect_speech_function)
 	}
 
 	if (argc < 2) {
-		if (!strcasecmp(argv[0], "help")) {
+		if (argc && !strcasecmp(argv[0], "help")) {
                 	stream->write_function(stream, "  uuid_detect_speech <uuid> grammar http://127.0.0.1/demo.grxml test\n");
         	        stream->write_function(stream, "  uuid_detect_speech <uuid> nogrammar test\n");
 	                stream->write_function(stream, "  uuid_detect_speech <uuid> grammaron test\n");


### PR DESCRIPTION
execute app via esl can't start recognize again immediately when speaking long text, must speak done then execute app from queue.
this api can execute immediately, where speaking long long text, used by  interrupted by keywords

you can use `uuid_detect_speech help`  how to use

`https://freeswitch.org/confluence/display/FREESWITCH/mod_dptools%3A+detect_speech`

example :
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 grammar http://127.0.0.1/demo.grxml test
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 nogrammar test
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 grammaron test
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 grammaroff test
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 grammarsalloff test
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 init unimrcp:ali-asr
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 init unimrcp ali-asr
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 pause
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 resume
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 stop
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 param sensitivity-level 0.3
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 param no-input-timeout 10000
uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 start_input_timers

uuid_detect_speech 6308ee86-c5be-42c0-baab-d8eece65fd59 unimrcp:ali-asr {sensitivity-level=0.3,confidence-threshold=0.1,no-input-timeout=10000,recognition-timeout=50000}http://127.0.0.1/demo.grxml test
