### PR TITLE
[libvpx] configure.sh handle new macOS numbering starting with 11.5.1

### DIFF
--- a/libs/libvpx/build/make/configure.sh
+++ b/libs/libvpx/build/make/configure.sh
@@ -865,7 +865,12 @@ process_common_toolchain() {
   case ${toolchain} in
     *-darwin-*)
       mvmin=$(sw_vers -productVersion)
-      mvmin="-mmacosx-version-min="${mvmin%.*}
+      if [[ $mvmin == 10.* ]]; then
+        mvmin="${mvmin%.*}"
+      else
+        mvmin="${mvmin%%.*}"
+      fi
+      mvmin="-mmacosx-version-min=""$mvmin"
       add_cflags  $mvmin
       add_ldflags $mvmin
       ;;


### PR DESCRIPTION
Fixes #1286, see that for more detail. macOS for the first time added modification level for security patches starting with 11.5.1. That causes erroneous warning messages during libvpx make. This affects only macOS libvpx to use different logic for macOS 10 than later versions. Tested on 10.14 Mojave, 10.15 Catalina, and 11 Big Sur.