### PR TITLE
Update mod_sofia.c too long and incorrectly closed reason text.

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -509,6 +509,16 @@ switch_status_t sofia_on_hangup(switch_core_session_t *session)
 					switch_snprintf(reason, sizeof(reason), "SIP;cause=%d;text=\"%s\"", cause, switch_channel_cause2str(cause));
 				}
 			}
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "reason .[%s].\n", reason);
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "reason lg (%zu). cause %d \n", strlen(reason), cause);
+
+			if(strlen(reason) > 126 && strstr(reason, "text=\"") != NULL && reason[126] != '"') {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "avant reason .[%s].\n", reason);
+				reason[126] = '"';
+				reason[127] = 0;
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "apres reason .[%s].\n", reason);
+			}
 		}
 
 		if (switch_channel_test_flag(channel, CF_INTERCEPT) || cause == SWITCH_CAUSE_PICKED_OFF || cause == SWITCH_CAUSE_LOSE_RACE) {


### PR DESCRIPTION
Patch for too long and incorrectly closed reason text.

if the reason text field received is too long, the field is no longer correct.
Too long Reason header swallowed #1481
A leg not being closed down when B ends call #1293
if the reason text field received is too long, the field is no longer correct #1789

my apologies, I deleted this patch that I had already published, I give it back. sorry for my mishandling of github.
