### PR TITLE
[mod_voicemail] Fix voicemail ignoring vm-a1-hash

### DIFF
--- a/src/mod/applications/mod_voicemail/mod_voicemail.c
+++ b/src/mod/applications/mod_voicemail/mod_voicemail.c
@@ -2583,7 +2583,7 @@ static void voicemail_check_main(switch_core_session_t *session, vm_profile_t *p
 				if (!auth) {
 					if (!zstr(cbt.password) && !strcmp(cbt.password, mypass)) {
 						auth++;
-					} else if (!thepass && profile->allow_empty_password_auth) {
+					} else if (!thehash && !thepass && profile->allow_empty_password_auth) {
 						auth++;
 					}
 


### PR DESCRIPTION
Fix #1135 - Consider the presence of a hash as equivalent to the presence of a password when evaluating the allow-empty-password-auth option.