### PR TITLE
[mod_conference] Adding Endconf event header to conference participant events

### DIFF
--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -269,6 +269,7 @@ switch_status_t conference_member_add_event_data(conference_member_t *member, sw
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Member-Ghost", "%s", conference_utils_member_test_flag(member, MFLAG_GHOST) ? "true" : "false");
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Energy-Level", "%d", member->energy_level);
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Current-Energy", "%d", member->score);
+	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Endconf", "%s", conference_utils_member_test_flag(member, MFLAG_ENDCONF) ? "true" : "false" );
 
 	return status;
 }


### PR DESCRIPTION
Description:

Currently, if endconf member flag is set to conference participant channel, we are not able to identify on conference participant event if its have endconf true or false.

After this commit event json look like this:

{
  "Action": "add-member",
  "Answer-State": "answered",
  "Authsid": "3BI9RQRCCHAZMM76E8IS",
  "Call-Direction": "outbound",
  "Caller-Ani": "919967609476",
  "Caller-Callee-Id-Name": "919967609476",
  "Caller-Callee-Id-Number": "919967609476",
  "Caller-Caller-Id-Name": "Outbound Call",
  "Caller-Caller-Id-Number": "917976055614",
  "Caller-Channel-Answered-Time": "1642649624143862",
  "Caller-Channel-Bridged-Time": "0",
  "Caller-Channel-Created-Time": "1642649613802895",
  "Caller-Channel-Hangup-Time": "0",
  "Caller-Channel-Hold-Accum": "0",
  "Caller-Channel-Last-Hold": "0",
  "Caller-Channel-Name": "sofia/external/917976055614",
  "Caller-Channel-Progress-Media-Time": "1642649616342656",
  "Caller-Channel-Progress-Time": "0",
  "Caller-Channel-Resurrect-Time": "0",
  "Caller-Channel-Transfer-Time": "0",
  "Caller-Context": "default",
  "Caller-Destination-Number": "917976055614",
  "Caller-Direction": "outbound",
  "Caller-Logical-Direction": "outbound",
  "Caller-Network-Addr": "3.1.168.82",
  "Caller-Orig-Caller-Id-Name": "919967609476",
  "Caller-Orig-Caller-Id-Number": "919967609476",
  "Caller-Privacy-Hide-Name": "false",
  "Caller-Privacy-Hide-Number": "false",
  "Caller-Profile-Created-Time": "1642649613802895",
  "Caller-Profile-Index": "1",
  "Caller-Screen-Bit": "true",
  "Caller-Source": "src/switch_ivr_originate.c",
  "Caller-Unique-Id": "be0166b4-c6ba-4207-8bbf-a966e0800d62",
  "Channel-Call-State": "ACTIVE",
  "Channel-Call-Uuid": "be0166b4-c6ba-4207-8bbf-a966e0800d62",
  "Channel-Hit-Dialplan": "true",
  "Channel-Name": "sofia/external/917976055614",
  "Channel-Read-Codec-Bit-Rate": "128000",
  "Channel-Read-Codec-Name": "L16",
  "Channel-Read-Codec-Rate": "8000",
  "Channel-State": "CS_EXECUTE",
  "Channel-State-Number": "4",
  "Channel-Write-Codec-Bit-Rate": "64000",
  "Channel-Write-Codec-Name": "PCMU",
  "Channel-Write-Codec-Rate": "8000",
  "Conference-Domain": "10.0.12.163",
  "Conference-Ghosts": "0",
  "Conference-Name": "3BI9RQRCCHAZMM76E8IS-Room 1234",
  "Conference-Profile-Name": "conference_demo",
  "Conference-Size": "1",
  "Conference-Unique-Id": "2263970c-96e2-45b4-85c6-b95fb53a6ce2",
  "Confsid": "d9e84c35-388d-4e5e-9ab4-76f9cad5baec",
  "Core-Uuid": "08849150-d888-49a2-a491-3bee1df48285",
  "Current-Energy": "0",
  ****"Endconf": "true",****
  "Energy-Level": "200",
  "Event-Calling-File": "conference_member.c",
  "Event-Calling-Function": "conference_member_add",
  "Event-Calling-Line-Number": "958",
  "Event-Date-Gmt": "Thu, 20 Jan 2022 03:33:44 GMT",
  "Event-Date-Local": "2022-01-20 03:33:44",
  "Event-Date-Timestamp": "1642649624543236",
  "Event-Name": "CUSTOM",
  "Event-Sequence": "15127",
  "Event-Subclass": "conference::maintenance",
  "Floor": "false",
  "Freeswitch-Hostname": "ip-10-0-12-163",
  "Freeswitch-Ipv4": "10.0.12.163",
  "Freeswitch-Ipv6": "::1",
  "Freeswitch-Switchname": "ip-10-0-12-163",
  "Hear": "true",
  "Hold": "false",
  "Member-Ghost": "false",
  "Member-Id": "3",
  "Member-Type": "moderator",
  "Mute-Detect": "false",
  "Presence-Call-Direction": "outbound",
  "See": "true",
  "Speak": "true",
  "Statuscallback_Method": "GET",
  "Statuscallback_Url": "https://enmna9w5cf3jkdy.m.pipedream.net",
  "Talking": "false",
  "Unique-Id": "be0166b4-c6ba-4207-8bbf-a966e0800d62",
  "Video": "false"
}