### PR TITLE
 fix socket bind error under windows 

### DIFF
--- a/libs/esl/src/esl.c
+++ b/libs/esl/src/esl.c
@@ -747,6 +747,16 @@ ESL_DECLARE(esl_status_t) esl_listen_threaded(const char *host, esl_port_t port,
 	esl_status_t status = ESL_SUCCESS;
 	struct thread_handler *handler = NULL;
 
+#ifndef WIN32
+#else
+	WORD wVersionRequested = MAKEWORD(2, 0);
+	WSADATA wsaData;
+	int err = WSAStartup(wVersionRequested, &wsaData);
+	if (err != 0) {
+		return ESL_FAIL;
+	}
+#endif
+
 	if ((server_sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
 		return ESL_FAIL;
 	}


### PR DESCRIPTION
Function esl_listen_threaded cannot start correctly under windows. It lacked function WSAStartup.