### PR TITLE
fix the color rendering in the chrome 84+

### DIFF
--- a/conf/vanilla/autoload_configs/av.conf.xml
+++ b/conf/vanilla/autoload_configs/av.conf.xml
@@ -107,7 +107,7 @@ enum AVColorSpace {
     AVCOL_SPC_NB                ///< Not part of ABI
 };
 -->
-      <param name="colorspace" value="0"/>
+      <param name="colorspace" value="1"/>
 
 <!--
 enum AVColorRange {


### PR DESCRIPTION
fix the color rendering in the chrome 84+ that sRGB not support