### PR TITLE
[mod_logfile] Continue renaming if a logfile doesn't exist

### DIFF
--- a/src/mod/loggers/mod_logfile/mod_logfile.c
+++ b/src/mod/loggers/mod_logfile/mod_logfile.c
@@ -163,8 +163,9 @@ static switch_status_t mod_logfile_rotate(logfile_profile_t *profile)
 			if ((status = switch_file_rename(from_filename, to_filename, pool)) != SWITCH_STATUS_SUCCESS) {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Error renaming log from %s to %s [%s]\n",
 								  from_filename, to_filename, strerror(errno));
-				if (errno != ENOENT)
+				if (errno != ENOENT) {
 					goto end;
+				}
 			}
 		}
 

--- a/src/mod/loggers/mod_logfile/mod_logfile.c
+++ b/src/mod/loggers/mod_logfile/mod_logfile.c
@@ -163,7 +163,8 @@ static switch_status_t mod_logfile_rotate(logfile_profile_t *profile)
 			if ((status = switch_file_rename(from_filename, to_filename, pool)) != SWITCH_STATUS_SUCCESS) {
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Error renaming log from %s to %s [%s]\n",
 								  from_filename, to_filename, strerror(errno));
-				goto end;
+				if (errno != ENOENT)
+					goto end;
 			}
 		}
 


### PR DESCRIPTION
this prevents a scenario where freeswitch.log fails to get rotated and eventually fills up the hard drive causing a crash. See issue #1738