### PR TITLE
[mod_avmd] Fix underlinking

### DIFF
--- a/src/mod/applications/mod_avmd/Makefile.am
+++ b/src/mod/applications/mod_avmd/Makefile.am
@@ -4,5 +4,5 @@ MODNAME=mod_avmd
 mod_LTLIBRARIES = mod_avmd.la
 mod_avmd_la_SOURCES  = mod_avmd.c avmd_buffer.c avmd_desa2_tweaked.c avmd_fast_acosf.c
 mod_avmd_la_CFLAGS   = $(AM_CFLAGS) $(AM_MOD_AVMD_CXXFLAGS)
-mod_avmd_la_LIBADD   = $(switch_builddir)/libfreeswitch.la
+mod_avmd_la_LIBADD   = $(switch_builddir)/libfreeswitch.la -lm
 mod_avmd_la_LDFLAGS  = -avoid-version -module -no-undefined -shared


### PR DESCRIPTION
When building with `-Wl,--no-undefined` an error occured:

```
DEBUG: make[4]: Entering directory '/builddir/build/BUILD/freeswitch-1.10.7.-release/src/mod/applications/mod_avmd'
DEBUG:   CC       mod_avmd_la-mod_avmd.lo
DEBUG:   CC       mod_avmd_la-avmd_buffer.lo
DEBUG:   CC       mod_avmd_la-avmd_desa2_tweaked.lo
DEBUG:   CC       mod_avmd_la-avmd_fast_acosf.lo
DEBUG:   CCLD     mod_avmd.la
DEBUG: /usr/bin/aarch64-rosa-linux-gnu-ld: .libs/mod_avmd_la-mod_avmd.o: in function `avmd_decision_amplitude':
DEBUG: /builddir/build/BUILD/freeswitch-1.10.7.-release/src/mod/applications/mod_avmd/mod_avmd.c:1928: undefined reference to `sqrt'
DEBUG: /usr/bin/aarch64-rosa-linux-gnu-ld: .libs/mod_avmd_la-mod_avmd.o: in function `avmd_decision_freq':
DEBUG: /builddir/build/BUILD/freeswitch-1.10.7.-release/src/mod/applications/mod_avmd/mod_avmd.c:1947: undefined reference to `sqrt'
DEBUG: /usr/bin/aarch64-rosa-linux-gnu-ld: .libs/mod_avmd_la-mod_avmd.o: in function `avmd_process_sample':
DEBUG: /builddir/build/BUILD/freeswitch-1.10.7.-release/src/mod/applications/mod_avmd/mod_avmd.c:2207: undefined reference to `acos'
DEBUG: /usr/bin/aarch64-rosa-linux-gnu-ld: .libs/mod_avmd_la-avmd_desa2_tweaked.o: in function `avmd_desa2_tweaked':
DEBUG: /builddir/build/BUILD/freeswitch-1.10.7.-release/src/mod/applications/mod_avmd/avmd_desa2_tweaked.c:69: undefined reference to `sqrt'
DEBUG: /usr/bin/aarch64-rosa-linux-gnu-ld: .libs/mod_avmd_la-avmd_fast_acosf.o: in function `compute_table':
DEBUG: /builddir/build/BUILD/freeswitch-1.10.7.-release/src/mod/applications/mod_avmd/avmd_fast_acosf.c:116: undefined reference to `acosf'
DEBUG: collect2: error: ld returned 1 exit status
```