### PR TITLE
[freetdm] Fix stack overflow in ftmod_analog

### DIFF
--- a/libs/freetdm/src/ftmod/ftmod_analog/ftmod_analog.c
+++ b/libs/freetdm/src/ftmod/ftmod_analog/ftmod_analog.c
@@ -481,7 +481,7 @@ static void *ftdm_analog_channel_run(ftdm_thread_t *me, void *obj)
 		ftdm_wait_flag_t flags = FTDM_READ;
 		ftdm_size_t dlen = 0;
 		
-		len = sizeof(frame);
+		len = sizeof(frame) / 2;
 		
 		elapsed += interval;
 		state_counter += interval;


### PR DESCRIPTION
I was encountering intermittent FreeSWITCH crashes while using FreeTDM with an AEX410 card. A handset off-hook would randomly trigger the crash. After rebuilding with address sanitizer, I tracked the crash to an out of bounds write to the `frame` variable in ftmod_analog. Codec conversion buffers are limited to 1,024 bytes, so initial `len` was adjusted to half of `frame` size to accommodate later `len` doubling for the conversion code paths.

In _ftdm_analog_channel_run_:
```
uint8_t frame[1024];

<snip>

len = sizeof(frame);

<snip>

if (ftdmchan->effective_codec != FTDM_CODEC_SLIN) {
  len *= 2;
}

rlen = ftdm_buffer_read_loop(dt_buffer, frame, len);
```

Here's the output from ASan before modification:
```
==33==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fd4206dbc50 at pc 0x7fd42a3b8e6f bp 0x7fd4206d6ad0 sp 0x7fd4206d6278                                                                                                                        [29/1715]
WRITE of size 2048 at 0x7fd4206dbc50 thread T205                                                                                                                                                                                                                        
    #0 0x7fd42a3b8e6e in __interceptor_memcpy /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827                                                                                                                                    
    #1 0x7fd421a05d51 in ftdm_buffer_read src/ftdm_buffer.c:196                                                                                                                                                                                                         
    #2 0x7fd421a05a4c in ftdm_buffer_read_loop src/ftdm_buffer.c:167                                                                                                                                                                                                    
    #3 0x7fd42190ad7e in ftdm_analog_channel_run src/ftmod/ftmod_analog/ftmod_analog.c:929                                                                                                                                                                              
    #4 0x7fd421a06882 in thread_launch src/ftdm_threadmutex.c:117                                                                                                                                                                                                       
    #5 0x7fd428dff258 in start_thread (/usr/lib/libpthread.so.0+0x9258)                                                                                                                                                                                                 
    #6 0x7fd4289b95e2 in __GI___clone (/usr/lib/libc.so.6+0xfe5e2)                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                        
Address 0x7fd4206dbc50 is located in stack of thread T205 at offset 20608 in frame                                                                                                                                                                                      
    #0 0x7fd421902bbe in ftdm_analog_channel_run src/ftmod/ftmod_analog/ftmod_analog.c:421                                                                                                                                                                              
                                                                                                                                                                                                                                                                        
  This frame has 16 object(s):                                                                                                                                                                                                                                          
    [32, 36) 'tt' (line 427)                                                                                                                                                                                                                                            
    [48, 52) 'state_counter' (line 432)                                                                                                                                                                                                                                 
    [64, 68) 'interval' (line 432)                                                                                                                                                                                                                                      
    [80, 84) 'dial_timeout' (line 432)                                                                                                                                                                                                                                  
    [96, 100) 'flags' (line 481)                                                                                                                                                                                                                                        
    [112, 116) 'polarity' (line 679)                                                                                                                                                                                                                                    
    [128, 132) 'polarity' (line 722)                                                                                                                                                                                                                                    
    [144, 152) 'ftdmchan' (line 422)                                                                                                                                                                                                                                    
    [176, 184) 'dt_buffer' (line 423)                                                                                                                                                                                                                                   
    [208, 216) 'len' (line 426)                                                                                                                                                                                                                                         
    [240, 248) 'rlen' (line 426)                                                                                                                                                                                                                                        
    [272, 400) 'sig' (line 434)                                                                                                                                                                                                                                         
    [432, 560) 'sig' (line 763)                                                                                                                                                                                                                                         
    [592, 18984) 'ts' (line 424)                                                                                                                                                                                                                                        
    [19248, 19505) 'dtmf' (line 428)                                                                                                                                                                                                                                    
    [19584, 20608) 'frame' (line 425) <== Memory access at offset 20608 overflows this variable                                                                                                                                                                         
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork                  
      (longjmp and C++ exceptions *are* supported)
Thread T205 created by T20 here:                                                                                                  
    #0 0x7fd42a3d7fa7 in __interceptor_pthread_create /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:216
    #1 0x7fd421a06b2f in ftdm_thread_create_detached_ex src/ftdm_threadmutex.c:161                                                     
    #2 0x7fd421a06945 in ftdm_thread_create_detached src/ftdm_threadmutex.c:128                                                        
    #3 0x7fd42190d043 in process_event src/ftmod/ftmod_analog/ftmod_analog.c:1109                                   
    #4 0x7fd42190ea01 in ftdm_analog_run src/ftmod/ftmod_analog/ftmod_analog.c:1231
    #5 0x7fd421a06882 in thread_launch src/ftdm_threadmutex.c:117              
    #6 0x7fd428dff258 in start_thread (/usr/lib/libpthread.so.0+0x9258)          
                                                                                                                                  
Thread T20 created by T0 here:                                                                                                    
    #0 0x7fd42a3d7fa7 in __interceptor_pthread_create /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:216
    #1 0x7fd421a06b2f in ftdm_thread_create_detached_ex src/ftdm_threadmutex.c:161                                                     
    #2 0x7fd421a06945 in ftdm_thread_create_detached src/ftdm_threadmutex.c:128                                                     
    #3 0x7fd4218ffedf in ftdm_analog_start src/ftmod/ftmod_analog/ftmod_analog.c:147                                                
    #4 0x7fd4219e1c82 in ftdm_span_start src/ftdm_io.c:5900       
    #5 0x7fd421a784a0 in load_config /home/chris/freeswitch/src/mod/../../libs/freetdm/mod_freetdm/mod_freetdm.c:3847               
    #6 0x7fd421a855a7 in mod_freetdm_load /home/chris/freeswitch/src/mod/../../libs/freetdm/mod_freetdm/mod_freetdm.c:5650          
    #7 0x7fd4297e9940 in switch_loadable_module_load_file src/switch_loadable_module.c:1751                                         
    #8 0x7fd4297ea48b in switch_loadable_module_load_module_ex src/switch_loadable_module.c:1858                                    
    #9 0x7fd4297ec94c in switch_loadable_module_init src/switch_loadable_module.c:2287                                              
    #10 0x7fd429726b0a in switch_core_init_and_modload src/switch_core.c:2484                                                       
    #11 0x564bb9231485 in main src/switch.c:1200                  
    #12 0x7fd4288e2b24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)                                                            

SUMMARY: AddressSanitizer: stack-buffer-overflow /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827 in __interceptor_memcpy
Shadow bytes around the buggy address:                                                                                                                                                                                                                                  
  0x0ffb040d3730: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                                                                                                                                                       
  0x0ffb040d3740: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                 
  0x0ffb040d3750: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ffb040d3760: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                 
  0x0ffb040d3770: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                 
=>0x0ffb040d3780: 00 00 00 00 00 00 00 00 00 00[f3]f3 f3 f3 f3 f3                                                                      
  0x0ffb040d3790: f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 00 00 00 00 00 00                                                                      
  0x0ffb040d37a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                 
  0x0ffb040d37b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                 
  0x0ffb040d37c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                 
  0x0ffb040d37d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                                                 
Shadow byte legend (one shadow byte represents 8 application bytes):                                                              
  Addressable:           00                                                                                                       
  Partially addressable: 01 02 03 04 05 06 07                                                                                     
  Heap left redzone:       fa                                                                                                          
  Freed heap region:       fd                                                                                                       
  Stack left redzone:      f1                                                                                                       
  Stack mid redzone:       f2                                     
  Stack right redzone:     f3                                                                                                       
  Stack after return:      f5                                                                                                       
  Stack use after scope:   f8                                                                                                       
  Global redzone:          f9                                                                                                       
  Global init order:       f6                                                                                                       
  Poisoned by user:        f7                                                                                                       
  Container overflow:      fc                                     
  Array cookie:            ac                                                                                                       
  Intra object redzone:    bb                                     
  ASan internal:           fe                                                                                                                                                                                                                                           
  Left alloca redzone:     ca                                     
  Right alloca redzone:    cb                                     
  Shadow gap:              cc                                     
==33==ABORTING
```