### PR TITLE
[mod_http_cache] Fix the query string not included for HTTP PUT requests to s3

### DIFF
--- a/src/mod/applications/mod_http_cache/aws.c
+++ b/src/mod/applications/mod_http_cache/aws.c
@@ -47,7 +47,7 @@
  */
 static char *hmac256(char* buffer, unsigned int buffer_length, const char* key, unsigned int key_length, const char* message)
 {
-	if (zstr(key) || zstr(message) || buffer_length < SHA256_DIGEST_LENGTH) {
+	if (!key || zstr(message) || buffer_length < SHA256_DIGEST_LENGTH) {
 		return NULL;
 	}
 


### PR DESCRIPTION
Addresses https://github.com/signalwire/freeswitch/issues/1280

In certain random but valid conditions (  date and aws key dependent )  we found scenarios where the call to `zstr(key)`  would return true and thus result in empty querystring in our AWS S3 puts.

Here is a sample portion of the evidence ( note that the logging of key_bytes ) was our own interim troubleshooting.  Note the `00` 

```
2021-07-23 19:37:09.126912 [INFO] aws.c:52 key_bytes: 
2021-07-23 19:37:09.126912 [INFO] aws.c:52 00
2021-07-23 19:37:09.126912 [INFO] aws.c:52 3f
```
