### PR TITLE
[core] Fix memory leak caused by persistence of AVPacket side_data

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -14721,7 +14721,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_video_frame(switch_cor
 			status = switch_core_session_write_encoded_video_frame(session, frame, flags, stream_id);
 		}
 
-	} while(status == SWITCH_STATUS_SUCCESS && encode_status == SWITCH_STATUS_MORE_DATA);
+	} while(encode_status == SWITCH_STATUS_MORE_DATA);
 
  done:
 


### PR DESCRIPTION
When encoded frames cannot be written to session, the loop breaks and the remaining data cannot be processed in consume_h264_bitstream function.
This lead to situation when AVPacket is not wiped out and its side_data are not released from memory causing the leak.

With this fix we are not breaking the loop when we cannot write the encoded frame to session, giving the chance to process the whole frame and in consequence to wipe out the AVPacket and free side_data.