### PR TITLE
[mod_opusfile] add opc_encoder_drain before destroying handle

### DIFF
--- a/src/mod/formats/mod_opusfile/mod_opusfile.c
+++ b/src/mod/formats/mod_opusfile/mod_opusfile.c
@@ -316,6 +316,7 @@ static switch_status_t switch_opusfile_close(switch_file_handle_t *handle)
 	}
 #ifdef HAVE_OPUSFILE_ENCODE
 	if (context->enc) {
+		ope_encoder_drain(context->enc);
 		ope_encoder_destroy(context->enc);
 	}
 	if (context->comments) {


### PR DESCRIPTION
not draining before destroying encoder causes loss at the end of the encoded file