### PR TITLE
vanilla conf remove unused param

### DIFF
--- a/conf/vanilla/sip_profiles/internal.xml
+++ b/conf/vanilla/sip_profiles/internal.xml
@@ -413,13 +413,6 @@
     <!-- Turn on a jitterbuffer for every call -->
     <!-- <param name="auto-jitterbuffer-msec" value="60"/> -->
 
-
-    <!-- By default mod_sofia will ignore the codecs in the sdp for hold/unhold operations
-         Set this to true if you want to actually parse the sdp and re-negotiate the codec during hold/unhold.
-         It's probably not what you want so stick with the default unless you really need to change this.
-    -->
-    <!--<param name="renegotiate-codec-on-hold" value="true"/>-->
-
     <!-- By default mod_sofia will send "100 Trying" in response to a SIP INVITE. Set this to false if
          you want to turn off this behavior and manually send the "100 Trying" via the acknowledge_call application.
     -->


### PR DESCRIPTION
This param was removed in https://github.com/signalwire/freeswitch/commit/2e3227b50f897ab7471b09979ba25b6ca0ff5887