### PR TITLE
Expose custom data from a channel in the conference ESL events and xml/json list command

### DIFF
--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -236,6 +236,7 @@ void conference_member_update_status_field(conference_member_t *member)
 switch_status_t conference_member_add_event_data(conference_member_t *member, switch_event_t *event)
 {
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
+	const char *v;
 
 	if (!member)
 		return status;
@@ -255,7 +256,9 @@ switch_status_t conference_member_add_event_data(conference_member_t *member, sw
 		}
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Video", "%s",
 								switch_channel_test_flag(switch_core_session_get_channel(member->session), CF_VIDEO) ? "true" : "false" );
-
+		if ((v = switch_channel_get_variable_dup(channel, "conference_custom_channel_data", SWITCH_FALSE, -1))) {
+			switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Conference-Custom-Channel-Data", v);
+		}
 	}
 
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Hear", "%s", conference_utils_member_test_flag(member, MFLAG_CAN_HEAR) ? "true" : "false" );

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -1237,6 +1237,7 @@ void conference_xlist(conference_obj_t *conference, switch_xml_t x_conference, i
 		switch_channel_t *channel;
 		switch_caller_profile_t *profile;
 		char *uuid;
+		const char *custom_chan_data;
 		//char *name;
 		uint32_t count = 0;
 		switch_xml_t x_tag;
@@ -1299,6 +1300,10 @@ void conference_xlist(conference_obj_t *conference, switch_xml_t x_conference, i
 
 		switch_snprintf(i, sizeof(i), "%d", member->volume_out_level);
 		add_x_tag(x_member, "volume_out", i, toff++);
+
+		if ((custom_chan_data = switch_channel_get_variable_dup(channel, "conference_custom_channel_data", SWITCH_FALSE, -1))) {
+			add_x_tag(x_member, "custom_channel_data", custom_chan_data, toff++);
+		}
 
 		x_flags = switch_xml_add_child_d(x_member, "flags", count++);
 		switch_assert(x_flags);
@@ -1401,6 +1406,7 @@ void conference_jlist(conference_obj_t *conference, cJSON *json_conferences)
 		switch_channel_t *channel;
 		switch_caller_profile_t *profile;
 		char *uuid;
+		const char *custom_chan_data;
 		switch_bool_t hold = conference_utils_member_test_flag(member, MFLAG_HOLD);
 
 		cJSON_AddItemToObject(json_conference_members, "member", json_conference_member = cJSON_CreateObject());
@@ -1434,6 +1440,9 @@ void conference_jlist(conference_obj_t *conference, cJSON *json_conferences)
 		cJSON_AddNumberToObject(json_conference_member, "volume_out", member->volume_out_level);
 		cJSON_AddNumberToObject(json_conference_member, "output-volume", member->volume_out_level);
 		cJSON_AddNumberToObject(json_conference_member, "input-volume", member->volume_in_level);
+		if ((custom_chan_data = switch_channel_get_variable_dup(channel, "conference_custom_channel_data", SWITCH_FALSE, -1))) {
+			cJSON_AddStringToObject(json_conference_member, "custom_channel_data", custom_chan_data);
+		}
 		ADDBOOL(json_conference_member_flags, "can_hear", !hold && conference_utils_member_test_flag(member, MFLAG_CAN_HEAR));
 		ADDBOOL(json_conference_member_flags, "can_see", !hold && conference_utils_member_test_flag(member, MFLAG_CAN_SEE));
 		ADDBOOL(json_conference_member_flags, "can_speak", !hold && conference_utils_member_test_flag(member, MFLAG_CAN_SPEAK));


### PR DESCRIPTION
This patch allows to expose the contents of a pre-defined channel variable `conference_custom_channel_data` in the ESL conference member events and in the `conference <name> [xml_list|json_list]` lists. This is useful for attaching custom data to any conference members in a generic way.

Note that the `verbose-events` conference profile parameter can also be used to expose *all* channel variables in the ESL conference events, but that wasn't desired in our case and we also needed this custom data to be available in the `xml_list` and `json_list` commands in order to be able to synchronise to the conference state on initial ESL connect.

We have used this to successfully implement raise/lower hand functionality, where the conference member raise hand state is tracked with the help of this channel variable.