### PR TITLE
[mod_sofia] Remove redundant sip_from->a_url checks

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -10661,7 +10661,7 @@ void sofia_handle_sip_i_invite(switch_core_session_t *session, nua_t *nua, sofia
 		}
 	}
 
-	if (sip->sip_from && sip->sip_from->a_url) {
+	if (sip->sip_from) {
 		tech_pvt->from_user = switch_core_session_strdup(session, sip->sip_from->a_url->url_user);
 	}
 	tech_pvt->mparams.remote_ip = switch_core_session_strdup(session, network_ip);
@@ -11236,7 +11236,7 @@ void sofia_handle_sip_i_invite(switch_core_session_t *session, nua_t *nua, sofia
 
 	if (profile->pres_type) {
 		const char *presence_id = switch_channel_get_variable(channel, "presence_id");
-		if (zstr(presence_id) && sip->sip_from && sip->sip_from->a_url) {
+		if (zstr(presence_id) && sip->sip_from) {
 			const char *user = switch_str_nil(sip->sip_from->a_url->url_user);
 			const char *host = switch_str_nil(sip->sip_from->a_url->url_host);
 			char *tmp = switch_mprintf("%s@%s", user, host);


### PR DESCRIPTION
A recent commit added some tests to src/mod/endpoints/mod_sofia/sofia.c which cause build errors on OpenBSD:

> sofia.c:10664:38: error: address of array 'sip->sip_from->a_url' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]
        if (sip->sip_from && sip->sip_from->a_url) {
                          ~~ ~~~~~~~~~~~~~~~^~~~~
sofia.c:11239:60: error: address of array 'sip->sip_from->a_url' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]
                if (zstr(presence_id) && sip->sip_from && sip->sip_from->a_url)
{
                                                       ~~ ~~~~~~~~~~~~~~~^~~~~
2 errors generated.


The proposed diff leaves the sip->sip_from tests but removes the sip->sip_from->a_url tests.