### PR TITLE
mod_curl: add option to force only ipv4 or ipv6 name resolving

### DIFF
--- a/src/mod/applications/mod_curl/mod_curl.c
+++ b/src/mod/applications/mod_curl/mod_curl.c
@@ -50,7 +50,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_curl_load);
  */
 SWITCH_MODULE_DEFINITION(mod_curl, mod_curl_load, mod_curl_shutdown, NULL);
 
-static char *SYNTAX = "curl url [headers|json|content-type <mime-type>|connect-timeout <seconds>|timeout <seconds>|append_headers <header_name:header_value>[|append_headers <header_name:header_value>]|insecure|secure|[proxy <http://proxy:port>]] [get|head|post|delete|put [data]]";
+static char *SYNTAX = "curl url [headers|json|content-type <mime-type>|connect-timeout <seconds>|timeout <seconds>|append_headers <header_name:header_value>[|append_headers <header_name:header_value>]|insecure|secure|[proxy <http://proxy:port>]|ipv4|ipv6] [get|head|post|delete|put [data]]";
 
 #define HTTP_SENDFILE_ACK_EVENT "curl_sendfile::ack"
 #define HTTP_SENDFILE_RESPONSE_SIZE 32768
@@ -129,6 +129,8 @@ struct curl_options_obj {
 	long connect_timeout;
 	long timeout;
 	int insecure;
+	int ipv4;
+	int ipv6;
 	char *proxy;
 };
 typedef struct curl_options_obj curl_options_t;
@@ -206,6 +208,14 @@ static http_data_t *do_lookup_url(switch_memory_pool_t *pool, const char *url, c
 
 	if (options->timeout) {
 		switch_curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, options->timeout);
+	}
+
+	if (options->ipv4) {
+		switch_curl_easy_setopt(curl_handle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+	}
+
+	if (options->ipv6) {
+		switch_curl_easy_setopt(curl_handle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
 	}
 
 	if (options->proxy) {
@@ -894,6 +904,10 @@ SWITCH_STANDARD_APP(curl_app_function)
 				if (++i < argc) {
 					options.proxy = argv[i];
 				}
+			} else if (!strcasecmp("ipv4", argv[i])) {
+				options.ipv4 = 1;
+			} else if (!strcasecmp("ipv6", argv[i])) {
+				options.ipv6 = 1;
 			}
 		}
 	}
@@ -1034,6 +1048,10 @@ SWITCH_STANDARD_API(curl_function)
 				if (++i < argc) {
 					options.proxy = argv[i];
 				}
+			} else if (!strcasecmp("ipv4", argv[i])) {
+				options.ipv4 = 1;
+			} else if (!strcasecmp("ipv6", argv[i])) {
+				options.ipv6 = 1;
 			}
 		}
 


### PR DESCRIPTION
when using curl by default it will resolve ipv4 and ipv6 address even if network ipv6 is disable. 

freeswitch@debian> curl google.com
TCPDUMP: 
13:18:36.329927 IP 192.168.10.182.51569 > 192.168.10.1.53: 54763+ A? google.com. (28)
13:18:36.329968 IP 192.168.10.182.51569 > 192.168.10.1.53: 34035+ AAAA? google.com. (28)
13:18:36.358794 IP 192.168.10.1.53 > 192.168.10.182.51569: 54763 1/0/0 A 142.250.200.110 (44)
13:18:36.358817 IP 192.168.10.1.53 > 192.168.10.182.51569: 34035 1/0/0 AAAA 2a00:1450:4003:80e::200e (56)
13:18:36.585177 IP 192.168.10.182.41783 > 192.168.10.1.53: 180+ A? www.google.com. (32)
13:18:36.585209 IP 192.168.10.182.41783 > 192.168.10.1.53: 24763+ AAAA? www.google.com. (32)
13:18:36.614905 IP 192.168.10.1.53 > 192.168.10.182.41783: 180 1/0/0 A 142.250.201.68 (48)
13:18:36.614929 IP 192.168.10.1.53 > 192.168.10.182.41783: 24763 1/0/0 AAAA 2a00:1450:4003:811::2004 (60)

after this commit we can force to resolve only ipv4 or ipv6 address.

freeswitch@debian> curl google.com ipv4
TCPDUMP:
13:20:21.586135 IP 192.168.10.182.33849 > 192.168.10.1.53: 15427+ A? google.com. (28)
13:20:21.614864 IP 192.168.10.1.53 > 192.168.10.182.33849: 15427 1/0/0 A 142.250.200.110 (44)
13:20:21.831889 IP 192.168.10.182.55731 > 192.168.10.1.53: 61998+ A? www.google.com. (32)
13:20:21.861427 IP 192.168.10.1.53 > 192.168.10.182.55731: 61998 1/0/0 A 142.250.201.68 (48)


freeswitch@debian> curl google.com ipv6 
TCPDUMP:
13:21:11.682411 IP 192.168.10.182.40544 > 192.168.10.1.53: 56884+ AAAA? google.com. (28)
13:21:11.712069 IP 192.168.10.1.53 > 192.168.10.182.40544: 56884 1/0/0 AAAA 2a00:1450:4003:80e::200e (56)

