### PR TITLE
new chanvars for inbound multiple header identity

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -11498,6 +11498,15 @@ void sofia_handle_sip_i_invite(switch_core_session_t *session, nua_t *nua, sofia
 			}
 		}
 
+		if (sip->sip_identity) {
+			sip_identity_t *id;
+			for (id = sip->sip_identity; id; id = id->id_next) {
+				if(!zstr(id->id_value)) {
+					switch_channel_add_variable_var_check(channel, "sip_identity", id->id_value, SWITCH_FALSE, SWITCH_STACK_PUSH);
+				}
+			}
+		}
+
 		if (sip->sip_identity && sip->sip_identity->id_value) {
 			switch_channel_set_variable(channel, "sip_h_identity", sip->sip_identity->id_value);
 		}


### PR DESCRIPTION
From rfc8224 https://datatracker.ietf.org/doc/html/rfc8224#page-7
Note that unlike the prior specification in [RFC4474], the Identity header field is now allowed to appear more than one time in a SIP request.

created by: https://github.com/signalwire/freeswitch/issues/1741

depend to libsofia's change:  https://github.com/freeswitch/sofia-sip/pull/165