### PR TITLE
[mod_verto] fix websocket PING

### DIFF
--- a/src/mod/endpoints/mod_verto/ws.c
+++ b/src/mod/endpoints/mod_verto/ws.c
@@ -981,7 +981,8 @@ ssize_t ws_read_frame(wsh_t *wsh, ws_opcode_t *oc, uint8_t **data)
 
 			if (*oc == WSOC_PING) {
 				ws_write_frame(wsh, WSOC_PONG, wsh->body, wsh->rplen);
-				goto again;
+				// goto again;
+				return 0;
 			}
 
 			*(wsh->body+wsh->rplen) = '\0';


### PR DESCRIPTION
when a ping packet is received, it `goto again` then blocks reading and expects new packets, but when the other side only sends ping in certain intervals, the reading is blocked until it receives new packets, it will block write, e.g. subscribered events cannot been delivered before the other side send any real data packets.

