### PR TITLE
mod_callcenter add queue count agents with external calls

### DIFF
--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -3518,7 +3518,7 @@ static int list_result_json_callback(void *pArg, int argc, char **argv, char **c
 "\tcallcenter_config queue list members [queue_name] | \n" \
 "\tcallcenter_config queue list tiers [queue_name] | \n" \
 "\tcallcenter_config queue count | \n" \
-"\tcallcenter_config queue count agents [queue_name] [status] [state] | \n" \
+"\tcallcenter_config queue count agents [queue_name] [status] [state] [external-calls]| \n" \
 "\tcallcenter_config queue count members [queue_name] | \n" \
 "\tcallcenter_config queue count tiers [queue_name]"
 
@@ -3959,6 +3959,7 @@ SWITCH_STANDARD_API(cc_config_api_function)
 				const char *queue_name = argv[1 + initial_argc];
 				const char *status = NULL;
 				const char *state = NULL;
+				const char *external = NULL;
 				char res[256] = "";
 
 				/* queue count agents */
@@ -3969,7 +3970,14 @@ SWITCH_STANDARD_API(cc_config_api_function)
 					if (argc-initial_argc > 3) {
 						state = argv[3 + initial_argc];
 					}
-					if (state)	{
+					if (argc-initial_argc > 4) {
+						external = argv[4 + initial_argc];
+					}
+
+					if (external)	{
+						sql = switch_mprintf("SELECT count(*) FROM agents,tiers WHERE tiers.agent = agents.name AND tiers.queue = '%q' AND agents.status = '%q' AND agents.state = '%q' AND external_calls_count = '%d' ", queue_name, status, state, atoi(external));
+					}
+					else if (state)	{
 						sql = switch_mprintf("SELECT count(*) FROM agents,tiers WHERE tiers.agent = agents.name AND tiers.queue = '%q' AND agents.status = '%q' AND agents.state = '%q'", queue_name, status, state);
 					}
 					else if (status)	{


### PR DESCRIPTION
when tracking external calls the extra column "external_calls" is used. So if the agent is in a call outside the callcenter the agent is not available to receive calls. 

Now before placing a call in a queue i check for available agents using:

callcenter_config queue count agents support 'Available' 'Waiting'

Is not enough, because it doesn't check for external calls.

With this change is possible to use:
callcenter_config queue count agents support 'Available' 'Waiting' 0 


It will return only the available agents ready to receive calls. 

