### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install ca-certificates lsb-release -y --no-instal
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
 # Add anything else here
 
 ## Ports


### PR DESCRIPTION
Make the entrypoint script executable to avoid the following error in Podman run:
Error: crun: open executable: Permission denied: OCI permission denied

See: https://github.com/containers/podman/issues/9377