### PR TITLE
[mod_distributor] Reload message should be same as others (+OK instead of +ok)

### DIFF
--- a/src/mod/applications/mod_distributor/mod_distributor.c
+++ b/src/mod/applications/mod_distributor/mod_distributor.c
@@ -403,7 +403,7 @@ SWITCH_STANDARD_API(distributor_ctl_function)
 	if (argc > 0) {
 		if (!strcasecmp(argv[0], "reload")) {
 			if (load_config(SWITCH_TRUE) == SWITCH_STATUS_SUCCESS) {
-				stream->write_function(stream, "+ok reloaded.\n");
+				stream->write_function(stream, "+OK reloaded.\n");
 				err = NULL;
 			}
 		} else if (!strcasecmp(argv[0], "dump")) {


### PR DESCRIPTION
PR for #1217 the reload message of distributor should be same as others 