### PR TITLE
allow smaller size for ECDSA certs

### DIFF
--- a/src/include/switch_ssl.h
+++ b/src/include/switch_ssl.h
@@ -47,6 +47,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/bio.h>
+#include <crypto/evp/evp.h>
 
 SWITCH_DECLARE(int) switch_core_cert_extract_fingerprint(X509* x509, dtls_fingerprint_t *fp);
 

--- a/src/include/switch_ssl.h
+++ b/src/include/switch_ssl.h
@@ -47,7 +47,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/bio.h>
-#include <crypto/evp/evp.h>
+#include <openssl/evp.h>
 
 SWITCH_DECLARE(int) switch_core_cert_extract_fingerprint(X509* x509, dtls_fingerprint_t *fp);
 

--- a/src/switch_core_cert.c
+++ b/src/switch_core_cert.c
@@ -365,7 +365,8 @@ SWITCH_DECLARE(switch_bool_t) switch_core_check_dtls_pem(const char *file)
 	}
 
 	bits = EVP_PKEY_bits(pkey);
-	min_cert_size_bits = EVP_PKEY_EC == pkey->type ? 256 : 4096;
+	min_cert_size_bits = EVP_PKEY_EC == EVP_PKEY_id(pkey) ? 256 : 4096;
+
 	EVP_PKEY_free(pkey);
 
 	if (bits < min_cert_size_bits) {

--- a/src/switch_core_cert.c
+++ b/src/switch_core_cert.c
@@ -336,6 +336,7 @@ SWITCH_DECLARE(switch_bool_t) switch_core_check_dtls_pem(const char *file)
 	FILE *fp = NULL;
 	EVP_PKEY *pkey = NULL;
 	int bits = 0;
+	int min_cert_size_bits = 0;
 
 	if (switch_is_file_path(file)) {
 		pem = strdup(file);
@@ -364,10 +365,12 @@ SWITCH_DECLARE(switch_bool_t) switch_core_check_dtls_pem(const char *file)
 	}
 
 	bits = EVP_PKEY_bits(pkey);
+	min_cert_size_bits = EVP_PKEY_EC == pkey->type ? 256 : 4096;
 	EVP_PKEY_free(pkey);
 
-	if (bits < 4096) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "%s cryptographic length is too short (%d), it will be regenerated\n", pem, bits);
+	if (bits < min_cert_size_bits) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "%s cryptographic length is too short (%d, < %d), it will be regenerated\n",
+			pem, bits, min_cert_size_bits);
 		goto rename_pem;
 	}
 


### PR DESCRIPTION
ECDSA certificates come with much smaller keys compared to RSA.  256 bits versus 4096, for example.  FS code currently checks for minimum key length of 4096 regardless of type, which effectively precludes use of ECDSA.  This patch checks the certificate type and sets a lower limit as needed.