### PR TITLE
Correct index to return the correct data

### DIFF
--- a/src/switch_utils.c
+++ b/src/switch_utils.c
@@ -4529,6 +4529,7 @@ SWITCH_DECLARE(char *)switch_html_strip(const char *str)
 		if (*p == '\n') {
 			x++;
 			if (x == 2) {
+				p++;
 				break;
 			}
 		} else if (x && (*p != '\r')) {


### PR DESCRIPTION
The switch_html_strip function incorrectly left a newline character. I put in an issue #1632 but figured I could just make the pull request.