### PR TITLE
FS-1107: free memory only if it was malloc'ed

### DIFF
--- a/src/switch_xml.c
+++ b/src/switch_xml.c
@@ -1024,7 +1024,9 @@ SWITCH_DECLARE(switch_xml_t) switch_xml_parse_str_dynamic(char *s, switch_bool_t
 	data = dup ? switch_must_strdup(s) : s;
 
 	if ((root = (switch_xml_root_t) switch_xml_parse_str(data, strlen(data)))) {
-		root->dynamic = 1;		/* Make sure we free the memory is switch_xml_free() */
+		if (dup) {
+			root->dynamic = 1;	/* Make sure we free the memory is switch_xml_free() */
+		}
 		return &root->xml;
 	} else {
 		if (dup) {


### PR DESCRIPTION
**Ticket ID**: https://github.com/signalwire/freeswitch/issues/1107

**Changes**
In switch_xml_parse_str_dynamic(), root->dynamic = 1, only if the function was called with SWITCH_TRUE.