### PR TITLE
[mod_conference] add API command to get/set conference variables

### DIFF
--- a/src/mod/applications/mod_conference/conference_api.c
+++ b/src/mod/applications/mod_conference/conference_api.c
@@ -106,6 +106,8 @@ api_command_t conference_api_sub_commands[] = {
 	{"nopin", (void_fn_t) & conference_api_sub_pin, CONF_API_SUB_ARGS_SPLIT, "nopin", ""},
 	{"get", (void_fn_t) & conference_api_sub_get, CONF_API_SUB_ARGS_SPLIT, "get", "<parameter-name>"},
 	{"set", (void_fn_t) & conference_api_sub_set, CONF_API_SUB_ARGS_SPLIT, "set", "<max_members|sound_prefix|caller_id_name|caller_id_number|endconference_grace_time> <value>"},
+	{"getvar", (void_fn_t) & conference_api_sub_getvar, CONF_API_SUB_ARGS_SPLIT, "getvar", "<conference-variable-name>"},
+	{"setvar", (void_fn_t) & conference_api_sub_setvar, CONF_API_SUB_ARGS_SPLIT, "setvar", "<name> <value>"},
 	{"file-vol", (void_fn_t) & conference_api_sub_file_vol, CONF_API_SUB_ARGS_SPLIT, "file-vol", "<vol#>"},
 	{"floor", (void_fn_t) & conference_api_sub_floor, CONF_API_SUB_MEMBER_TARGET, "floor", "<member_id|last>"},
 	{"vid-floor", (void_fn_t) & conference_api_sub_vid_floor, CONF_API_SUB_MEMBER_TARGET, "vid-floor", "<member_id|last> [force]"},
@@ -4070,7 +4072,33 @@ switch_status_t conference_api_sub_set(conference_obj_t *conference,
 	return ret_status;
 }
 
+switch_status_t conference_api_sub_getvar(conference_obj_t *conference,
+									   switch_stream_handle_t *stream, int argc, char **argv) {
+	int ret_status = SWITCH_STATUS_GENERR;
 
+	if (argc != 3 || zstr(argv[2])) {
+		ret_status = SWITCH_STATUS_FALSE;
+	} else {
+		ret_status = SWITCH_STATUS_SUCCESS;
+		stream->write_function(stream, "%s", conference_get_variable(conference, argv[2]));
+	}
+
+	return ret_status;
+}
+
+switch_status_t conference_api_sub_setvar(conference_obj_t *conference,
+									   switch_stream_handle_t *stream, int argc, char **argv) {
+	int ret_status = SWITCH_STATUS_GENERR;
+
+	if (argc != 4 || zstr(argv[2]) || zstr(argv[3])) {
+		ret_status = SWITCH_STATUS_FALSE;
+	} else {
+		ret_status = SWITCH_STATUS_SUCCESS;
+		conference_set_variable(conference, argv[2], switch_core_strdup(conference->pool, argv[3]));
+	}
+
+	return ret_status;
+}
 
 switch_status_t conference_api_sub_xml_list(conference_obj_t *conference, switch_stream_handle_t *stream, int argc, char **argv)
 {

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -2760,6 +2760,7 @@ conference_obj_t *conference_new(char *name, conference_xml_cfg_t cfg, switch_co
 	const char *force_rate = NULL, *force_interval = NULL, *force_channels = NULL, *presence_id = NULL, *force_canvas_size = NULL;
 	uint32_t force_rate_i = 0, force_interval_i = 0, force_channels_i = 0, video_auto_floor_msec = 0;
 	switch_event_t *event;
+	switch_event_header_t *eh = NULL;
 
 	int scale_h264_canvas_width = 0;
 	int scale_h264_canvas_height = 0;
@@ -3778,6 +3779,19 @@ conference_obj_t *conference_new(char *name, conference_xml_cfg_t cfg, switch_co
 				}
 			}
 		}
+	}
+
+	/* set conference variables from any channel variables which start with the conference variable prefix */
+	if ((eh = switch_channel_variable_first(channel))) {
+		for (; eh; eh = eh->next) {
+			const char *name = (char *) eh->name;
+			if (!strncasecmp(name, CONFERENCE_VARIABLE_PREFIX, strlen(CONFERENCE_VARIABLE_PREFIX))) {
+					const char *varname = name + strlen(CONFERENCE_VARIABLE_PREFIX);
+					char *value = (char *) eh->value;
+					conference_set_variable(conference, switch_core_strdup(conference->pool, varname), switch_core_strdup(conference->pool, value));
+			}
+		}
+		switch_channel_variable_last(channel);
 	}
 
 	switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, CONF_EVENT_MAINT);

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -57,6 +57,7 @@
 #define DEFAULT_LAYER_TIMEOUT 10
 #define DEFAULT_AGC_LEVEL 1100
 #define CONFERENCE_UUID_VARIABLE "conference_uuid"
+#define CONFERENCE_VARIABLE_PREFIX "conference_var_"
 
 /* Size to allocate for audio buffers */
 #define CONF_BUFFER_SIZE 1024 * 128
@@ -1222,11 +1223,13 @@ switch_status_t conference_api_sub_exit_sound(conference_obj_t *conference, swit
 switch_status_t conference_api_sub_vid_banner(conference_member_t *member, switch_stream_handle_t *stream, void *data);
 switch_status_t conference_api_sub_enter_sound(conference_obj_t *conference, switch_stream_handle_t *stream, int argc, char **argv);
 switch_status_t conference_api_sub_set(conference_obj_t *conference, switch_stream_handle_t *stream, int argc, char **argv);
+switch_status_t conference_api_sub_setvar(conference_obj_t *conference, switch_stream_handle_t *stream, int argc, char **argv);
 switch_status_t conference_api_sub_vid_res_id(conference_obj_t *conference, switch_stream_handle_t *stream, int argc, char **argv);
 switch_status_t conference_api_sub_vid_res_id_member(conference_member_t *member, switch_stream_handle_t *stream, char *res_id, int clear, int force);
 switch_status_t conference_api_sub_vid_role_id(conference_member_t *member, switch_stream_handle_t *stream, void *data);
 switch_status_t conference_api_sub_get_uuid(conference_member_t *member, switch_stream_handle_t *stream, void *data);
 switch_status_t conference_api_sub_get(conference_obj_t *conference, switch_stream_handle_t *stream, int argc, char **argv);
+switch_status_t conference_api_sub_getvar(conference_obj_t *conference, switch_stream_handle_t *stream, int argc, char **argv);
 switch_status_t conference_api_sub_vid_mute_img(conference_member_t *member, switch_stream_handle_t *stream, void *data);
 switch_status_t conference_api_sub_vid_codec_group(conference_member_t *member, switch_stream_handle_t *stream, void *data);
 switch_status_t conference_api_sub_vid_logo_img(conference_member_t *member, switch_stream_handle_t *stream, void *data);


### PR DESCRIPTION
The conference profiles already allow for setting conference level variables, but these are essentially read-only. This pull request adds two new API commands:

- `conference <name> servar <var-name> <var-value>`
- `conference <name> getvar <var-name>`

This enables read-write access to any existing conference level variables as defined in the profile and also allows setting new conference level variables on a specific conference instance once the conference is already in progress.

Additionally, a channel variable prefix `conference_var_` is defined and can be used to pre-set any conference level variables from the dial plan just prior to starting a conference. Everything which comes after the prefix will end up as a conference variable in the conference.

For example a channel variable `conference_var_My-Conference-Var=some data` will end up as a `My-Conference-Var: some data` conference level variable and will be sent like this in the conference ESL events.