### PR TITLE
add ability to read queue configuration settings from a database

### DIFF
--- a/src/mod/applications/mod_callcenter/conf/autoload_configs/callcenter.conf.xml
+++ b/src/mod/applications/mod_callcenter/conf/autoload_configs/callcenter.conf.xml
@@ -4,6 +4,8 @@
     <!--<param name="dbname" value="/dev/shm/callcenter.db"/>-->
     <!--<param name="reserve-agents" value="true"/>-->
     <!--<param name="cc-instance-id" value="single_box"/>-->
+    <!-- load queues from database as well as config -->
+    <!--<param name="cc-queue-db" value="true"/>-->
   </settings>
 
   <queues>


### PR DESCRIPTION
This allows you to tell the mod_callcenter config file to look in the defined database for a `queues` table and load the queue settings from there.