### PR TITLE
Update mod_sofia.c handling long bye reason

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -487,7 +487,7 @@ switch_status_t sofia_on_hangup(switch_core_session_t *session)
 	if (sofia_test_pflag(tech_pvt->profile, PFLAG_DESTROY)) {
 		sofia_set_flag(tech_pvt, TFLAG_BYE);
 	} else if (tech_pvt->nh && !sofia_test_flag(tech_pvt, TFLAG_BYE)) {
-		char reason[128] = "";
+		char reason[256] = "";
 		char *bye_headers = sofia_glue_get_extra_headers(channel, SOFIA_SIP_BYE_HEADER_PREFIX);
 		const char *val = NULL;
 		const char *max_forwards = switch_channel_get_variable(channel, SWITCH_MAX_FORWARDS_VARIABLE);


### PR DESCRIPTION
hello i recently starts a integration with msteams everything it's working,
 but when the reason is big the softswitch not sent  `bye` after enabling loglevel for nua i found `nua_stack.c:301 nua_stack_event() nua(0x7f430c014660): event r_bye 900 Internal error at nua_client.c:553` and after some research i found the `reason` was big
example:

~~~
sip::reason_str: "Q.850;cause=16;text="b5bc901e-8914-4b24-b457-488bb5c83738;Participant was removed from the conversation by another participant." 
~~~

so the `span_quoted` does not works correctly because not found the end "

after increasing `reason` to `256` now `bye` works ok.

another solution for the problems described in #1813

tested in 
~~~
FreeSWITCH (Version 1.10.10-dev git f5f7f76 2023-03-29 16:19:47Z 64bit)
~~~