### PR TITLE
[mod_opus] Do not hangup call on decode error - fix 86a5ee3509

### DIFF
--- a/src/mod/codecs/mod_opus/mod_opus.c
+++ b/src/mod/codecs/mod_opus/mod_opus.c
@@ -914,7 +914,7 @@ static switch_status_t switch_opus_decode(switch_codec_t *codec,
 	if (samples < 0) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Decoder Error: %s fs:%u plc:%s!\n",
 						  opus_strerror(samples), frame_size, plc ? "true" : "false");
-		return SWITCH_STATUS_FALSE;
+		return SWITCH_STATUS_NOOP;
 	}
 
 	*decoded_data_len = samples * 2 * (!context->codec_settings.sprop_stereo ? codec->implementation->number_of_channels : 2);


### PR DESCRIPTION
Had this issue back in October with a specific Chrome version. When there's packet loss from the browser (tested with 10% using Linux netem (tc qdisc add dev ethx root netem loss 10%) and VMware fusion) mod_opus fails to decode the samples and return SWITCH_STATUS_FALSE and this makes switch_core_media hangup the call, changing to SWITCH_STATUS_NOOP fixed the issue and there's no, apparently, audio issues.

With latest chrome stable and canary I couldn't reproduce the issue anymore.