### PR TITLE
[mod_sofia] Fix profile name when update sip registration

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_reg.c
+++ b/src/mod/endpoints/mod_sofia/sofia_reg.c
@@ -2021,11 +2021,13 @@ uint8_t sofia_reg_handle_register_token(nua_t *nua, sofia_profile_t *profile, nu
 								 "sub_host='%q', network_ip='%q',network_port='%q',"
 								 "presence_hosts='%q', server_host='%q', orig_server_host='%q',"
 								 "hostname='%q', orig_hostname='%q',"
+								 "profile_name='%q',"
 								 "expires = %ld, ping_expires=%ld, force_ping=%d "
 								 "where sip_user='%q' and sip_username='%q' and sip_host='%q' and contact='%q'",
 								 call_id, sub_host, network_ip, network_port_c,
 								 profile->presence_hosts ? profile->presence_hosts : "", guess_ip4, guess_ip4,
                                                                  mod_sofia_globals.hostname, mod_sofia_globals.hostname,
+                                                                profile->name,
 								 (long) reg_time + (long) exptime + profile->sip_expires_late_margin,
 								 (long) switch_epoch_time_now(NULL) + sofia_reg_uniform_distribution(profile->iping_seconds),
 								 force_ping, to_user, username, reg_host, contact_str);


### PR DESCRIPTION
When registering the same phone into a different profile and multiple-registrations enabled, sofia_contact returns the wrong contact with the old profile.
This commit fixes that. 
