### PR TITLE
Fixed remote SSRC

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -4281,7 +4281,7 @@ static switch_status_t check_ice(switch_media_handle_t *smh, switch_media_type_t
 				switch_channel_set_flag(smh->session->channel, CF_DTLS);
 
 			} else if (!engine->remote_ssrc && !strcasecmp(attr->a_name, "ssrc") && attr->a_value) {
-				engine->remote_ssrc = (uint32_t) atol(attr->a_value);
+				engine->remote_ssrc = (uint32_t) atoll(attr->a_value);
 
 				if (engine->rtp_session && engine->remote_ssrc) {
 					switch_rtp_set_remote_ssrc(engine->rtp_session, engine->remote_ssrc);


### PR DESCRIPTION
Changed `atol` to `atoll` to correctly read SSRC values above `2,147,483,647`.

According to the spec, SSRC is a 32-bit unsigned integer.  `atol` only supports $\pm$ `2,147,483,647` meaning when the client sends an SSRC above this, behaviour is undefined.

Spec:
https://www.rfc-editor.org/rfc/rfc3550.html#section-2.4