### PR TITLE
fix nat ignore for proxy on loopback network

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -8142,9 +8142,7 @@ SWITCH_DECLARE(int) switch_core_media_check_nat(switch_media_handle_t *smh, cons
 {
 	switch_assert(network_ip);
 
-	return (smh->mparams->extsipip &&
-			!switch_check_network_list_ip(network_ip, "loopback.auto") &&
-			!switch_check_network_list_ip(network_ip, smh->mparams->local_network));
+	return (smh->mparams->extsipip && !switch_check_network_list_ip(network_ip, smh->mparams->local_network));
 }
 
 //?


### PR DESCRIPTION
<img width="1312" alt="Screen Shot 2022-07-17 at 22 42 00" src="https://user-images.githubusercontent.com/58973699/179406852-981cef83-4100-4039-9865-1d2ad6bbceda.png">

**Environment:**
- Kamailio is sip proxy for FreeSWITCH, they are runing on the same in.
- Kamailio bind on loopback 127.0.0.3
- FreeSWITCH SIP bind on 127.0.0.2 (sip-ip, ext-sip-ip), RTP bind on PRIVATE_IP (`rtp-ip`) and PUBLIC_IP (`ext-rtp-ip`)
- Set the `local-network-acl` to `rfc1918.auto` or  `none`


**Step:** 
make call from UAC (sip phone)
[UAC]  ---internet ---- [KAMAILIO] --- loopback ---- [FreeSWITCH] ------- [NEXTHOP]


**Actual Result:**
- IP address in SDP body is always PRIVATE_IP

**Expected:**
- IP address in SDP body is always PUBLIC_IP

**Self-Check:**
since the NAT check logic in `switch_core_media.c` always include ignore if remote is loopback as below:
```
	return (smh->mparams->extsipip &&
			!switch_check_network_list_ip(network_ip, "loopback.auto") &&
			!switch_check_network_list_ip(network_ip, smh->mparams->local_network));
```

**Work Around**
Override built in loopback.auto by:
```
        <list name="loopback.auto" default="deny">
          <node type="allow" cidr="127.0.0.1/32"/>
       </list>
```





