### PR TITLE
[core] fix segfault when switch_channel_get_private gets a NULL value

### DIFF
--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -1081,6 +1081,9 @@ SWITCH_DECLARE(switch_status_t) switch_channel_set_private(switch_channel_t *cha
 SWITCH_DECLARE(void *) switch_channel_get_private(switch_channel_t *channel, const char *key)
 {
 	void *val;
+	if (!key) {
+		return NULL;
+	}
 	switch_assert(channel != NULL);
 	val = switch_core_hash_find_locked(channel->private_hash, key, channel->profile_mutex);
 	return val;


### PR DESCRIPTION
When `switch_channel_get_private` gets a NULL value, it will segfault at https://github.com/signalwire/freeswitch/blob/master/src/include/switch_hashtable.h#L230