### PR TITLE
Assignment of User in CentOS systemd unit file

### DIFF
--- a/build/freeswitch.service
+++ b/build/freeswitch.service
@@ -6,11 +6,12 @@ After=postgresql.service postgresql-9.3.service postgresql-9.4.service mysqld.se
 [Service]
 EnvironmentFile=-/etc/sysconfig/freeswitch
 Environment="USER=freeswitch"
+Environment="GROUP=freeswitch"
 # RuntimeDirectory is not yet supported in CentOS 7. A workaround is to use /etc/tmpfiles.d/freeswitch.conf
 #RuntimeDirectory=/run/freeswitch
 #RuntimeDirectoryMode=0750
 WorkingDirectory=/run/freeswitch
-ExecStart=/usr/bin/freeswitch -nc -nf -u ${USER} $FREESWITCH_PARAMS
+ExecStart=/usr/bin/freeswitch -nc -nf -u ${USER} -g ${GROUP} $FREESWITCH_PARAMS
 ExecReload=/usr/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
Fix signalwire/freeswitch#758


It has been stated by Freeswitch developers in multiple places that rather than starting Freeswitch with a non-root user, it should be started as root, and passed a user with lower permissions as a parameter. Functionally, this is doing this:

`sudo freeswitch -u freeswitch_user`

Instead of:

`sudo -u freeswitch_user freeswitch`

The problem is that the systemd unit file for the service sets the user as it's parameter, rather than a parameter passed to freeswitch.

This PR addresses this by using the same logic that is used in the Debian systemd unit file for setting the user. There may be some other beneficial things to be gained from using even more of the Debian systemd unit file, but for now this commit is very short and to the point.