### PR TITLE
[mod_event_multicast] Few fixes

### DIFF
--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
@@ -293,12 +293,12 @@ static switch_status_t initialize_sockets(switch_xml_t input_cfg)
 		char *host_string;
 		char ipv6_first_octet[3];
 
-		memset(&globals.dst_sockaddrs[globals.num_dst_addrs].sockaddr, 0, sizeof(dst_sockaddr_t));
-
 		if (globals.num_dst_addrs > MAX_DST_HOSTS) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Cannot add destination address: %s, exceeded maximum of %d\n", dst_hosts[i], MAX_DST_HOSTS);
 			continue;
 		}
+
+		memset(&globals.dst_sockaddrs[globals.num_dst_addrs].sockaddr, 0, sizeof(dst_sockaddr_t));
 
 		if (switch_sockaddr_info_get(&globals.dst_sockaddrs[globals.num_dst_addrs].sockaddr, dst_hosts[i], SWITCH_UNSPEC, globals.port, 0, module_pool) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Cannot find address: %s\n", dst_hosts[i]);

--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
@@ -293,7 +293,7 @@ static switch_status_t initialize_sockets(switch_xml_t input_cfg)
 		char *host_string;
 		char ipv6_first_octet[3];
 
-		if (globals.num_dst_addrs > MAX_DST_HOSTS) {
+		if (globals.num_dst_addrs >= MAX_DST_HOSTS) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Cannot add destination address: %s, exceeded maximum of %d\n", dst_hosts[i], MAX_DST_HOSTS);
 			continue;
 		}

--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
@@ -298,7 +298,7 @@ static switch_status_t initialize_sockets(switch_xml_t input_cfg)
 			continue;
 		}
 
-		memset(&globals.dst_sockaddrs[globals.num_dst_addrs].sockaddr, 0, sizeof(dst_sockaddr_t));
+		memset(&globals.dst_sockaddrs[globals.num_dst_addrs], 0, sizeof(dst_sockaddr_t));
 
 		if (switch_sockaddr_info_get(&globals.dst_sockaddrs[globals.num_dst_addrs].sockaddr, dst_hosts[i], SWITCH_UNSPEC, globals.port, 0, module_pool) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Cannot find address: %s\n", dst_hosts[i]);

--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
@@ -627,8 +627,8 @@ static void event_handler(switch_event_t *event)
 					len = strlen(packet) + strlen((char *) MAGIC);
 #endif
 					buf = malloc(len + 1);
-					memset(buf, 0, len + 1);
 					switch_assert(buf);
+					memset(buf, 0, len + 1);
 
 #ifdef HAVE_OPENSSL
 					if (globals.psk) {

--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
@@ -777,7 +777,11 @@ static switch_status_t process_packet(char* packet, size_t len)
 				switch_url_decode(val);
 				switch_snprintf(tmpname, sizeof(tmpname), "Orig-%s", var);
 				switch_event_add_header_string(local_event, SWITCH_STACK_BOTTOM, tmpname, val);
-				var = term + 1;
+				if (term) {
+					var = term + 1;
+				} else {
+					var = NULL;
+				}
 			} else {
 				/* This should be our magic packet, done processing incoming headers */
 				break;


### PR DESCRIPTION
The important one might be related to derefencing invalid pointer (crashing) when specific message is received (example: ":" followed by MAGIC and followed by some filler).

I've attached simple Win32 tool to reproduce this. It is pre-filled by default with multicast address - this worked in my test with Linux FS, but for Windows I had to use unicast address. I have not investigated it further yet, it might be my local issue.

Same tool can be used to trigger another issue, related to empty UDP packet being received (https://github.com/signalwire/freeswitch/issues/1884).

[Win32 UdpSender.zip](https://github.com/signalwire/freeswitch/files/10144236/UdpSender.zip)
