### PR TITLE
fix originate arg handling error

### DIFF
--- a/src/mod/applications/mod_commands/mod_commands.c
+++ b/src/mod/applications/mod_commands/mod_commands.c
@@ -5077,7 +5077,7 @@ SWITCH_STANDARD_API(originate_function)
 		char *app_name = switch_core_session_strdup(caller_session, (exten + 1));
 		char *arg = NULL, *e;
 
-		if ((e = strchr(app_name, ')'))) {
+		if ((e = strrchr(app_name, ')'))) {
 			*e = '\0';
 		}
 


### PR DESCRIPTION
originate user/123 &bridge({testvar=${strftime(%Y-%m-%d)}}user/122)

2021-04-08 22:55:41.325139 [ERR] switch_core_session.c:2697 Invalid Application bridge({testvar=${strftime

after correction

EXECUTE [depth=0] sofia/internal/123@192.168.31.118:59930 bridge({testvar=2021-04-08}user/122)