### PR TITLE
Update base image for Dockerfile unstable to Buster as dependency libmariadb3 fails otherwise closes #1364 and #154

### DIFF
--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -1,5 +1,6 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie
+FROM debian:buster
+ENV DEBIAN_VERSION buster
 
 # Source Dockerfile:
 # https://github.com/docker-library/postgres/blob/master/9.4/Dockerfile
@@ -9,7 +10,7 @@ RUN groupadd -r freeswitch --gid=999 && useradd -r -g freeswitch --uid=999 frees
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y gpg && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
     && gpg --verify /usr/local/bin/gosu.asc \
@@ -22,17 +23,17 @@ RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* 
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
-# https://files.freeswitch.org/repo/deb/freeswitch-1.*/dists/jessie/main/binary-amd64/Packages
+# https://files.freeswitch.org/repo/deb/freeswitch-1.*/dists/buster/main/binary-amd64/Packages
 
 ENV FS_MAJOR debian-unstable
 
-RUN sed -i "s/jessie main/jessie main contrib non-free/" /etc/apt/sources.list
+RUN sed -i "s/${DEBIAN_VERSION} main/${DEBIAN_VERSION} main contrib non-free/" /etc/apt/sources.list
 
-# https://freeswitch.org/confluence/display/FREESWITCH/Debian+8+Jessie#Debian8Jessie-InstallingfromDebianpackages
+# https://freeswitch.org/confluence/display/FREESWITCH/Debian+10+Buster
 
 RUN apt-get update && apt-get install -y curl \
     && curl https://files.freeswitch.org/repo/deb/debian/freeswitch_archive_g0.pub | apt-key add - \
-    && echo "deb http://files.freeswitch.org/repo/deb/$FS_MAJOR/ jessie main" > /etc/apt/sources.list.d/freeswitch.list \
+    && echo "deb http://files.freeswitch.org/repo/deb/$FS_MAJOR/ ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/freeswitch.list \
     && apt-get purge -y --auto-remove curl
 
 RUN apt-get update && apt-get install -y freeswitch-all \


### PR DESCRIPTION
This updates the Dockerfile base image to buster from jessie.  I also moved the debian version to a ENV variable to make future updates a bit cleaner.  It is likely this has not built since mid 2019 when the libmariadb3 dep was added. NOTE this will still not build until request #1363 is merged.

Install GPG as well as no longer included by default, if we want to use --no-install-recommends will need to manually include some additional packages to get gpg to work for what we use it for.

Fixes #1364 and Fixes #154