### PR TITLE
[mod_sofia] PBX Unify OpenScape 4000 - Partner ID update fix

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -2056,7 +2056,10 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 									  switch_stristr("Grandstream", ua) ||
 									  switch_stristr("Yealink", ua) ||
 									  switch_stristr("Mitel", ua) ||
-									  switch_stristr("Panasonic", ua))) {
+									  switch_stristr("Panasonic", ua) ||
+									  switch_string_match(ua, strlen(ua) - 1, "OpenScape 4000", 13) == SWITCH_STATUS_SUCCESS)) {
+							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Do UPDATE P-Asserted-Identity: \"%s\" <sip:%s@%s>\n", name, number, tech_pvt->profile->sipip);
+
 							snprintf(message, sizeof(message), "P-Asserted-Identity: \"%s\" <sip:%s@%s>", name, number, tech_pvt->profile->sipip);
 
 							sofia_set_flag_locked(tech_pvt, TFLAG_UPDATING_DISPLAY);

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -10073,6 +10073,28 @@ void sofia_handle_sip_i_reinvite(switch_core_session_t *session,
 		}
 	}
 
+	if (session && channel && sip && sip->sip_user_agent)
+	{
+		const char* ua = switch_channel_get_variable(channel, "sip_user_agent");
+		if (ua &&
+			(switch_string_match(ua, strlen(ua) - 1, "OpenScape 4000", 13) == SWITCH_STATUS_SUCCESS ||
+				switch_string_match(ua, strlen(ua) - 1, "anynode", 6) == SWITCH_STATUS_SUCCESS)) {
+
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Potential update callee ID\n");
+
+			if (sip->sip_referred_by) {
+				if (sip->sip_referred_by->b_display) {
+					switch_channel_set_variable_printf(channel, "sip_reffered-by_name", "%d", sip->sip_referred_by->b_display);
+				}
+				if (sip->sip_referred_by->b_cid) {
+					switch_channel_set_variable_printf(channel, "sip_reffered-by_cid", "%d", sip->sip_referred_by->b_cid);
+				}
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Update callee ID\n");
+				sofia_update_callee_id(session, profile, sip, SWITCH_TRUE);
+			}
+		}
+	}
+
 	if (session && profile && sip && sofia_test_pflag(profile, PFLAG_TRACK_CALLS)) {
 		switch_channel_t *channel = switch_core_session_get_channel(session);
 		private_object_t *tech_pvt = (private_object_t *) switch_core_session_get_private(session);


### PR DESCRIPTION
PBX Unify Openscape 4000 - SIP Trunk Connection:
Scenario
- A caller from the PBX, who is in a consultation call, calls a FreeSwitch Client. 
- FreeSwitch Client accepts the call
- The caller from the PBX transfers his first call to the Freeswitch Client.
- The Freeswitch Client still sees the original caller as the callee ID and not the actual partner.

This fix causes the ReInvite with the "referred-by" information from the PBX to trigger the update mechanism. 