### PR TITLE
fix function expand_vars bug

### DIFF
--- a/src/switch_xml.c
+++ b/src/switch_xml.c
@@ -1260,16 +1260,18 @@ static char *expand_vars(char *buf, char *ebuf, switch_size_t elen, switch_size_
 
 			if (e) {
 				rp += 3;
-				var = rp;
-				*e++ = '\0';
-				rp = e;
+				var = malloc(e - rp + 1);
+				memcpy(var, rp, e - rp);
+				var[e - rp] = 0;
+				rp = e + 1;
 				if ((val = switch_core_get_variable_dup(var))) {
 					char *p;
-					for (p = val; p && *p && wp <= ep; p++) {
+					for (p = val; p && *p && wp < ep; p++) {
 						*wp++ = *p;
 					}
 					free(val);
 				}
+				free(var);
 				continue;
 			} else if (err) {
 				*err = "unterminated ${var}";


### PR DESCRIPTION
switch_xml.c  function preprocess
line 1436
		while (!(bp = expand_vars(buf, ebuf, eblen, &cur, &err))) {
                        //expand_vars There is a bug, and the following code cannot be executed correctly 
			eblen *= 2;
			ebuf = switch_must_realloc(ebuf, eblen);
			memset(ebuf, 0, eblen);
		}




static char *expand_vars(char *buf, char *ebuf, switch_size_t elen, switch_size_t *newlen, const char **err)
{
	char *var, *val;
	char *rp = buf;
	char *wp = ebuf;
	char *ep = ebuf + elen - 1;

	if (!(var = strstr(rp, "$${"))) {
		*newlen = strlen(buf);
		return buf;
	}

	while (*rp && wp < ep) {

		if (*rp == '$' && *(rp + 1) == '$' && *(rp + 2) == '{') {
			char *e = switch_find_end_paren(rp + 2, '{', '}');

			if (e) {
				rp += 3;
				var = rp;
				*e++ = '\0';  // This is a bug changed buf  Changed buf 
				rp = e;
				if ((val = switch_core_get_variable_dup(var))) {
					char *p;
                                       //wp <= ep  This is also a bug they cannot be equal 
					for (p = val; p && *p && wp <= ep; p++) {
						*wp++ = *p;
					}
					free(val);
				}
				continue;
			} else if (err) {
				*err = "unterminated ${var}";
			}
		}

		*wp++ = *rp++;
	}

	if (wp == ep) {
		return NULL;
	}

	*wp++ = '\0';
	*newlen = strlen(ebuf);

	return ebuf;
}