### PR TITLE
Use SHA-256 for self-signed certificates

### DIFF
--- a/src/switch_core_cert.c
+++ b/src/switch_core_cert.c
@@ -474,7 +474,7 @@ static int mkcert(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int days
 	 */
 	X509_set_issuer_name(x, name);
 
-	if (!X509_sign(x, pk, EVP_sha1()))
+	if (!X509_sign(x, pk, EVP_sha256()))
 		goto err;
 
 	*x509p = x;


### PR DESCRIPTION
Partially fixes #1150 (but does not give users any flexibility)