### PR TITLE
[mod_gsmopen] Use TIME_T_FMT

### DIFF
--- a/src/mod/endpoints/mod_gsmopen/gsmopen_protocol.cpp
+++ b/src/mod/endpoints/mod_gsmopen/gsmopen_protocol.cpp
@@ -853,7 +853,7 @@ int gsmopen_serial_read_AT(private_t *tech_pvt, int look_for_ack, int timeout_us
 
 				if (tech_pvt->interface_state != GSMOPEN_STATE_RING) {
 					gettimeofday(&(tech_pvt->call_incoming_time), NULL);
-					DEBUGA_GSMOPEN("GSMOPEN_STATE_RING call_incoming_time.tv_sec=%ld\n", GSMOPEN_P_LOG, tech_pvt->call_incoming_time.tv_sec);
+					DEBUGA_GSMOPEN("GSMOPEN_STATE_RING call_incoming_time.tv_sec=%" TIME_T_FMT "\n", GSMOPEN_P_LOG, tech_pvt->call_incoming_time.tv_sec);
 
 				}
 
@@ -1177,7 +1177,7 @@ int gsmopen_serial_read_AT(private_t *tech_pvt, int look_for_ack, int timeout_us
 					//mark the time of CALLFLOW_CALL_INCOMING
 					gettimeofday(&(tech_pvt->call_incoming_time), NULL);
 					tech_pvt->phone_callflow = CALLFLOW_CALL_INCOMING;
-					DEBUGA_GSMOPEN("CALLFLOW_CALL_INCOMING call_incoming_time.tv_sec=%ld\n", GSMOPEN_P_LOG, tech_pvt->call_incoming_time.tv_sec);
+					DEBUGA_GSMOPEN("CALLFLOW_CALL_INCOMING call_incoming_time.tv_sec=%" TIME_T_FMT "\n", GSMOPEN_P_LOG, tech_pvt->call_incoming_time.tv_sec);
 
 				}
 			}
@@ -1946,14 +1946,14 @@ int gsmopen_serial_read_AT(private_t *tech_pvt, int look_for_ack, int timeout_us
 		gettimeofday(&call_incoming_timeout, NULL);
 		call_incoming_timeout.tv_sec -= 3;
 		DEBUGA_GSMOPEN
-			("CALLFLOW_CALL_INCOMING call_incoming_time.tv_sec=%ld, call_incoming_timeout.tv_sec=%ld\n",
+			("CALLFLOW_CALL_INCOMING call_incoming_time.tv_sec=%" TIME_T_FMT ", call_incoming_timeout.tv_sec=%" TIME_T_FMT "\n",
 			 GSMOPEN_P_LOG, tech_pvt->call_incoming_time.tv_sec, call_incoming_timeout.tv_sec);
 		if (call_incoming_timeout.tv_sec > tech_pvt->call_incoming_time.tv_sec) {
 
 			tech_pvt->call_incoming_time.tv_sec = 0;
 			tech_pvt->call_incoming_time.tv_usec = 0;
 			DEBUGA_GSMOPEN
-				("CALLFLOW_CALL_INCOMING call_incoming_time.tv_sec=%ld, call_incoming_timeout.tv_sec=%ld\n",
+				("CALLFLOW_CALL_INCOMING call_incoming_time.tv_sec=%" TIME_T_FMT ", call_incoming_timeout.tv_sec=%" TIME_T_FMT "\n",
 				 GSMOPEN_P_LOG, tech_pvt->call_incoming_time.tv_sec, call_incoming_timeout.tv_sec);
 			int res = gsmopen_serial_write_AT_ack(tech_pvt, "AT+CPBS=RC");
 			if (res) {
@@ -1983,7 +1983,7 @@ int gsmopen_serial_read_AT(private_t *tech_pvt, int look_for_ack, int timeout_us
 		if (call_incoming_timeout.tv_sec > tech_pvt->ringtime.tv_sec) {
 			ERRORA("Ringing stopped and I have not answered. Why?\n", GSMOPEN_P_LOG);
 			DEBUGA_GSMOPEN
-				("CALLFLOW_CALL_INCOMING call_incoming_time.tv_sec=%ld, call_incoming_timeout.tv_sec=%ld\n",
+				("CALLFLOW_CALL_INCOMING call_incoming_time.tv_sec=%" TIME_T_FMT ", call_incoming_timeout.tv_sec=%" TIME_T_FMT "\n",
 				 GSMOPEN_P_LOG, tech_pvt->call_incoming_time.tv_sec, call_incoming_timeout.tv_sec);
 			if (tech_pvt->owner) {
 				gsmopen_queue_control(tech_pvt->owner, GSMOPEN_CONTROL_HANGUP);


### PR DESCRIPTION
```
libcs are implementing changes to fix the year 2038 issue on 32 bit
platforms (see [1]). musl libc already went ahead and implemented it,
starting with musl-1.2.0 (see [2]).

FreeSWITCH already supports time64 libcs since commit
aa71d87528643fd1b3897a64ecec8c11e92b5b55. But as it turns out, mod_gsmopen
doesn't use TIME_T_FMT (everything else does). And now with a time64 libc
compiling for a 32 bit target, warnings like this appear:

In file included from gsmopen_protocol.cpp:37:
gsmopen.h:121:97: warning: format '%ld' expects argument of type 'long int', but argument 16 has type 'time_t' {aka 'long long int'} [-Wformat=]
  121 | #define DEBUGA_GSMOPEN(...)  switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,            "rev %s [%p|%-7lx][DEBUG_GSMOPEN  %-5d][%-10s][%2d,%2d,%2d] " __VA_ARGS__ );
gsmopen.h:121:97: note: in definition of macro 'DEBUGA_GSMOPEN'
  121 | #define DEBUGA_GSMOPEN(...)  switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,            "rev %s [%p|%-7lx][DEBUG_GSMOPEN  %-5d][%-10s][%2d,%2d,%2d] " __VA_ARGS__ );
      |                                                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gsmopen_protocol.cpp:856:104: note: format string is defined here
  856 |                                         DEBUGA_GSMOPEN("GSMOPEN_STATE_RING call_incoming_time.tv_sec=%ld\n", GSMOPEN_P_LOG, tech_pvt->call_incoming_time.tv_sec);
      |                                                                                                      ~~^
      |                                                                                                        |
      |                                                                                                        long int
      |                                                                                                      %lld

This commit adds TIME_T_FMT to mod_gsmopen. All warnings are gone.

[1] https://sourceware.org/glibc/wiki/Y2038ProofnessDesign
[2] https://musl.libc.org/time64.html

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
```