### PR TITLE
[core] Do not block waiting for peer_channel after the bridge ended with CF_ATTENDED_TRANSFER

### DIFF
--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -1800,7 +1800,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_multi_threaded_bridge(switch_core_ses
 			switch_channel_stop_broadcast(peer_channel);
 
 
-			while (switch_channel_get_state(peer_channel) == CS_EXCHANGE_MEDIA) {
+			while (switch_channel_get_state(peer_channel) == CS_EXCHANGE_MEDIA && !switch_channel_test_flag(peer_channel, CF_ATTENDED_TRANSFER)) {
 				switch_ivr_parse_all_messages(session);
 				switch_cond_next();
 			}


### PR DESCRIPTION
[core] Do not block waiting for peer_channel after the bridge ended due to CF_ATTENDED_TRANSFER

In some attended transfer scenarios the BYE was only being sent after
the call between peer_channel and his new party is finished. ref
https://freeswitch.org/jira/browse/FS-7242

This was happening because between the audio_bridge_thread finishing and
the while loop checking for peer_channel state, the peer_channel got
quickly bridged to another channel, keeping his state in CS_EXCHANGE_MEDIA
and holding the original channel in the CS_EXECUTE state. Since this
loop doesn't finish the session couldn't transition to CS_PARK to be
hung up with park_timeout (ATTENDED_TRANSFER) ref: mod_sofia
sofia_handle_sip_i_refer.