### PR TITLE
Added global-db-lock setting in mod_sofia

### DIFF
--- a/conf/vanilla/autoload_configs/sofia.conf.xml
+++ b/conf/vanilla/autoload_configs/sofia.conf.xml
@@ -5,6 +5,7 @@
     <!-- <param name="abort-on-empty-external-ip" value="true"/> -->
     <!-- <param name="auto-restart" value="false"/> -->
     <param name="debug-presence" value="0"/>
+    <!-- <param name="global-db-lock" value="0"/>-->
     <!-- <param name="capture-server" value="udp:homer.domain.com:5060"/> -->
     
     <!-- 

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -416,6 +416,7 @@ struct mod_sofia_globals {
 	const char *stir_shaken_vs_ca_dir;
 	int stir_shaken_vs_cert_path_check;
 	int stir_shaken_vs_require_date;
+	int global_db_lock;
 };
 extern struct mod_sofia_globals mod_sofia_globals;
 

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -4502,6 +4502,7 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 	mod_sofia_globals.auto_restart = SWITCH_TRUE;
 	mod_sofia_globals.reg_deny_binding_fetch_and_no_lookup = SWITCH_FALSE; /* handle backwards compatilibity - by default use new behavior */
 	mod_sofia_globals.rewrite_multicasted_fs_path = SWITCH_FALSE;
+	mod_sofia_globals.global_db_lock = SWITCH_TRUE;
 
 	if ((settings = switch_xml_child(cfg, "global_settings"))) {
 		for (param = switch_xml_child(settings, "param"); param; param = param->next) {
@@ -4517,6 +4518,9 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 				mod_sofia_globals.debug_presence = atoi(val);
 			} else if (!strcasecmp(var, "debug-sla")) {
 				mod_sofia_globals.debug_sla = atoi(val);
+			} else if (!strcasecmp(var, "global-db-lock")) {
+				mod_sofia_globals.global_db_lock = switch_true(val);
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "sofia global_db_lock : %d \n", mod_sofia_globals.global_db_lock);
 			} else if (!strcasecmp(var, "max-reg-threads") && val) {
 				int x = atoi(val);
 

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -2806,15 +2806,21 @@ void sofia_glue_actually_execute_sql_trans(sofia_profile_t *profile, char *sql, 
 {
 	switch_cache_db_handle_t *dbh = NULL;
 
-	if (mutex) {
-		switch_mutex_lock(mutex);
+	if (mod_sofia_globals.global_db_lock) {
+		if (mutex) {
+			switch_mutex_lock(mutex);
+		}
 	}
 
 
 	if (!(dbh = sofia_glue_get_db_handle(profile))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error Opening DB\n");
 
+	if (mod_sofia_globals.global_db_lock) {
+		return;
+	} else {
 		goto end;
+	}
 	}
 
 	switch_cache_db_persistant_execute_trans_full(dbh, sql, 1,
@@ -2828,8 +2834,10 @@ void sofia_glue_actually_execute_sql_trans(sofia_profile_t *profile, char *sql, 
 
  end:
 
-	if (mutex) {
-		switch_mutex_unlock(mutex);
+	if (mod_sofia_globals.global_db_lock) {
+		if (mutex) {
+			switch_mutex_unlock(mutex);
+		}
 	}
 }
 
@@ -2838,24 +2846,30 @@ void sofia_glue_actually_execute_sql(sofia_profile_t *profile, char *sql, switch
 	switch_cache_db_handle_t *dbh = NULL;
 	char *err = NULL;
 
-	if (mutex) {
-		switch_mutex_lock(mutex);
+	if (mod_sofia_globals.global_db_lock) {
+		if (mutex) {
+			switch_mutex_lock(mutex);
+		}
 	}
 
 	if (!(dbh = sofia_glue_get_db_handle(profile))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error Opening DB\n");
 
+	if (mod_sofia_globals.global_db_lock) {
 		if (mutex) {
 			switch_mutex_unlock(mutex);
 		}
+	}
 
 		return;
 	}
 
 	switch_cache_db_execute_sql(dbh, sql, &err);
 
-	if (mutex) {
-		switch_mutex_unlock(mutex);
+	if (mod_sofia_globals.global_db_lock) {
+		if (mutex) {
+			switch_mutex_unlock(mutex);
+		}
 	}
 
 	if (err) {
@@ -2873,24 +2887,30 @@ switch_bool_t sofia_glue_execute_sql_callback(sofia_profile_t *profile,
 	char *errmsg = NULL;
 	switch_cache_db_handle_t *dbh = NULL;
 
-	if (mutex) {
-		switch_mutex_lock(mutex);
+	if (mod_sofia_globals.global_db_lock) {
+		if (mutex) {
+			switch_mutex_lock(mutex);
+		}
 	}
 
 	if (!(dbh = sofia_glue_get_db_handle(profile))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error Opening DB\n");
 
+	if (mod_sofia_globals.global_db_lock) {
 		if (mutex) {
 			switch_mutex_unlock(mutex);
 		}
+	}
 
 		return ret;
 	}
 
 	switch_cache_db_execute_sql_callback(dbh, sql, callback, pdata, &errmsg);
 
-	if (mutex) {
-		switch_mutex_unlock(mutex);
+	if (mod_sofia_globals.global_db_lock) {
+		if (mutex) {
+			switch_mutex_unlock(mutex);
+		}
 	}
 
 	if (errmsg) {
@@ -2909,24 +2929,30 @@ char *sofia_glue_execute_sql2str(sofia_profile_t *profile, switch_mutex_t *mutex
 	char *err = NULL;
 	switch_cache_db_handle_t *dbh = NULL;
 
-	if (mutex) {
-		switch_mutex_lock(mutex);
+	if (mod_sofia_globals.global_db_lock) {
+		if (mutex) {
+			switch_mutex_lock(mutex);
+		}
 	}
 
 	if (!(dbh = sofia_glue_get_db_handle(profile))) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error Opening DB\n");
 
+	if (mod_sofia_globals.global_db_lock) {
 		if (mutex) {
 			switch_mutex_unlock(mutex);
 		}
+	}
 
 		return NULL;
 	}
 
 	ret = switch_cache_db_execute_sql2str(dbh, sql, resbuf, len, &err);
 
-	if (mutex) {
-		switch_mutex_unlock(mutex);
+	if (mod_sofia_globals.global_db_lock) {
+		if (mutex) {
+			switch_mutex_unlock(mutex);
+		}
 	}
 
 	if (err) {


### PR DESCRIPTION
**Purpose**
This fixes the handling of global-db-lock in mod_sofia has configurable.

**Overview**
As the Freeswitch use global DB locks to ensure a module will execute just one query at a time creates a bottleneck and it is required only for sqlite , not required for Mariadb or postgresql as it can handle multiple concurrent queries. To overcome this issue added and enabled the global-db-lock settings for mutex lock conditions in sofia_glue.c file.

**Enhancements**
1.To make the code backward compatibility added a new setting global-db-lock in suitable files to enable or disable mutex lock and unlock.
2.Added a new header for global-db-lock.

**Problems faced**
Creates bottleneck

Changes done
1.Modified sofia_glue.c file mutex conditions with enabling global_db_lock settings.
2.Added a header for global-db-lock in mod_sofia.h.