### PR TITLE
Fix misplaced brackets inside ifs with assignment + comparison

### DIFF
--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -515,7 +515,7 @@ SWITCH_DECLARE(switch_status_t) switch_channel_queue_dtmf(switch_channel_t *chan
 		switch_set_flag((&new_dtmf), DTMF_FLAG_SENSITIVE);
 	}
 
-	if ((status = switch_core_session_recv_dtmf(channel->session, dtmf) != SWITCH_STATUS_SUCCESS)) {
+	if ((status = switch_core_session_recv_dtmf(channel->session, dtmf)) != SWITCH_STATUS_SUCCESS) {
 		goto done;
 	}
 

--- a/src/switch_ivr.c
+++ b/src/switch_ivr.c
@@ -4318,7 +4318,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_create_message_reply(switch_event_t *
 {
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-	if ((status = switch_event_dup_reply(reply, message) != SWITCH_STATUS_SUCCESS)) {
+	if ((status = switch_event_dup_reply(reply, message)) != SWITCH_STATUS_SUCCESS) {
 		abort();
 	}
 


### PR DESCRIPTION
This fixes misplaced brackets in two occurrences of "if" with assignment + comparison.
I don't think this would be important functionally but with misplaced brackets all non-success statuses were changed to 1 = SWITCH_STATUS_FALSE.