### PR TITLE
[core] switch_ivr_originate set originate endpoint used

### DIFF
--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -3215,6 +3215,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 						l_session = NULL;
 					}
 
+					switch_channel_set_variable(oglobals.originate_status[i].peer_channel, "originate_endpoint", chan_type);
 					switch_channel_execute_on(oglobals.originate_status[i].peer_channel, SWITCH_CHANNEL_EXECUTE_ON_ORIGINATE_VARIABLE);
 					switch_channel_api_on(oglobals.originate_status[i].peer_channel, SWITCH_CHANNEL_API_ON_ORIGINATE_VARIABLE);
 				}


### PR DESCRIPTION
This commit introduces a new channel variable that sets the channel endpoint used by the originate. This is particulary useful when using `execute_on_originate` that will execute multiple times when using fake endpoints as `user/` or `group/`. With this variable, a user can determine which endpoint is being used by the originate, and whether they want to process it.