### PR TITLE
[core] When unbridge, set the channel state atomically

### DIFF
--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -2402,6 +2402,7 @@ SWITCH_DECLARE(switch_channel_state_t) switch_channel_perform_set_state(switch_c
 {
 	switch_channel_state_t last_state;
 	int ok = 0;
+	const char *protected_channel_status = switch_channel_get_variable(channel, "protected_channel_status");
 
 	switch_assert(channel != NULL);
 	switch_assert(state <= CS_DESTROY);
@@ -2412,6 +2413,10 @@ SWITCH_DECLARE(switch_channel_state_t) switch_channel_perform_set_state(switch_c
 
 	if (last_state == state) {
 		goto done;
+	}
+	
+	if (protected_channel_status != NULL && last_state < CS_NONE && protected_channel_status[last_state] == '1'){
+		goto done;			
 	}
 
 	if (last_state >= CS_HANGUP && state < last_state) {

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -1630,6 +1630,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_multi_threaded_bridge(switch_core_ses
 	const char *var;
 	switch_call_cause_t cause;
 	switch_core_session_message_t msg = { 0 };
+	char protected_channel_status[CS_NONE + 1] = {"0000000000000"};
 
 	if (switch_channel_test_flag(caller_channel, CF_PROXY_MODE)) {
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Call has no media... Redirecting to signal bridge.\n");
@@ -1952,10 +1953,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_multi_threaded_bridge(switch_core_ses
 		if (switch_channel_test_flag(caller_channel, CF_RESET)) {
 			switch_channel_clear_flag(caller_channel, CF_RESET);
 		} else {
-			state = switch_channel_get_state(caller_channel);
-			if (!(state == CS_RESET || state == CS_PARK || state == CS_ROUTING || state == CS_EXECUTE)) {
-				switch_channel_set_state(caller_channel, CS_RESET);
-			}
+			protected_channel_status[CS_RESET] = '1';
+			protected_channel_status[CS_PARK] = '1';
+			protected_channel_status[CS_ROUTING] = '1';
+			protected_channel_status[CS_EXECUTE] = '1';			
+			switch_channel_set_variable(caller_channel, "protected_channel_status", protected_channel_status);
+			switch_channel_set_state(caller_channel, CS_RESET);	
 		}
 	}
 


### PR DESCRIPTION
for issue https://github.com/signalwire/freeswitch/issues/1698

after we get channel state at line 1995 in switch_ivr_bridge.c, it may be modified by other thread, so line 1956 "if judgement" maybe invalid.