### PR TITLE
[mod_conference] file descriptor stays open

### DIFF
--- a/src/mod/applications/mod_conference/conference_file.c
+++ b/src/mod/applications/mod_conference/conference_file.c
@@ -164,6 +164,11 @@ switch_status_t conference_file_play(conference_obj_t *conference, char *file, u
 
 	switch_assert(conference != NULL);
 
+        if (!conference_utils_test_flag(conference, CFLAG_RUNNING)) {
+                return SWITCH_STATUS_FALSE;
+	}
+
+
 	if (zstr(file)) {
 		return SWITCH_STATUS_NOTFOUND;
 	}


### PR DESCRIPTION
Issue  #1119
Solution: don't even start to play file if conference is not running.