### PR TITLE
[mod_ladspa] Added activate/deactivate support.

### DIFF
--- a/src/mod/applications/mod_ladspa/mod_ladspa.c
+++ b/src/mod/applications/mod_ladspa/mod_ladspa.c
@@ -370,6 +370,11 @@ static switch_bool_t ladspa_callback(switch_media_bug_t *bug, void *user_data, s
 					}
 				}
 			}
+
+			if (pvt->ldesc->activate) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(pvt->session), SWITCH_LOG_DEBUG, "ACTIVATE\n");
+				pvt->ldesc->activate(pvt->handle);
+			}
 		}
 
 		break;
@@ -382,6 +387,10 @@ static switch_bool_t ladspa_callback(switch_media_bug_t *bug, void *user_data, s
 			}
 
 			if (pvt->handle && pvt->ldesc) {
+				if (pvt->ldesc->deactivate) {
+					pvt->ldesc->deactivate(pvt->handle);
+				}
+
 				pvt->ldesc->cleanup(pvt->handle);
 			}
 


### PR DESCRIPTION
Without these -- especially activate() -- stateful plugins will not be set up correctly.

For example, the low-pass filter "lpf" in the CMT library may produce a pop when starting since its state is not zeroed out.

Fixes #1899 