### PR TITLE
[mod_callcenter] Add 'CC-Member-Joined-Time' header to 'agent-offering' event

### DIFF
--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -1729,6 +1729,7 @@ static void *SWITCH_THREAD_FUNC outbound_agent_thread_run(switch_thread_t *threa
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "CC-Member-CID-Name", h->member_cid_name);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "CC-Member-CID-Number", h->member_cid_number);
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "CC-Member-DNIS", member_dnis);
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "CC-Member-Joined-Time", "%" SWITCH_TIME_T_FMT, t_member_called);
 		switch_event_fire(&event);
 	}
 


### PR DESCRIPTION
Due to timing issues, 'agent-offering' event can be received before 'member-queue-start' by external systems integrating with mod_callcenter via events.
This aids implementation of such external integrations by simply providing 'CC-Member-Joined-Time' in 'agent-offer' to remove the need to match the two events in such cases.

I am not aware of any restrictions to what data may be included in these events. Please tell me if there's anything we've missed.