### PR TITLE
[mod_enum] fix mem leak - ldns_resolver_new() - vanilla cfg.

### DIFF
--- a/src/mod/applications/mod_enum/mod_enum.c
+++ b/src/mod/applications/mod_enum/mod_enum.c
@@ -496,6 +496,9 @@ switch_status_t ldns_lookup(const char *number, const char *root, char *server_n
 	if (!added_server) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "No Nameservers specified, using host default\n");
 		/* create a new resolver from /etc/resolv.conf */
+		if (res) {
+			ldns_resolver_free(res);
+		}
 		s = ldns_resolver_new_frm_file(&res, NULL);
 	}
 


### PR DESCRIPTION
```Direct leak of 504 byte(s) in 3 object(s) allocated from:
    #0 0x7f9d9cf2fd28 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc1d28)
    #1 0x7f9d8e2775ca in ldns_resolver_new (/usr/lib/x86_64-linux-gnu/libldns.so.2+0x395ca)
    #2 0x7f9d8e4b9d23 in enum_lookup /root/github/freeswitch/src/mod/applications/mod_enum/mod_enum.c:626
    #3 0x7f9d8e4b9ff0 in enum_dialplan_hunt /root/github/freeswitch/src/mod/applications/mod_enum/mod_enum.c:647
    #4 0x7f9d9be2857f in switch_core_standard_on_routing src/switch_core_state_machine.c:282
    #5 0x7f9d9be2857f in switch_core_session_run src/switch_core_state_machine.c:644
    #6 0x7f9d9be1a78c in switch_core_session_thread src/switch_core_session.c:1709
    #7 0x7f9d9be105e8 in switch_core_session_thread_pool_worker src/switch_core_session.c:1772
    #8 0x7f9d9c4ebc4a in dummy_worker threadproc/unix/thread.c:151
    #9 0x7f9d9b2234a3 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x74a3)```