### PR TITLE
[mod_sofia] Fix sip_invite_to_uri without host

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -1327,7 +1327,7 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 			invite_contact = sofia_overcome_sip_uri_weakness(session, tech_pvt->invite_contact, tech_pvt->transport, SWITCH_FALSE, invite_contact_params, NULL);
 		}
 		from_str = sofia_overcome_sip_uri_weakness(session, invite_from_uri ? invite_from_uri : use_from_str, 0, SWITCH_TRUE, invite_from_params, NULL);
-		to_str = sofia_overcome_sip_uri_weakness(session, invite_to_uri ? invite_to_uri : tech_pvt->dest_to, 0, SWITCH_FALSE, invite_to_params, NULL);
+		to_str = sofia_overcome_sip_uri_weakness(session, tech_pvt->dest_to ? tech_pvt->dest_to : invite_to_uri, 0, SWITCH_FALSE, invite_to_params, NULL);
 
 		switch_channel_set_variable(channel, "sip_outgoing_contact_uri", invite_contact);
 


### PR DESCRIPTION
`sofia_outgoing_channel()` sets the `tech_pvt->dest_to` and handles if sip_invite_to_uri doesn't have the host part in it, but that was being overwritten in `sofia_glue_do_invite` that sets the to_str to the sip_invite_to_uri and overwrites the `tech_pvt->dest_to`

technically the whole ternary isn't needed as `tech_pvt->dest_to` is already being set in `sofia_outgoing_channel` and `tech_pvt->dest_to` will have the value of `sip_invite_to_uri` if it's set on the channel