### PR TITLE
[mod_curl] remove phrase check in http response

### DIFF
--- a/src/mod/applications/mod_curl/mod_curl.c
+++ b/src/mod/applications/mod_curl/mod_curl.c
@@ -369,11 +369,9 @@ static char *print_json(switch_memory_pool_t *pool, http_data_t *http_data)
 				char *argv[3] = { 0 };
 				int argc;
 				if ((argc = switch_separate_string(header->data, ' ', argv, (sizeof(argv) / sizeof(argv[0]))))) {
+					cJSON_AddItemToObject(top, "version", cJSON_CreateString(argv[0]));
 					if (argc > 2) {
-						cJSON_AddItemToObject(top, "version", cJSON_CreateString(argv[0]));
 						cJSON_AddItemToObject(top, "phrase", cJSON_CreateString(argv[2]));
-					} else {
-						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Unparsable header: argc: %d\n", argc);
 					}
 				} else {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Starts with HTTP but not parsable: %s\n", header->data);


### PR DESCRIPTION
Compatible the tomcat over [8.5](https://stackoverflow.com/questions/39120756/tomcat-8-5-header-missing-in-the-http-response) version.
