### PR TITLE
[mod_say_fa] Fixes saying current time when minutes is zero in persian say module 

### DIFF
--- a/src/mod/say/mod_say_fa/mod_say_fa.c
+++ b/src/mod/say/mod_say_fa/mod_say_fa.c
@@ -409,8 +409,12 @@ static switch_status_t fa_say_time(switch_core_session_t *session, char *tosay, 
 		}
 
 		say_file("time/hour-e.wav");
-		say_file("digits/%do.wav",hour);
-		play_group(SSM_PRONOUNCED, 0, (tm.tm_min - tm.tm_min % 10) / 10, tm.tm_min % 10, "time/minutes-e.wav", session, args);
+		if (tm.tm_min == 0) {
+			say_file("digits/%d.wav",hour);
+		} else {
+			say_file("digits/%do.wav",hour);
+			play_group(SSM_PRONOUNCED, 0, (tm.tm_min - tm.tm_min % 10) / 10, tm.tm_min % 10, "time/minutes-e.wav", session, args);
+		}
 		say_file("time/%s.wav", pm ? "p-m" : "a-m");
 	}
 


### PR DESCRIPTION
When minute of the current time is zero, saying time in persian (farsi) is like this

It's eight and pm

This change will fix it to say the sentence in the right way:

It's eight pm