### PR TITLE
[core] Add support to phrase play-file to set a volume attribute

### DIFF
--- a/src/include/switch_module_interfaces.h
+++ b/src/include/switch_module_interfaces.h
@@ -356,6 +356,7 @@ struct switch_file_handle {
 	switch_size_t samples_in;
 	switch_size_t samples_out;
 	int32_t vol;
+	int32_t volgranular;
 	switch_audio_resampler_t *resampler;
 	switch_buffer_t *buffer;
 	switch_byte_t *dbuf;

--- a/src/switch_ivr_play_say.c
+++ b/src/switch_ivr_play_say.c
@@ -251,7 +251,17 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_phrase_macro_event(switch_core_sessio
 								  module_name);
 
 				if (!strcasecmp(func, "play-file")) {
-					status = switch_ivr_play_file(session, NULL, odata, args);
+					char *volume_str = (char *) switch_xml_attr_soft(action, "volume");
+					switch_file_handle_t pfh = { 0 };
+					if (volume_str && switch_is_number(volume_str)) {
+						int32_t volume = atoi(volume_str);
+
+						switch_normalize_volume_granular(volume)
+						pfh.volgranular = volume;
+
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Setting playback volume to %d\n", pfh.volgranular);
+					}
+					status = switch_ivr_play_file(session, &pfh, odata, args);
 				} else if (!strcasecmp(func, "phrase")) {
 					char *name = (char *) switch_xml_attr_soft(action, "phrase");
 					status = switch_ivr_phrase_macro(session, name, odata, chan_lang, args);
@@ -1957,8 +1967,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_play_file(switch_core_session_t *sess
 			}
 #endif
 #endif
-			if (!switch_test_flag(fh, SWITCH_FILE_NATIVE) && fh->vol) {
-				switch_change_sln_volume(write_frame.data, write_frame.datalen / 2, fh->vol);
+			if (!switch_test_flag(fh, SWITCH_FILE_NATIVE)) {
+				if (fh->volgranular) {
+					switch_change_sln_volume_granular(write_frame.data, write_frame.datalen / 2, fh->volgranular);
+				} else if (fh->vol) { /* deprecated 2022-Q1 */
+					switch_change_sln_volume(write_frame.data, write_frame.datalen / 2, fh->vol);
+				}
 			}
 
 			/* write silence while dmachine is in reading state */


### PR DESCRIPTION
This add support to specify volume="-10" in phrase action

the switch_file_handle only supported the ->vol flag which have a total of 8 volume correction position.
So I've added the ->volgranular which is based on the switch_resample code which is similar to the ->vol, but provide 100 volume setting in a much larger range of value.