### PR TITLE
[mod_shout] Replace space with tab in Makefile.am

### DIFF
--- a/src/mod/formats/mod_shout/Makefile.am
+++ b/src/mod/formats/mod_shout/Makefile.am
@@ -16,7 +16,7 @@ else
 install: error
 all: error
 error:
-       $(error You must install libmp3lame-dev to build mod_shout)
+	$(error You must install libmp3lame-dev to build mod_shout)
 endif
 
 else


### PR DESCRIPTION
Space indent will cause a error when running ./configure when HAVE_MP3LAME is false.