### PR TITLE
When using 'as json', make sure response is terminated

### DIFF
--- a/src/mod/applications/mod_commands/mod_commands.c
+++ b/src/mod/applications/mod_commands/mod_commands.c
@@ -5987,7 +5987,7 @@ SWITCH_STANDARD_API(show_function)
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Memory Error!\n");
 					holder.stream->write_function(holder.stream, "-ERR Memory Error!\n");
 				} else {
-					holder.stream->write_function(holder.stream, "%s", json_text);
+					holder.stream->write_function(holder.stream, "%s\n", json_text);
 				}
 				cJSON_Delete(result);
 				switch_safe_free(json_text);


### PR DESCRIPTION
Super trivial bug I noticed when using 'as json', but it's a bug 8)

There is no \n automatically appended to a JSON response, so
there wasn't any way to determine the result was completed.
You can see the 'rows:0' result below has a \n, and that worked
correctly.

Signed-Off-By: Rob Thomas <xrobau@gmail.com>