### PR TITLE
[mod_amqp] Fix memory leaks on command queue name and parsing configure file

### DIFF
--- a/src/mod/event_handlers/mod_amqp/mod_amqp_command.c
+++ b/src/mod/event_handlers/mod_amqp/mod_amqp_command.c
@@ -274,11 +274,11 @@ static void mod_amqp_command_response(mod_amqp_command_profile_t *profile, char 
 
 void * SWITCH_THREAD_FUNC mod_amqp_command_thread(switch_thread_t *thread, void *data)
 {
+	amqp_bytes_t queueName = { 0, NULL };
 	mod_amqp_command_profile_t *profile = (mod_amqp_command_profile_t *) data;
 
 	while (profile->running) {
 		amqp_queue_declare_ok_t *recv_queue;
-		amqp_bytes_t queueName = { 0, NULL };
 
 		/* Ensure we have an AMQP connection */
 		if (!profile->conn_active) {

--- a/src/mod/event_handlers/mod_amqp/mod_amqp_utils.c
+++ b/src/mod/event_handlers/mod_amqp/mod_amqp_utils.c
@@ -193,6 +193,7 @@ switch_status_t mod_amqp_do_config(switch_bool_t reload)
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Unable to locate logging section for mod_amqp\n" );
 	}
 
+	switch_xml_free(xml);
 	return SWITCH_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Found queueName leak here.

https://github.com/signalwire/freeswitch/blob/f3604557e52ff14ae98f7f5080472ba2543ef1ac/src/mod/event_handlers/mod_amqp/mod_amqp_command.c#L368

