### PR TITLE
mod_av: Handle deprecated av_init_packet() in ffmpeg's api

### DIFF
--- a/src/mod/applications/mod_av/avcodec.c
+++ b/src/mod/applications/mod_av/avcodec.c
@@ -1511,7 +1511,7 @@ static switch_status_t switch_h264_encode(switch_codec_t *codec, switch_frame_t 
 		switch_set_flag(frame, SFF_WAIT_KEY_FRAME);
 	}
 
-	av_init_packet(pkt);
+	av_packet_unref(pkt);	//setup sane default paramters
 	pkt->data = NULL;      // packet data will be allocated by the encoder
 	pkt->size = 0;
 
@@ -1702,22 +1702,22 @@ static switch_status_t switch_h264_decode(switch_codec_t *codec, switch_frame_t 
 
 	if (frame->m) {
 		uint32_t size = switch_buffer_inuse(context->nalu_buffer);
-		AVPacket pkt = { 0 };
+		AVPacket* pkt;
 		AVFrame *picture;
 		int got_picture = 0;
 		int decoded_len;
 
 		if (size > 0) {
-			av_init_packet(&pkt);
+			pkt = av_packet_alloc();
 			switch_buffer_zero_fill(context->nalu_buffer, AV_INPUT_BUFFER_PADDING_SIZE);
-			switch_buffer_peek_zerocopy(context->nalu_buffer, (const void **)&pkt.data);
-			pkt.size = size;
+			switch_buffer_peek_zerocopy(context->nalu_buffer, (const void **)pkt->data);
+			pkt->size = size;
 
 			if (!context->decoder_avframe) context->decoder_avframe = av_frame_alloc();
 			picture = context->decoder_avframe;
 			switch_assert(picture);
 GCC_DIAG_OFF(deprecated-declarations)
-			decoded_len = avcodec_decode_video2(avctx, picture, &got_picture, &pkt);
+			decoded_len = avcodec_decode_video2(avctx, picture, &got_picture, pkt);
 GCC_DIAG_ON(deprecated-declarations)
 
 			// switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "buffer: %d got pic: %d len: %d [%dx%d]\n", size, got_picture, decoded_len, picture->width, picture->height);
@@ -1745,6 +1745,7 @@ GCC_DIAG_ON(deprecated-declarations)
 			}
 
 			av_frame_unref(picture);
+			av_packet_free(&pkt);
 		}
 
 		switch_buffer_zero(context->nalu_buffer);


### PR DESCRIPTION
Ffmpeg deprecated `av_init_packet` in 2021 (see [https://github.com/FFmpeg/FFmpeg/commit/f7db77bd8785d1715d3e7ed7e69bd1cc991f2d07](https://github.com/signalwire/freeswitch/pull/url)). 

In deprecating `av_init_packet`, it is now clumsy to store `AVPacket`s on the stack; which is how mod_av has mostly stored them.

avcodec: AVPacket kept within struct: `h264_codec_context_t`; otherwise it's not easy to predict when and where memory will need to be freed. 
avformat: Changes made to try and safely manage heap storage within loops and under a variety of exit conditions. 

This pull request is required for compatibility with Ubuntu 22.04

(attempt #2)