### PR TITLE
[core] fix macOS build when missing CRYPTO_mem_ctrl

### DIFF
--- a/src/switch_core_cert.c
+++ b/src/switch_core_cert.c
@@ -281,7 +281,9 @@ SWITCH_DECLARE(int) switch_core_gen_certs(const char *prefix)
 		}
 	}
 
+#ifdef CRYPTO_MEM_CHECK_ON
 	CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
+#endif
 
 	//bio_err=BIO_new_fp(stderr, BIO_NOCLOSE);
 


### PR DESCRIPTION
https://github.com/signalwire/freeswitch/issues/1461
https://github.com/signalwire/libks/commit/3493e9c952964c80e402aa0497891d57dc5f8d40