### PR TITLE
[mod_sofia] Randomize OPTIONS Ping interval

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -2949,6 +2949,9 @@ void *SWITCH_THREAD_FUNC sofia_profile_worker_thread_run(switch_thread_t *thread
 
 	sofia_set_pflag_locked(profile, PFLAG_WORKER_RUNNING);
 
+	/* Seed PRNG for functions within worker thread */
+	srand((unsigned)((intptr_t) switch_thread_self() + switch_micro_time_now()));
+
 	while ((mod_sofia_globals.running == 1 && sofia_test_pflag(profile, PFLAG_RUNNING))) {
 
 		if (tick) {

--- a/src/mod/endpoints/mod_sofia/sofia_presence.c
+++ b/src/mod/endpoints/mod_sofia/sofia_presence.c
@@ -3755,7 +3755,6 @@ void sofia_presence_handle_sip_i_subscribe(int status,
 
 	if ((sub_max_deviation_var = profile->sip_subscription_max_deviation)) {
 		int sub_deviation;
-		srand( (unsigned) ( (unsigned)(intptr_t)switch_thread_self() + switch_micro_time_now() ) );
 		/* random negative number between 0 and negative sub_max_deviation_var: */
 		sub_deviation = ( rand() % sub_max_deviation_var ) - sub_max_deviation_var;
 		if ( (exp_delta + sub_deviation) > 45 ) {


### PR DESCRIPTION
In FS-6400, the attempt was made to randomize OPTIONS
packets to be sent at a random interval.  The same random
interval is applied to all endpoints so this doesn't work.

Furthermore, rounding withing the code will ultimately
make the ping times converge over time.

This commmit will apply the random interval only during
registration of the endpoint.  All subsequent pings will
be incremented with the actual value of ping-mean-interval.

Fixes #1132, Fixes #1133