### PR TITLE
[core] fix "--disable-libyuv"

### DIFF
--- a/src/switch_core_video.c
+++ b/src/switch_core_video.c
@@ -3116,6 +3116,7 @@ SWITCH_DECLARE(switch_status_t) switch_img_data_url_png(switch_image_t *img, cha
 
 SWITCH_DECLARE(switch_image_t *) switch_img_read_from_file(const char* file_name, switch_img_fmt_t img_fmt)
 {
+#ifdef SWITCH_HAVE_YUV
 	int width = 0, height = 0, channels = 0;
 	int comp = STBI_rgb;
 	unsigned char *data = NULL;
@@ -3155,12 +3156,16 @@ SWITCH_DECLARE(switch_image_t *) switch_img_read_from_file(const char* file_name
 	} else if (data) {
 		stbi_image_free(data);
 	}
+#endif
 
 	return NULL;
 }
 
 SWITCH_DECLARE(switch_status_t) switch_img_write_to_file(switch_image_t *img, const char* file_name, int quality)
 {
+#ifndef SWITCH_HAVE_YUV
+	return SWITCH_STATUS_FALSE;
+#else
 	int comp = STBI_rgb;
 	unsigned char *data = NULL;
 	const char *ext = strrchr(file_name, '.');
@@ -3217,6 +3222,7 @@ SWITCH_DECLARE(switch_status_t) switch_img_write_to_file(switch_image_t *img, co
 	free(data);
 
 	return ret ? SWITCH_STATUS_SUCCESS : SWITCH_STATUS_FALSE;
+#endif
 }
 
 typedef struct data_url_context_s {
@@ -3224,14 +3230,19 @@ typedef struct data_url_context_s {
 	char **urlP;
 } data_url_context_t;
 
+#ifdef SWITCH_HAVE_YUV
 static void data_url_write_func(void *context, void *data, int size)
 {
 	switch_buffer_t *buffer = (switch_buffer_t *)context;
 	switch_buffer_write(buffer, data, size);
 }
+#endif
 
 SWITCH_DECLARE(switch_status_t) switch_img_data_url(switch_image_t *img, char **urlP, const char *type, int quality)
 {
+#ifndef SWITCH_HAVE_YUV
+	return SWITCH_STATUS_FALSE;
+#else
 	int comp = STBI_rgb;
 	unsigned char *data = NULL;
 	int stride_in_bytes = 0;
@@ -3300,6 +3311,7 @@ SWITCH_DECLARE(switch_status_t) switch_img_data_url(switch_image_t *img, char **
 	switch_buffer_destroy(&buffer);
 
 	return ret ? SWITCH_STATUS_SUCCESS : SWITCH_STATUS_FALSE;
+#endif /* SWITCH_HAVE_YUV */
 }
 
 

--- a/tests/unit/switch_core_video.c
+++ b/tests/unit/switch_core_video.c
@@ -48,6 +48,7 @@ FST_CORE_BEGIN("./conf")
 		}
 		FST_TEARDOWN_END()
 
+#ifdef SWITCH_HAVE_YUV
 		FST_TEST_BEGIN(data_url_test)
 		{
 			char *data_url = NULL;
@@ -88,6 +89,7 @@ FST_CORE_BEGIN("./conf")
 			unlink(argb_filename);
 		}
 		FST_TEST_END()
+#endif /* SWITCH_HAVE_YUV */
 
 		FST_TEST_BEGIN(img_patch)
 		{
@@ -239,6 +241,7 @@ FST_CORE_BEGIN("./conf")
 		}
 		FST_TEST_END()
 
+#ifdef SWITCH_HAVE_YUV
 		FST_TEST_BEGIN(stb_data_url)
 		{
 			switch_image_t *img = switch_img_alloc(NULL, SWITCH_IMG_FMT_I420, 120, 60, 1);
@@ -321,6 +324,7 @@ FST_CORE_BEGIN("./conf")
 			unlink(jpg_write_filename);
 		}
 		FST_TEST_END()
+#endif /* SWITCH_HAVE_YUV */
 	}
 	FST_SUITE_END()
 }


### PR DESCRIPTION
Recent changes made it impossible to compile freeswitch without libyuv
support.

src/switch_core_video.c: In function 'switch_img_read_from_file':
src/switch_core_video.c:3139:4: error: implicit declaration of function 'RAWToI420' [-Werror=implicit-function-declaration]
RAWToI420(data, width * 3,
^
src/switch_core_video.c:3148:4: error: implicit declaration of function 'ABGRToARGB' [-Werror=implicit-function-declaration]
ABGRToARGB(data, width * 4, img->planes[SWITCH_PLANE_PACKED], img->stride[SWITCH_PLANE_PACKED], width, height);
^

Fix this my adding/moving the checks for "SWITCH_HAVE_YUV".

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>