### PR TITLE
[mod_sofia] add ext-tls-sip-port parameter

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -686,6 +686,7 @@ struct sofia_profile {
 	switch_port_t sip_port;
 	switch_port_t extsipport;
 	switch_port_t tls_sip_port;
+	switch_port_t ext_tls_sip_port;
 	char *tls_ciphers;
 	int tls_version;
 	unsigned int tls_timeout;

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -3381,6 +3381,7 @@ void *SWITCH_THREAD_FUNC sofia_profile_thread_run(switch_thread_t *thread, void 
 
 			if (sofia_test_pflag(profile, PFLAG_AUTO_ASSIGN_TLS_PORT) && !strcmp(via->v_protocol, "SIP/2.0/TLS")) {
 				profile->tls_sip_port = (switch_port_t)atoi(via->v_port);
+				if (!profile->ext_tls_sip_port) profile->ext_tls_sip_port = profile->tls_sip_port;
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Found auto sip port %d for %s (TLS)\n", profile->tls_sip_port, profile->name);
 			}
 
@@ -4174,14 +4175,14 @@ static void parse_gateways(sofia_profile_t *profile, switch_xml_t gateways_tag, 
 					gateway->register_contact = switch_core_sprintf(gateway->pool, format, extension,
 							sipip,
 							sofia_glue_transport_has_tls(gateway->register_transport) ?
-							profile->tls_sip_port : profile->extsipport, params, str_rfc_5626);
+							profile->ext_tls_sip_port : profile->extsipport, params, str_rfc_5626);
 
 				} else {
 					format = strchr(sipip, ':') ? "<sip:%s@[%s]:%d%s>" : "<sip:%s@%s:%d%s>";
 					gateway->register_contact = switch_core_sprintf(gateway->pool, format, extension,
 							sipip,
 							sofia_glue_transport_has_tls(gateway->register_transport) ?
-							profile->tls_sip_port : profile->extsipport, params);
+							profile->ext_tls_sip_port : profile->extsipport, params);
 				}
 			} else {
 				if (rfc_5626) {
@@ -4189,14 +4190,14 @@ static void parse_gateways(sofia_profile_t *profile, switch_xml_t gateways_tag, 
 					gateway->register_contact = switch_core_sprintf(gateway->pool, format, gateway->name,
 							sipip,
 							sofia_glue_transport_has_tls(gateway->register_transport) ?
-							profile->tls_sip_port : profile->extsipport, params, str_rfc_5626);
+							profile->ext_tls_sip_port : profile->extsipport, params, str_rfc_5626);
 
 				} else {
 					format = strchr(sipip, ':') ? "<sip:gw+%s@[%s]:%d%s>" : "<sip:gw+%s@%s:%d%s>";
 					gateway->register_contact = switch_core_sprintf(gateway->pool, format, gateway->name,
 							sipip,
 							sofia_glue_transport_has_tls(gateway->register_transport) ?
-							profile->tls_sip_port : profile->extsipport, params);
+							profile->ext_tls_sip_port : profile->extsipport, params);
 
 				}
 			}
@@ -4326,13 +4327,14 @@ static void config_sofia_profile_urls(sofia_profile_t * profile)
 		if (!profile->tls_sip_port && !sofia_test_pflag(profile, PFLAG_AUTO_ASSIGN_TLS_PORT)) {
 			profile->tls_sip_port = (switch_port_t) atoi(SOFIA_DEFAULT_TLS_PORT);
 		}
+		if (!profile->ext_tls_sip_port) profile->ext_tls_sip_port = profile->tls_sip_port;
 
 		if (profile->extsipip) {
 			char *ipv6 = strchr(profile->extsipip, ':');
 			profile->tls_public_url = switch_core_sprintf(profile->pool,
 														  "sip:%s@%s%s%s:%d",
 														  profile->contact_user,
-														  ipv6 ? "[" : "", profile->extsipip, ipv6 ? "]" : "", profile->tls_sip_port);
+														  ipv6 ? "[" : "", profile->extsipip, ipv6 ? "]" : "", profile->ext_tls_sip_port);
 		}
 
 		if (profile->extsipip && !sofia_test_pflag(profile, PFLAG_AUTO_NAT)) {
@@ -4340,7 +4342,7 @@ static void config_sofia_profile_urls(sofia_profile_t * profile)
 			profile->tls_url =
 				switch_core_sprintf(profile->pool,
 									"sip:%s@%s%s%s:%d",
-									profile->contact_user, ipv6 ? "[" : "", profile->extsipip, ipv6 ? "]" : "", profile->tls_sip_port);
+									profile->contact_user, ipv6 ? "[" : "", profile->extsipip, ipv6 ? "]" : "", profile->ext_tls_sip_port);
 			profile->tls_bindurl =
 				switch_core_sprintf(profile->pool,
 									"sips:%s@%s%s%s:%d;maddr=%s",
@@ -5875,6 +5877,10 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 							sofia_clear_pflag(profile, PFLAG_AUTO_ASSIGN_TLS_PORT);
 							profile->tls_sip_port = (switch_port_t) atoi(val);
 						}
+						if (!profile->ext_tls_sip_port) profile->ext_tls_sip_port = profile->tls_sip_port;
+					} else if (!strcasecmp(var, "ext-tls-sip-port") && val) {
+						int tmp = atoi(val);
+						if (tmp > 0) profile->ext_tls_sip_port = (switch_port_t)tmp;
 					} else if (!strcasecmp(var, "tls-cert-dir") && !zstr(val)) {
 						profile->tls_cert_dir = switch_core_strdup(profile->pool, val);
 					} else if (!strcasecmp(var, "tls-passphrase") && !zstr(val)) {
@@ -11040,7 +11046,7 @@ void sofia_handle_sip_i_invite(switch_core_session_t *session, nua_t *nua, sofia
 			if (sip->sip_contact->m_url->url_port) {
 				port = atoi(sip->sip_contact->m_url->url_port);
 			} else {
-				port = sofia_glue_transport_has_tls(transport) ? profile->tls_sip_port : profile->extsipport;
+				port = sofia_glue_transport_has_tls(transport) ? profile->ext_tls_sip_port : profile->extsipport;
 			}
 
 			ipv6 = strchr(host, ':');

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -768,7 +768,7 @@ const char *sofia_glue_transport2str(const sofia_transport_t tp)
 char *sofia_glue_create_external_via(switch_core_session_t *session, sofia_profile_t *profile, sofia_transport_t transport)
 {
 	return sofia_glue_create_via(session, profile->extsipip, (sofia_glue_transport_has_tls(transport))
-								 ? profile->tls_sip_port : profile->extsipport, transport);
+								 ? profile->ext_tls_sip_port : profile->extsipport, transport);
 }
 
 char *sofia_glue_create_via(switch_core_session_t *session, const char *ip, switch_port_t port, sofia_transport_t transport)
@@ -1310,7 +1310,7 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 
 				if (sofia_glue_transport_has_tls(tech_pvt->transport)) {
 					tech_pvt->invite_contact = switch_core_session_sprintf(session, "sip:%s@%s%s%s:%d", contact,
-																		   ipv6 ? "[" : "", ip_addr, ipv6 ? "]" : "", tech_pvt->profile->tls_sip_port);
+																		   ipv6 ? "[" : "", ip_addr, ipv6 ? "]" : "", tech_pvt->profile->ext_tls_sip_port);
 				} else {
 					tech_pvt->invite_contact = switch_core_session_sprintf(session, "sip:%s@%s%s%s:%d", contact,
 																		   ipv6 ? "[" : "", ip_addr, ipv6 ? "]" : "", tech_pvt->profile->extsipport);


### PR DESCRIPTION
Right now, mod sofia tls support honors external ip, but there's no param to set an external port for tls like is present for udp/tcp.

This patch add a new ext-tls-sip-port parameter that allows to specify an external tls port.