### PR TITLE
[mod_png] Fix unexpected png video blocked read

### DIFF
--- a/src/mod/formats/mod_png/mod_png.c
+++ b/src/mod/formats/mod_png/mod_png.c
@@ -215,7 +215,7 @@ static switch_status_t png_file_read_video(switch_file_handle_t *handle, switch_
 		switch_goto_status(SWITCH_STATUS_FALSE, end);
 	}
 
-	if ((flags && SVR_BLOCK)) {
+	if ((flags & SVR_BLOCK)) {
 		switch_yield(33000);
 		have_frame = 1;
 	} else if ((context->reads++ % 20) == 0) {


### PR DESCRIPTION
### Issue 
During a conference call, a PNG file is played using the api:

`conference <conf-name> play {full-screen=true,png_ms=-1}/assets/image.png`

While this is active the conference participants experience choppy audio.

### Root cause

1 - FS skipping RTP timestamps in the member output streams.
2 - Because main conference thread was taking too long to acquire the `conference->file_mutex` at the end of its loop.
3 - `conference->file_mutex` was being locked by the conference muxing thread.
4 - conference muxing thread was trying to read a frame from the PNG file being played.
5 - Code typo in mod_png caused a "blocked" read to occur.

