### PR TITLE
Update phrase_en.xml

### DIFF
--- a/docs/phrase/phrase_en.xml
+++ b/docs/phrase/phrase_en.xml
@@ -579,7 +579,7 @@
       <prompt phrase="Man, that is cold foolish...COLD Foolish" filename="ivr-cold_foolish.wav"/>
       <prompt phrase="Congratulations! You've earned 1500 Trollover minutes this month!" filename="ivr-trollover_minutes.wav"/>
       <prompt phrase="Y U NO Silent Drill?!" filename="ivr-yuno_silent_drill.wav"/>
-      <prompt phrase="Beacuase, the voices where pretty good" filename="ivr-beacuase.wav"/>
+      <prompt phrase="Because, the voices where pretty good" filename="ivr-beacuase.wav"/>
       <prompt phrase="Day mode..." filename="ivr-day_mode.wav"/>
       <prompt phrase="Night mode..." filename="ivr-night_mode.wav"/>
       <prompt phrase="Lunch mode..." filename="ivr-lunch_mode.wav"/>


### PR DESCRIPTION
Fix a invalid word  Beacuase -> Because.
This issue causes garbled characters when the phrase is translated as Chinese.

BTW:
The correct meaning of this phrase is "Because, the voices where pretty good"  or  "Because, the voices were pretty good" ?