### PR TITLE
[mod_opusfile] fix type errors

### DIFF
--- a/src/mod/formats/mod_opusfile/mod_opusfile.c
+++ b/src/mod/formats/mod_opusfile/mod_opusfile.c
@@ -930,7 +930,7 @@ static int decode_stream_cb(void *dcontext, unsigned char *data, int nbytes)
 	if (globals.debug) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "[OGG/OPUS Stream Decode] decode CB called: context: %p data: %p packet_len: %d\n", 
 				(void *)context, data, nbytes);
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "[OGG/OPUS Stream Decode] decode_stream_cb(): switch_thread_self(): %lx\n",  switch_thread_self());
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "[OGG/OPUS Stream Decode] decode_stream_cb(): switch_thread_self(): %lx\n", (unsigned long)(intptr_t)switch_thread_self());
 	}
 
 	switch_mutex_lock(context->ogg_mutex);
@@ -973,7 +973,7 @@ static void *SWITCH_THREAD_FUNC read_stream_thread(switch_thread_t *thread, void
 	int buffered_ogg_bytes;
 
 	if (globals.debug) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "[OGG/OPUS Stream Decode] read_stream_thread(): switch_thread_self(): 0x%lx\n",  switch_thread_self());
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "[OGG/OPUS Stream Decode] read_stream_thread(): switch_thread_self(): 0x%lx\n", (unsigned long)(intptr_t)switch_thread_self());
 	}
 	switch_thread_rwlock_rdlock(context->rwlock);
 	switch_mutex_lock(context->ogg_mutex);


### PR DESCRIPTION
Since the last round of changes it fails to compile:

```
mod_opusfile.c: In function 'decode_stream_cb':
mod_opusfile.c:933:143: error: format '%lx' expects argument of type 'long unsigned int', but argument 8 has type 'switch_thread_id_t' {aka 'struct __pthread *'} [-Werror=format=]
  933 |                 switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "[OGG/OPUS Stream Decode] decode_stream_cb(): switch_thread_self(): %lx\n",  switch_thread_self());
      |                                                                                                                                             ~~^      ~~~~~~~~~~~~~~~~~~~~
      |                                                                                                                                               |      |
      |                                                                                                                                               |      switch_thread_id_t {aka struct __pthread *}
      |                                                                                                                                               long unsigned int
```

Address this by applying the same casts that are also used in
src/mod/formats/mod_sndfile/test/test_sndfile.c already.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>