### PR TITLE
[mod_sofia] Fix PRESENCE_PROBE firing on rejection

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_presence.c
+++ b/src/mod/endpoints/mod_sofia/sofia_presence.c
@@ -4325,7 +4325,6 @@ void sofia_presence_handle_sip_i_subscribe(int status,
 		switch_event_fire(&event);
 	}
 
- end:
 
 	if (strcasecmp(event, "call-info") && strcasecmp(event, "line-seize")) {
 
@@ -4406,6 +4405,8 @@ void sofia_presence_handle_sip_i_subscribe(int status,
 			}
 		}
 	}
+
+ end:
 
 	if (event) {
 		su_free(nua_handle_get_home(nh), event);


### PR DESCRIPTION
After rejecting the subscription for authentication the function calls goto end. In the end block freeswitch fires PRESENCE_PROBE events and releases the allocated memory
* when rejecting a call for auth PRESENCE_PROBE should not get fired
* This caused all other subscribers to the same entity to get flooded with NOTIFY's because `call_id` only gets set later in the function, so when firing the PRESENCE_PROBE without `call_id` being set all subscriptions will get a notify
* this can be considered a security flaw as any unauthorized user can send
SUBSCRIBES and trigger thousands of NOTIFY's to the SUBSCRIBED endpoints

This was fixed simply my moving down the end label after the code that
sends the PRESENCE_PROBE event