### PR TITLE
[mod_sofia] Ignore user agent for display update when channel variable update_ignore_ua is true

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -2065,7 +2065,8 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 
 							nua_info(tech_pvt->nh, SIPTAG_CONTENT_TYPE_STR("message/sipfrag"),
 									 TAG_IF(!zstr(tech_pvt->user_via), SIPTAG_VIA_STR(tech_pvt->user_via)), SIPTAG_PAYLOAD_STR(message), TAG_END());
-						} else if (update_allowed && ua && (switch_stristr("polycom", ua) ||
+						} else if (update_allowed && ua && (switch_channel_var_true(tech_pvt->channel, "update_ignore_ua") ||
+									  switch_stristr("polycom", ua) ||
 									  (switch_stristr("aastra", ua) && !switch_stristr("Intelligate", ua)) ||
 									  (switch_stristr("cisco/spa50", ua) ||
 									  switch_stristr("cisco/spa525", ua)) ||


### PR DESCRIPTION
This allows a channel variable to force display update support for unsupported user agents. 

Example: We have a new mobile app that has a user-agent that is not currently in the freeswitch code to send display updates in situations such as call park pickup. 
We add to our dialplan 
```	
<condition field="${sip_user_agent}" expression="NewSoftphone">
	<action application="set" data="update_ignore_ua=true"/>
</condition>
```

Benefit: 

This has the huge benefit of not requiring a re-compile of freeswitch for every user agent we want to support for display update, we can simply handle new supported user agents in our applications or dialplans.