### PR TITLE
[CORE] Parameterize Video Buffer size

### DIFF
--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -2393,6 +2393,8 @@ static void switch_load_core_config(const char *file)
 					}
 				} else if (!strcasecmp(var, "max-audio-channels") && !zstr(val)) {
 					switch_core_max_audio_channels(atoi(val));
+                                } else if (!strcasecmp(var, "video-jb-size-factor") && !zstr(val)) {
+                                        switch_core_set_variable("video_jb_size_factor",val);
 				}
 			}
 		}

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -89,6 +89,9 @@ static const switch_payload_t INVALID_PT = 255;
 								 * characters when sending, but an implementation MUST accept up to 256
 								 * characters when receiving." */
 
+#define MAX_VIDEO_BUFFER_SIZE_FACTOR 100
+#define MIN_VIDEO_BUFFER_SIZE_FACTOR 10
+
 static switch_port_t START_PORT = RTP_START_PORT;
 static switch_port_t END_PORT = RTP_END_PORT;
 static switch_mutex_t *port_lock = NULL;
@@ -4761,6 +4764,8 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_get_video_buffer_size(switch_rtp_t *r
 
 SWITCH_DECLARE(switch_status_t) switch_rtp_set_video_buffer_size(switch_rtp_t *rtp_session, uint32_t frames, uint32_t max_frames)
 {
+	char *vb_size_factor = switch_core_get_variable("video_jb_size_factor");
+
 	if (!switch_rtp_ready(rtp_session)) {
 		return SWITCH_STATUS_FALSE;
 	}
@@ -4770,7 +4775,13 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_set_video_buffer_size(switch_rtp_t *r
 	}
 
 	if (!max_frames || frames >= max_frames) {
-		max_frames = frames * 10;
+	    if (vb_size_factor && atoi(vb_size_factor) < MAX_VIDEO_BUFFER_SIZE_FACTOR+1 && atoi(vb_size_factor) > MIN_VIDEO_BUFFER_SIZE_FACTOR) {
+		max_frames = frames * atoi(vb_size_factor);
+	    }
+	    else {
+		max_frames = MIN_VIDEO_BUFFER_SIZE_FACTOR;
+	    }
+	    switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO, "JDK Set video buffer to %d\n", max_frames);
 	}
 
 	rtp_session->last_max_vb_frames = max_frames;


### PR DESCRIPTION
Video Buffer size (max_frames) is hardcoded to the value of 10, which leads to overflow the buffer quite quickly, especially for higher resolutions or harder to encoded video scenes (e.g. high motion ones).

With this change, video buffer size can be configured via video-jb-size-factor parameter in switch.conf within boundaries 10 - 100.