### PR TITLE
[core, mod_cidlookup] Free memory allocated via strdup

### DIFF
--- a/src/mod/applications/mod_cidlookup/mod_cidlookup.c
+++ b/src/mod/applications/mod_cidlookup/mod_cidlookup.c
@@ -845,6 +845,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_cidlookup_load)
   Macro expands to: switch_status_t mod_cidlookup_shutdown() */
 SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_cidlookup_shutdown)
 {
+	switch_xml_config_cleanup(instructions);
 	switch_event_unbind(&reload_xml_event);
 	return SWITCH_STATUS_SUCCESS;
 }

--- a/src/switch_xml_config.c
+++ b/src/switch_xml_config.c
@@ -457,7 +457,7 @@ SWITCH_DECLARE(void) switch_xml_config_cleanup(switch_xml_config_item_t *instruc
 				char **ptr = (char **) item->ptr;
 				switch_xml_config_string_options_t *string_options = (switch_xml_config_string_options_t *) item->data;
 				/* if (using_strdup) */
-				if (string_options && !string_options->pool && !string_options->length) {
+				if (!string_options || (!string_options->pool && !string_options->length)) {
 					switch_safe_free(*ptr);
 				}
 			}


### PR DESCRIPTION
In mod_cidlookup and several other modules, config parameters
are read from external XML files using the SWITCH_CONFIG_ITEM_STRING_STRDUP
method.  These items do not have string_options, and are not freed
with switch_xml_config_cleanup.  We therefore need to call switch_safe_free
for config without string_options.  We also add switch_xml_config_cleanup
to mod_cidlookup.  There are other modules that may be affected but this
commit makes no attempt at fixing those.

Fixes #1752