### PR TITLE
[mod_curl] The Reason-Phrase can be a empty string

### DIFF
--- a/src/mod/applications/mod_curl/mod_curl.c
+++ b/src/mod/applications/mod_curl/mod_curl.c
@@ -369,9 +369,9 @@ static char *print_json(switch_memory_pool_t *pool, http_data_t *http_data)
 				char *argv[3] = { 0 };
 				int argc;
 				if ((argc = switch_separate_string(header->data, ' ', argv, (sizeof(argv) / sizeof(argv[0]))))) {
-					if (argc > 2) {
+					if (argc >= 2) {
 						cJSON_AddItemToObject(top, "version", cJSON_CreateString(argv[0]));
-						cJSON_AddItemToObject(top, "phrase", cJSON_CreateString(argv[2]));
+						cJSON_AddItemToObject(top, "phrase", cJSON_CreateString(argc > 2 ? argv[2] : ""));
 					} else {
 						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Unparsable header: argc: %d\n", argc);
 					}


### PR DESCRIPTION
See [RFC-2616 Section 6.1](https://datatracker.ietf.org/doc/html/rfc2616#section-6.1)
```
Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
Reason-Phrase  = *<TEXT, excluding CR, LF>
```