### PR TITLE
[mod_callcenter] Fix SWITCH_EVENT_PRESENCE_PROBE unbind

### DIFF
--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -4213,6 +4213,10 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_callcenter_load)
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", CALLCENTER_EVENT);
 		return SWITCH_STATUS_TERM;
 	}
+	
+	
+	memset(&globals, 0, sizeof(globals));
+	globals.pool = pool;
 
 	/* Subscribe to presence request events */
 	if (switch_event_bind_removable(modname, SWITCH_EVENT_PRESENCE_PROBE, SWITCH_EVENT_SUBCLASS_ANY,
@@ -4220,9 +4224,6 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_callcenter_load)
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to subscribe for presence events!\n");
 		return SWITCH_STATUS_GENERR;
 	}
-
-	memset(&globals, 0, sizeof(globals));
-	globals.pool = pool;
 
 	switch_core_hash_init(&globals.queue_hash);
 	switch_mutex_init(&globals.mutex, SWITCH_MUTEX_NESTED, globals.pool);


### PR DESCRIPTION
`globals` was getting initialized to null after `switch_event_bind_removable` binding causing `globals.nodes` to get set to NULL causing `switch_event_unbind` not to be able to unbind the `SWITCH_EVENT_PRESENCE_PROBE` event when unloading the module. Besides not being able to unbind the event, this was also causing a segfault  upon receiving a `PRESENCE_PROBE` event when unloading or reloading the module