### PR TITLE
Add Fanvil to vendors allowed to update.

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -2070,6 +2070,7 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 									  (switch_stristr("cisco/spa50", ua) ||
 									  switch_stristr("cisco/spa525", ua)) ||
 									  switch_stristr("cisco/spa30", ua) ||
+									  switch_stristr("Fanvil", ua) ||
 									  switch_stristr("Grandstream", ua) ||
 									  switch_stristr("Yealink", ua) ||
 									  switch_stristr("Mitel", ua) ||


### PR DESCRIPTION
Problem:
Pickup calls from Valet Park shows feature code rather than the Caller's original Caller ID.

Solution:
Add Fanvil to the update_allowed condition resolves this problem.

This is a useful improvement for people using Fanvil with FreeSWITCH.