### PR TITLE
[Core] switch_ivr: Ensure do_flush decrypts SRTP DTMF packets

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -552,6 +552,7 @@ typedef enum {
 
 static void do_2833(switch_rtp_t *rtp_session);
 
+static int check_recv_payload(switch_rtp_t *rtp_session);
 
 #define rtp_type(rtp_session) rtp_session->flags[SWITCH_RTP_FLAG_TEXT] ?  "text" : (rtp_session->flags[SWITCH_RTP_FLAG_VIDEO] ? "video" : "audio")
 


### PR DESCRIPTION
BUGFIX: switch_ivr.c do_flush() does not decrypt SRPT DTMF packets.  Mostly, this results in invalid DTMF character which is discarded.  However, it sometimes causes a valid (but spurious) DTMF character to be generated, causing intermittent, unexpected IVR behaviour.  This PR fixes that.