### PR TITLE
[build] skip checking unused execinfo.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -883,7 +883,7 @@ AC_SUBST(LIBTOOL_LIB_EXTEN)
 # Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDC
-AC_CHECK_HEADERS([sys/types.h sys/resource.h sched.h wchar.h sys/filio.h sys/ioctl.h sys/prctl.h sys/select.h netdb.h execinfo.h sys/time.h])
+AC_CHECK_HEADERS([sys/types.h sys/resource.h sched.h wchar.h sys/filio.h sys/ioctl.h sys/prctl.h sys/select.h netdb.h sys/time.h])
 
 # Solaris 11 privilege management
 AS_CASE([$host],

--- a/src/include/switch_private.h.cmake
+++ b/src/include/switch_private.h.cmake
@@ -22,9 +22,6 @@
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #cmakedefine HAVE_DLFCN_H
 
-/* Define to 1 if you have the <execinfo.h> header file. */
-#cmakedefine HAVE_EXECINFO_H
-
 /* Define to 1 if you have the `gethostname' function. */
 #cmakedefine HAVE_GETHOSTNAME
 


### PR DESCRIPTION
since 380fd060ef719b1d8f8781422e84d2a32066351d, execinfo.h is not used
anymore, so there is no need to check for it.