### PR TITLE
Reducing Read RTP function blocking timeout from 5 seconds to 200ms. …

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -7244,7 +7244,7 @@ static int rtp_common_read(switch_rtp_t *rtp_session, switch_payload_t *payload_
 	int check = 0;
 	int ret = -1;
 	int sleep_mss = 1000;
-	int poll_sec = 5;
+	int poll_msec = 200;
 	int poll_loop = 0;
 	int fdr = 0;
 	int rtcp_fdr = 0;
@@ -7413,7 +7413,7 @@ static int rtp_common_read(switch_rtp_t *rtp_session, switch_payload_t *payload_
 		}
 
 		if (!rtp_session->flags[SWITCH_RTP_FLAG_USE_TIMER] && rtp_session->read_pollfd) {
-			int pt = poll_sec * 1000000;
+			int pt = poll_msec * 1000;
 
 			do_2833(rtp_session);
 
@@ -7537,7 +7537,7 @@ static int rtp_common_read(switch_rtp_t *rtp_session, switch_payload_t *payload_
 			}
 
 			if (!rtp_session->flags[SWITCH_RTP_FLAG_UDPTL] && !rtp_session->flags[SWITCH_RTP_FLAG_VIDEO]) {
-				rtp_session->missed_count += (poll_sec * 1000) / (rtp_session->ms_per_packet ? rtp_session->ms_per_packet / 1000 : 20);
+				rtp_session->missed_count += (poll_msec) / (rtp_session->ms_per_packet ? rtp_session->ms_per_packet / 1000 : 20);
 				bytes = 0;
 
 				if (rtp_session->media_timeout && rtp_session->last_media) {


### PR DESCRIPTION
Read RTP function blocking timeout is 5 seconds which can block SIP BYE process for 5 seconds which means the caller SIP phone may have to re-transmit SIP BYE with SIP timer. 

Changing to 200ms would help to reduce the rate of re-transmission. This would mean that SIP phone's SIP BYE will not be delayed as seen in https://github.com/signalwire/freeswitch/issues/1268
