### PR TITLE
Security enhancement

### DIFF
--- a/src/mod/event_handlers/mod_event_socket/Makefile.am
+++ b/src/mod/event_handlers/mod_event_socket/Makefile.am
@@ -2,7 +2,7 @@ include $(top_srcdir)/build/modmake.rulesam
 MODNAME=mod_event_socket
 
 mod_LTLIBRARIES = mod_event_socket.la
-mod_event_socket_la_SOURCES  = mod_event_socket.c
+mod_event_socket_la_SOURCES  = mod_event_socket.c mod_event_socket_hash.c
 mod_event_socket_la_CFLAGS   = $(AM_CFLAGS)
 mod_event_socket_la_LIBADD   = $(switch_builddir)/libfreeswitch.la
 mod_event_socket_la_LDFLAGS  = -avoid-version -module -no-undefined -shared

--- a/src/mod/event_handlers/mod_event_socket/mod_event_socket.2017.vcxproj
+++ b/src/mod/event_handlers/mod_event_socket/mod_event_socket.2017.vcxproj
@@ -77,6 +77,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;Iphlpapi.lib;Winmm.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -92,6 +93,7 @@
       <DataExecutionPrevention>
       </DataExecutionPrevention>
       <TargetMachine>MachineX64</TargetMachine>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;Iphlpapi.lib;Winmm.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -103,6 +105,8 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;Iphlpapi.lib;Winmm.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -118,10 +122,13 @@
       <DataExecutionPrevention>
       </DataExecutionPrevention>
       <TargetMachine>MachineX64</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Ws2_32.lib;Iphlpapi.lib;Winmm.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="mod_event_socket.c" />
+    <ClCompile Include="mod_event_socket_hash.c" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\libs\win32\apr\libapr.2017.vcxproj">
@@ -132,6 +139,9 @@
       <Project>{202d7a4e-760d-4d0e-afa1-d7459ced30ff}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="mod_event_socket_hash.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/mod/event_handlers/mod_event_socket/mod_event_socket_hash.c
+++ b/src/mod/event_handlers/mod_event_socket/mod_event_socket_hash.c
@@ -1,0 +1,311 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ * Copyright (C) 2005-2014, Anthony Minessale II <anthm@freeswitch.org>
+ *
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * The Initial Developer of the Original Code is
+ * Anthony Minessale II <anthm@freeswitch.org>
+ * Portions created by the Initial Developer are Copyright (C)
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ * Paul Mateer <paul.mateer@jci.com>
+ *
+ *
+ * mod_event_socket_hash.c -- Authentication hashing for the Socket Controlled event handler
+ *
+ */
+#include <switch.h>
+#include <switch_utils.h>
+#include "mod_event_socket_hash.h"
+
+typedef struct {
+	wchar_t * alg;
+	char * salt;
+	char * hash;
+} auth_data_t;
+
+
+
+char *generate_salt() {
+	UINT random_factor = 0;
+	char salt_buffer[40];
+	char num_buffer[15];
+
+	salt_buffer[0] = '\0';	
+
+	while (strlen(salt_buffer) < 22)
+	{
+		if (SUCCEEDED(BCryptGenRandom(NULL, (BYTE*)&random_factor, sizeof(UINT), BCRYPT_USE_SYSTEM_PREFERRED_RNG))) {
+			sprintf_s(num_buffer, 15, "%u", random_factor);
+			strcat(salt_buffer, num_buffer);
+		}
+		else
+			return NULL;
+	}
+
+	return strdup(salt_buffer);
+}
+
+char *generate_hash(wchar_t* alg, char* salt, const char* password) {
+
+	unsigned char		b64_key[512];
+
+	b64_key[0] = '\0';
+
+	BCRYPT_ALG_HANDLE	alg_handle = NULL;
+	NTSTATUS			status = BCryptOpenAlgorithmProvider(&alg_handle, alg, NULL, 0);
+
+	if (SUCCEEDED(status)) 	{
+		DWORD data_size = 0;
+		DWORD hash_object_size = 0;
+
+		status = BCryptGetProperty(alg_handle, BCRYPT_OBJECT_LENGTH, (PBYTE)&hash_object_size, sizeof(DWORD), &data_size, 0);
+
+		if (SUCCEEDED(status)) {
+			//allocate the hash object on the heap
+			PBYTE pbHashObject = (PBYTE)HeapAlloc(GetProcessHeap(), 0, hash_object_size);
+
+			if (NULL != pbHashObject) {
+				DWORD hash_size = 0;
+
+				//calculate the length of the hash
+				status = BCryptGetProperty(alg_handle, BCRYPT_HASH_LENGTH, (PBYTE)&hash_size, sizeof(DWORD), &data_size, 0);
+
+				if (SUCCEEDED(status)) {
+
+					//allocate the hash buffer on the heap
+					PBYTE	hash = (PBYTE)HeapAlloc(GetProcessHeap(), 0, hash_size);
+
+					if (NULL != hash) {
+
+						BCRYPT_HASH_HANDLE	hash_handle = NULL;
+
+						status = BCryptCreateHash(alg_handle, &hash_handle, pbHashObject, hash_object_size, NULL, 0, 0);
+
+						if (SUCCEEDED(status)) {
+
+							size_t salted_data_len = strlen(salt) + strlen(password);
+							char* salted_data = malloc(salted_data_len + 1);
+
+							if (salted_data) {
+
+								strcpy_s(salted_data, salted_data_len + 1, salt);
+								strcat_s(salted_data, salted_data_len + 1, password);
+
+								status = BCryptHashData(hash_handle, (PBYTE)salted_data, (ULONG)salted_data_len, 0);
+
+								if (SUCCEEDED(status)) {
+
+									status = BCryptFinishHash(hash_handle, hash, hash_size, 0);
+
+									if (SUCCEEDED(status)) {
+										switch_b64_encode(hash, hash_size, b64_key, sizeof(b64_key));
+									}
+								}
+							}
+						}
+
+						HeapFree(GetProcessHeap(), 0, hash);
+					}
+				}
+
+				HeapFree(GetProcessHeap(), 0, pbHashObject);
+			}
+		}
+
+		BCryptCloseAlgorithmProvider(alg_handle, 0);
+	}
+
+	return strdup((const char *)b64_key);
+}
+
+void free_hash_data(auth_data_t** hash_data) {
+	if (hash_data)
+	{
+		if (*hash_data)
+		{
+			(*hash_data)->alg = NULL;
+			switch_safe_free((*hash_data)->salt);
+			switch_safe_free((*hash_data)->hash);
+			switch_safe_free(*hash_data);
+		}
+	}
+}
+
+auth_data_t* parse_hash(const char *auth_hash) {
+
+	auth_data_t* data = NULL;
+
+	if (auth_hash) {
+		const char *next = auth_hash;
+		uint16_t index = 0;
+		char *components[3];
+		size_t component_size = sizeof(components) / sizeof(char*);
+
+		memset(components, 0, sizeof(components));
+
+		do
+		{
+			const char *delim = strchr(next, '$');
+			if (delim == next)
+				next++;
+			else {
+				if (delim) {
+					size_t length = strlen(next) - strlen(delim);
+					char *component = malloc(length + 1);
+					if (component) {
+						strncpy(component, next, length);
+						component[length] = '\0';
+					}
+					else
+						break;
+					components[index++] = component;
+					next = delim++;
+				}
+				else {
+					components[index++] = strdup(next);
+					break;
+				}
+			}
+		} while (index < component_size);
+
+		if (component_size == index) {
+			wchar_t* alg = NULL;
+			if (strlen(components[0]) == 1)
+			{
+				switch (components[0][0]) {
+					case '1': {
+						alg = BCRYPT_MD5_ALGORITHM;
+						break;
+					}
+					case '5': {
+						alg = BCRYPT_SHA256_ALGORITHM;
+						break;
+					}
+					case '6': {
+						alg = BCRYPT_SHA512_ALGORITHM;
+						break;
+					}
+				}
+			}
+
+			if (alg) {
+				size_t b64_length = strlen(components[2]);
+
+				/* Account for any padding characters at the end of the string */
+				for (size_t idx = 0; idx < 2; idx++) {
+					if ('=' == components[2][b64_length - 1]) {
+						b64_length--;
+					}
+					else
+						break;
+				}
+
+				/* Confirm that the component contains only legitimate b64 characters */
+				switch_bool_t valid_b64 = SWITCH_TRUE;
+				for (size_t idx = 0; idx < b64_length; idx++) {
+					if (switch_isalnum(components[2][idx]))
+						continue;
+					switch (components[2][idx]) {
+					case '/':
+					case '+':
+						continue;
+					}
+
+					valid_b64 = SWITCH_FALSE;
+					break;
+				}
+
+				if (valid_b64) {
+					/* Create a authentication data structure to hold the details*/
+					data = malloc(sizeof(auth_data_t));
+
+					if (data)
+					{
+						switch_safe_free(components[0]);
+
+						data->alg = alg;
+						data->salt = strdup(components[1]);
+						data->hash = strdup(components[2]);
+					}
+				}
+			}
+		}
+
+		/* Free the memory allocated for the component array */
+		for (size_t idx = 0; idx < component_size; idx++)
+		{
+			switch_safe_free(components[0]);
+		}
+	}
+
+	return data;
+}
+
+switch_bool_t validate_hash(const char *auth_hash) {
+
+	auth_data_t* data = parse_hash(auth_hash);
+
+	if (data)
+	{
+		free_hash_data(&data);
+		return SWITCH_TRUE;
+	}
+	return SWITCH_FALSE;
+}
+
+switch_bool_t validate_password(const char *auth_hash, const char *password) {
+
+	switch_bool_t is_valid = SWITCH_FALSE;
+	auth_data_t* data = parse_hash(auth_hash);
+
+	if (data)
+	{
+		char *hash = generate_hash(data->alg, data->salt, password);
+
+		if ((hash) && (!strcmp(hash, data->hash)))
+		{
+			is_valid = SWITCH_TRUE;
+		}
+		switch_safe_free(hash);
+		free_hash_data(&data);
+	}
+	return is_valid;
+}
+
+const char * create_auth_hash(const char *password) {
+
+	char *auth_hash = NULL;
+	char *salt = generate_salt();
+
+	if (salt) {
+		char *hash = generate_hash(BCRYPT_SHA512_ALGORITHM, salt, password);
+
+		if (hash)
+		{
+			size_t auth_hash_len = 5 + strlen(salt) + strlen(hash);
+
+			auth_hash = malloc(auth_hash_len);
+			sprintf_s(auth_hash, auth_hash_len, "$6$%s$%s", salt, hash);
+		}
+
+		switch_safe_free(salt);
+	}
+
+	return auth_hash;
+}

--- a/src/mod/event_handlers/mod_event_socket/mod_event_socket_hash.h
+++ b/src/mod/event_handlers/mod_event_socket/mod_event_socket_hash.h
@@ -1,0 +1,41 @@
+/*
+* FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+* Copyright (C) 2005-2012, Anthony Minessale II <anthm@freeswitch.org>
+*
+* Version: MPL 1.1
+*
+* The contents of this file are subject to the Mozilla Public License Version
+* 1.1 (the "License"); you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+* http://www.mozilla.org/MPL/
+*
+* Software distributed under the License is distributed on an "AS IS" basis,
+* WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+* for the specific language governing rights and limitations under the
+* License.
+*
+* The Original Code is FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+*
+* The Initial Developer of the Original Code is
+* Anthony Minessale II <anthm@freeswitch.org>
+* Portions created by the Initial Developer are Copyright (C)
+* the Initial Developer. All Rights Reserved.
+*
+* Based on mod_skel by
+* Anthony Minessale II <anthm@freeswitch.org>
+*
+* Contributor(s):
+*
+* Paul Mateer <paul.mateer@jci.com>
+*
+* mod_event_socket_hash.c -- Performs authentication hashing for the event socket
+*
+*/
+#ifndef MOD_EVENT_SOCKET_HASH_H
+#define MOD_EVENT_SOCKET_HASH_H
+
+switch_bool_t validate_hash(const char *auth_hash);
+switch_bool_t validate_password(const char *auth_hash, const char *password);
+const char *create_auth_hash(const char * password);
+
+#endif /* MOD_EVENT_SOCKET_HASH_H */


### PR DESCRIPTION
Modifications to resolve issue #694

Amended the event socket code to allow for a configuration entry called authentication-hash which takes a value of the form:

$algId$salt$hash

where algId is the id of the hashing algorithm used, as follows:

MD5 has an algId of 1
SHA-256 has an algId of 5
SHA-512 has an algId of 6

hash is the hash value generated when the specified hashing algorithm is applied to an input value which consists of the password to use prepended with the salt value specified.

The code will still support the presence of a plain text password entry, but will prefer any authentication-hash provided. Appropriate logging messages will be issued if:

1) Only a password entry can be located in the config
2) Both password and authentication-hash entries are present in the config.

The module has also been modified to NOT LISTEN on the specified port and to issue a Critical logging message if no authentication data can be established (i.e. the module will not fall-back to a default password)