### PR TITLE
[Core] Capture return value of 2nd call to LoadLibraryEx and add a third call to widen the search to the module in switch_dso_open().

### DIFF
--- a/src/switch_dso.c
+++ b/src/switch_dso.c
@@ -39,7 +39,11 @@ SWITCH_DECLARE(switch_dso_lib_t) switch_dso_open(const char *path, int global, c
 	lib = LoadLibraryEx(path, NULL, 0);
 
 	if (!lib) {
-		LoadLibraryEx(path, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+		lib = LoadLibraryEx(path, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+	}
+
+	if (!lib) {
+		lib = LoadLibraryEx(path, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 	}
 
 	if (!lib) {


### PR DESCRIPTION
Modified to capture return value of 2nd call to LoadLibraryEx and added a third call to widen the search to the module.