### PR TITLE
[mod_mariadb] Fix "DeadLock. The retries are over." message.

### DIFF
--- a/src/mod/databases/mod_mariadb/mod_mariadb.c
+++ b/src/mod/databases/mod_mariadb/mod_mariadb.c
@@ -627,13 +627,27 @@ switch_status_t mariadb_send_query(mariadb_handle_t *handle, const char* sql)
 {
 	char *err_str;
 	int ret;
+	unsigned retries = 60; /* 60 tries, will take 30 to 60 seconds at worst */
 
 	switch_safe_free(handle->sql);
 	handle->sql = strdup(sql);
+    again:
 	handle->stored_results = 0;
 	ret = mysql_real_query(&handle->con, sql, (unsigned long)strlen(sql));	
 	if (ret) {
 		err_str = mariadb_handle_get_error(handle);
+		if (strstr(err_str, "Deadlock found when trying to get lock; try restarting transaction")) {
+			if (--retries > 0) {
+				switch_safe_free(err_str);
+				/* We are waiting for 500 ms and random time is not more than 500 ms.
+				  This is necessary so that the delay on the primary and secondary servers does not coincide and deadlock does not occur again. */
+				switch_yield(500 + (rand() & 511));
+				goto again;
+			}
+
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "DeadLock. The retries are over.\n");
+		}
+
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Failed to send query (%s) to database: %s\n", sql, err_str);
 		switch_safe_free(err_str);
 		mariadb_finish_results(handle);


### PR DESCRIPTION
Fix DeadLock. https://github.com/signalwire/freeswitch/issues/2063
If the message "Deadlock found when trying to get lock; try restarting transaction" is specified, then 100 attempts are made to retry the SQL request.
If all attempts fail, the message "DeadLock. The retries are over." is displayed in the logs.