### PR TITLE
[mod_sofia] on call term optionally ignore Q.850 Reason

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -8718,7 +8718,7 @@ static void sofia_handle_sip_i_state(switch_core_session_t *session, int status,
 			sofia_clear_flag_locked(tech_pvt, TFLAG_NOHUP);
 		} else if (switch_channel_up(channel)) {
 			int cause;
-			if (tech_pvt->q850_cause) {
+			if (tech_pvt->q850_cause && !switch_channel_var_true(channel, "ignore_q850_reason")) {
 				cause = tech_pvt->q850_cause;
 			} else {
 				cause = sofia_glue_sip_cause_to_freeswitch(status);


### PR DESCRIPTION
Currently SIP termination messages with Q.850 override the SIP
reason. Add chanvar ignore_q850_reason to ignore the Q.850 reason
and keep the SIP Reason Code.

Using the chan var avoids unexpected changes in behavior.

Co-authored-by: Brian West <brian@freeswitch.org>