### PR TITLE
Fix signalwire/freeswitch#1965 where received audio payload is misinterpreted as DTMF

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -10387,7 +10387,7 @@ SWITCH_DECLARE(void) switch_core_media_gen_local_sdp(switch_core_session_t *sess
 															 imp->iananame, imp->samples_per_second, smh->fmtp[i], &orig_pt, NULL, &orig_fmtp) == SWITCH_STATUS_SUCCESS) {
 
 						if (orig_pt == smh->mparams->te) {
-							smh->mparams->te  = (switch_payload_t)smh->payload_space++;
+							smh->mparams->recv_te = smh->mparams->te  = (switch_payload_t)smh->payload_space++;
 						}
 
 						smh->ianacodes[i] = orig_pt;


### PR DESCRIPTION
This fixes an issue with one-sided audio from A to B, where the audio from B is misinterpreted by FreeSWITCH as DTMF (signalwire/freeswitch#1965).

As mentioned in the issue, the problem stems from a misbehaviour where FreeSWITCH sets up telephone-event to be received with a payload type which is already in use for the OPUS audio stream.

This commit solves the issue by setting `smh->mparams->recv_te` in the same manner as `smh->mparams->te`, respecting the payload space.