### PR TITLE
Avoid setting the SHELL command on Dockerfiles

### DIFF
--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -66,7 +66,6 @@ VOLUME ["/tmp"]
 COPY    build/freeswitch.limits.conf /etc/security/limits.d/
 
 # Healthcheck to make sure the service is running
-SHELL       ["/bin/bash"]
 HEALTHCHECK --interval=15s --timeout=5s \
     CMD  fs_cli -x status | grep -q ^UP || exit 1
 

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -64,7 +64,6 @@ VOLUME ["/tmp"]
 COPY    build/freeswitch.limits.conf /etc/security/limits.d/
 
 # Healthcheck to make sure the service is running
-SHELL       ["/bin/bash"]
 HEALTHCHECK --interval=15s --timeout=5s \
     CMD  fs_cli -x status | grep -q ^UP || exit 1
 


### PR DESCRIPTION
Not needed and this breaks any commands after it right now (as wrong format as well) fixes #1366 which has more details in it.    if there is a reason (that I cannot see) for doing so, we need to at least modify the command.

Note this won't actually fully build until #1365 and #1363 are merged (at least for unstable/master).