### PR TITLE
[Core] ICE: fix wrong buffer size being passed and unitialized buffer

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -4764,11 +4764,12 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_activate_ice(switch_rtp_t *rtp_sessio
 	if ((type & ICE_VANILLA)) {
 		switch_snprintf(ice_user, sizeof(ice_user), "%s:%s", login, rlogin);
 		switch_snprintf(user_ice, sizeof(user_ice), "%s:%s", rlogin, login);
-		switch_snprintf(luser_ice, sizeof(user_ice), "%s%s", rlogin, login);
+		switch_snprintf(luser_ice, sizeof(luser_ice), "%s%s", rlogin, login);
 		ice->ready = ice->rready = 0;
 	} else {
 		switch_snprintf(ice_user, sizeof(ice_user), "%s%s", login, rlogin);
 		switch_snprintf(user_ice, sizeof(user_ice), "%s%s", rlogin, login);
+		switch_snprintf(luser_ice, sizeof(luser_ice), "");
 		ice->ready = ice->rready = 1;
 	}
 


### PR DESCRIPTION
Wrong buffer size (and larger than the available memory size, 513 instead of 256) is passed when filling luser_ice in snprintf.
If ICE type is other than ICE_VANILLA then luser_ice buffer is unitialized when it is passed to strdup. I've filled it with empty string here, but I'm not sure if this is functionally correct for all the cases.