### PR TITLE
[core] allow redirection of com modules

### DIFF
--- a/src/include/switch_loadable_module.h
+++ b/src/include/switch_loadable_module.h
@@ -330,6 +330,21 @@ SWITCH_DECLARE(switch_status_t) switch_loadable_module_load_module(const char *d
 SWITCH_DECLARE(switch_status_t) switch_loadable_module_exists(const char *mod);
 
 /*!
+  \brief Check if a module is available in dir
+  \param name the module name
+  \param dir the directory for checking
+  \return the status
+*/
+SWITCH_DECLARE(int) switch_loadable_module_available_in_dir(const char *name, const char *dir);
+
+/*!
+  \brief Check if a module is available in global dirs
+  \param name the module name
+  \return the status
+*/
+SWITCH_DECLARE(int) switch_loadable_module_available(const char *name);
+
+/*!
 \brief Protect module from beeing unloaded
 \param mod the module name
 \return the status


### PR DESCRIPTION
checks redirect-mod-load-to-com-module core variable
and redirects the load to com module if it exists.
ex: load mod_g729 will load mod_com_g729 if its available.

this patch adds

* switch_loadable_module_available_in_dir
  checks if module is available in directory
* switch_loadable_module_available
  calls switch_loadable_module_available_in_dir with default module dir

this patch changes
* switch_loadable_module_enumerate_available
  use created pool and freeing after enumeration for switch_dir operations.
  this avoids the switch_dir pool allocations (loadable_modules.pool) to stay in memory
  allowing freeswith to run for long periods without the need to restart
  because of available memory