### PR TITLE
[mod_sofia] Set the proper content-length for multipart messages

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_media.c
+++ b/src/mod/endpoints/mod_sofia/sofia_media.c
@@ -104,7 +104,10 @@ static void process_mp(switch_core_session_t *session, switch_stream_handle_t *s
 	if ((dval = strchr(dname, ':'))) {
 		*dval++ = '\0';
 		if (*dval == '~') {
-			stream->write_function(stream, "--%s\r\nContent-Type: %s\r\nContent-Length: %d\r\n%s\r\n", boundary, dname, strlen(dval), dval + 1);
+			char *body;
+			if ((body = strstr(dval, "\r\n\r\n"))) {
+				stream->write_function(stream, "--%s\r\nContent-Type: %s\r\nContent-Length: %d\r\n%s\r\n", boundary, dname, strlen(body + 4) + 1, dval + 1);
+			}
 		} else {
 			stream->write_function(stream, "--%s\r\nContent-Type: %s\r\nContent-Length: %d\r\n\r\n%s\r\n", boundary, dname, strlen(dval) + 1, dval);
 		}


### PR DESCRIPTION
# Context
This change ensures that the proper content length is set when setting a multipart header with custom headers.

# Questions
- Is Content-Length even required or needed in the multipart data reading this email chain it seems like it may be unnecessary and unused but allowed since it isn't explicitly disallowed. 
  - https://lists.cs.columbia.edu/pipermail/sip-implementors/2012-March/028216.html

# Overview
- Use strstr to find the boundary of the body `\r\n\r\n` ignore if there is no valid body
- Use the pointer found by strstr + 4(accounting for the boundary) to call strlen with to get the real size of the body. But add one to match existing behavior.