### PR TITLE
added 180 and 183 to mod_sofia.c for mod_dptools: respond  

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -725,7 +725,7 @@ static switch_status_t sofia_answer_channel(switch_core_session_t *session)
 
 		if (switch_channel_test_flag(tech_pvt->channel, CF_PROXY_MEDIA)) {
 			sofia_media_activate_rtp(tech_pvt);
-			switch_core_media_patch_sdp(tech_pvt->session);			
+			switch_core_media_patch_sdp(tech_pvt->session);
 			switch_core_media_proxy_remote_addr(tech_pvt->session, NULL);
 		}
 
@@ -1290,7 +1290,7 @@ static switch_status_t sofia_send_dtmf(switch_core_session_t *session, const swi
 	switch_assert(tech_pvt != NULL);
 
 	switch_core_media_check_dtmf_type(session);
-	
+
 	dtmf_type = tech_pvt->mparams.dtmf_type;
 
 	/* We only can send INFO when we have no media */
@@ -1837,7 +1837,7 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 				full_to = switch_str_nil(switch_channel_get_variable(channel, "sip_full_to"));
 				nua_notify(tech_pvt->nh, NUTAG_NEWSUB(1), NUTAG_SUBSTATE(nua_substate_active),
 						   TAG_IF((full_to), SIPTAG_TO_STR(full_to)),SIPTAG_SUBSCRIPTION_STATE_STR("active"),
-						   SIPTAG_EVENT_STR(event), 
+						   SIPTAG_EVENT_STR(event),
 						   TAG_IF(!zstr(session_id_header), SIPTAG_HEADER_STR(session_id_header)),
 						   TAG_END());
 			}
@@ -1968,8 +1968,8 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 				ref_to = switch_mprintf("<sip:%s@%s?Replaces=%s>", to_user, to_host, out);
 				ref_by = switch_mprintf("<sip:%s@%s>", from_user, from_host);
 
-				nua_refer(tech_pvt->nh, SIPTAG_REFER_TO_STR(ref_to), SIPTAG_REFERRED_BY_STR(ref_by), 
-						TAG_IF(!zstr(session_id_header), SIPTAG_HEADER_STR(session_id_header)), 
+				nua_refer(tech_pvt->nh, SIPTAG_REFER_TO_STR(ref_to), SIPTAG_REFERRED_BY_STR(ref_by),
+						TAG_IF(!zstr(session_id_header), SIPTAG_HEADER_STR(session_id_header)),
 						TAG_END());
 				switch_safe_free(ref_to);
 				switch_safe_free(ref_by);
@@ -2260,7 +2260,7 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 
 				switch_core_session_local_crypto_key(tech_pvt->session, SWITCH_MEDIA_TYPE_AUDIO);
 				switch_core_media_gen_local_sdp(session, SDP_TYPE_RESPONSE, NULL, 0, NULL, 0);
-						
+
 				if (sofia_use_soa(tech_pvt)) {
 					nua_respond(tech_pvt->nh, SIP_200_OK,
 								SIPTAG_CONTACT_STR(tech_pvt->reply_contact),
@@ -2410,7 +2410,7 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 							}
 						} else {
 							if (msg->numeric_arg && !(switch_channel_test_flag(channel, CF_ANSWERED) && code == 488)) {
-								if (code > 399) {
+								if (code == 180 || code == 183 || code > 399) {
 									switch_call_cause_t cause = sofia_glue_sip_cause_to_freeswitch(code);
 									if (code == 401 || cause == 407) cause = SWITCH_CAUSE_USER_CHALLENGE;
 
@@ -5275,7 +5275,7 @@ static int notify_csta_callback(void *pArg, int argc, char **argv, char **column
 
 	nua_notify(nh, NUTAG_NEWSUB(1),
 			   TAG_IF(dst->route_uri, NUTAG_PROXY(route_uri)), TAG_IF(dst->route, SIPTAG_ROUTE_STR(dst->route)), TAG_IF(call_id, SIPTAG_CALL_ID_STR(call_id)),
-			   SIPTAG_EVENT_STR("as-feature-event"), SIPTAG_CONTENT_TYPE_STR(ct), TAG_IF(!zstr(extra_headers), SIPTAG_HEADER_STR(extra_headers)), TAG_IF(!zstr(body), SIPTAG_PAYLOAD_STR(body)), SIPTAG_CSEQ(cseq), 
+			   SIPTAG_EVENT_STR("as-feature-event"), SIPTAG_CONTENT_TYPE_STR(ct), TAG_IF(!zstr(extra_headers), SIPTAG_HEADER_STR(extra_headers)), TAG_IF(!zstr(body), SIPTAG_PAYLOAD_STR(body)), SIPTAG_CSEQ(cseq),
 			   TAG_END());
 
 
@@ -5427,7 +5427,7 @@ void general_event_handler(switch_event_t *event)
 							   NUTAG_NEWSUB(1), TAG_IF(sip_sub_st, SIPTAG_SUBSCRIPTION_STATE_STR(sip_sub_st)),
 							   TAG_IF(dst->route_uri, NUTAG_PROXY(dst->route_uri)), TAG_IF(dst->route, SIPTAG_ROUTE_STR(dst->route)), TAG_IF(call_id, SIPTAG_CALL_ID_STR(call_id)),
 							   SIPTAG_EVENT_STR(es), SIPTAG_CONTENT_TYPE_STR(ct), TAG_IF(!zstr(body), SIPTAG_PAYLOAD_STR(body)),
-							   TAG_IF(!zstr(extra_headers), SIPTAG_HEADER_STR(extra_headers)), 
+							   TAG_IF(!zstr(extra_headers), SIPTAG_HEADER_STR(extra_headers)),
 							   TAG_END());
 
 					switch_safe_free(route_uri);
@@ -6903,8 +6903,8 @@ void mod_sofia_shutdown_cleanup() {
 
 	su_deinit();
 
-	/* 
-		Release the clone of the default SIP parser 
+	/*
+		Release the clone of the default SIP parser
 		created by `sip_update_default_mclass(sip_extend_mclass(NULL))` call with NULL argument
 	*/
 	sip_cloned_parser_destroy();


### PR DESCRIPTION
We encountered an issues that the ability to trigger ad-hoc 180 & 183 Ringing back to a SIP Devices was not possible. Once the initial 180 `ring_ready` had been sent from FS to the SIP Device any subsequent attempts to trigger another ad-hoc 180 using `ring_ready` although received by FS did not trigger the relevant SIP messaging. The next 180 SIP Messages is triggered by a timer.

In our build of FS & ESL the use case for this is when a call-forward no answer kicks in, another 180 Ringing is needed to be sent back to the SIP Device with updated headers `sip_ph_` to inform them of the new ringing location.

This has been tested and working as needed in our build. THis is purely around the trigger of an ad-hoc SIP Message for 180/183 and is to be used in conjunction with `ring_ready` & `pre_answer`

** I did noticed that in **mod_dptools: respond** there was a notice advising this functionality had been removed (See link below) however the details where limited, for our use case and I am sure other peoples this is a very useful function. If there is a decision as to why this was removed please let me know the details so I can put a PR in to update the docs a with some information and guidance for other.

https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Modules/mod-dptools/6586984/#warnings