### PR TITLE
Replacement of all switch_true/switch_false on channel variable

### DIFF
--- a/src/include/switch_channel.h
+++ b/src/include/switch_channel.h
@@ -329,13 +329,18 @@ SWITCH_DECLARE(switch_status_t) switch_channel_get_variables(switch_channel_t *c
 SWITCH_DECLARE(switch_status_t) switch_channel_get_variables_prefix(switch_channel_t *channel, const char *prefix, switch_event_t **event);
 SWITCH_DECLARE(switch_status_t) switch_channel_pass_callee_id(switch_channel_t *channel, switch_channel_t *other_channel);
 
-static inline int switch_channel_var_false(switch_channel_t *channel, const char *variable) {
+/* This was added long after my patch... Caused conflict during a merge... I think it missing locking here which might cause issues
+static inline int switch_channel_var_false2(switch_channel_t *channel, const char *variable) {
 	return switch_false(switch_channel_get_variable_dup(channel, variable, SWITCH_FALSE, -1));
 }
+*/
+SWITCH_DECLARE(int) switch_channel_var_exist(switch_channel_t *channel, const char *variable);
 
-static inline int switch_channel_var_true(switch_channel_t *channel, const char *variable) {
-	return switch_true(switch_channel_get_variable_dup(channel, variable, SWITCH_FALSE, -1));
-}
+SWITCH_DECLARE(int) switch_channel_var_true(switch_channel_t *channel, const char *variable);
+SWITCH_DECLARE(int) switch_channel_var_true_or_default(switch_channel_t *channel, const char *variable, int default_if_not_set);
+
+SWITCH_DECLARE(int) switch_channel_var_false(switch_channel_t *channel, const char *variable);
+SWITCH_DECLARE(int) switch_channel_var_false_or_default(switch_channel_t *channel, const char *variable, int default_if_not_set);
 
 /*!
  * \brief Start iterating over the entries in the channel variable list.

--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -1973,7 +1973,7 @@ static void *SWITCH_THREAD_FUNC outbound_agent_thread_run(switch_thread_t *threa
 		switch_channel_set_variable(member_channel, "cc_agent_found", "true");
 		switch_channel_set_variable(member_channel, "cc_agent_uuid", agent_uuid);
 
-		if (switch_true(switch_channel_get_variable(member_channel, SWITCH_BYPASS_MEDIA_AFTER_BRIDGE_VARIABLE)) || switch_true(switch_channel_get_variable(agent_channel, SWITCH_BYPASS_MEDIA_AFTER_BRIDGE_VARIABLE))) {
+		if (switch_channel_var_true(member_channel, SWITCH_BYPASS_MEDIA_AFTER_BRIDGE_VARIABLE) || switch_channel_var_true(agent_channel, SWITCH_BYPASS_MEDIA_AFTER_BRIDGE_VARIABLE)) {
 			switch_channel_set_flag(member_channel, CF_BYPASS_MEDIA_AFTER_BRIDGE);
 		}
 
@@ -2708,7 +2708,7 @@ static int members_callback(void *pArg, int argc, char **argv, char **columnName
 			switch_channel_t *member_channel = switch_core_session_get_channel(member_session);
 			last_originated_call = switch_channel_get_variable(member_channel, "cc_last_originated_call");
 
-			if (last_originated_call && switch_channel_ready(member_channel) && ((long) local_epoch_time_now(NULL) < atoi(last_originated_call) + ring_progressively_delay) && !switch_true(switch_channel_get_variable(member_channel, "cc_agent_found"))) {
+			if (last_originated_call && switch_channel_ready(member_channel) && ((long) local_epoch_time_now(NULL) < atoi(last_originated_call) + ring_progressively_delay) && !switch_channel_var_true(member_channel, "cc_agent_found")) {
 				/* We wait for 500 ms here */
 				switch_yield(500000);
 				switch_core_session_rwunlock(member_session);
@@ -3010,7 +3010,6 @@ SWITCH_STANDARD_APP(callcenter_function)
 	char member_uuid[SWITCH_UUID_FORMATTED_LENGTH + 1] = "";
 	switch_bool_t agent_found = SWITCH_FALSE;
 	switch_bool_t moh_valid = SWITCH_TRUE;
-	const char *p;
 
 	if (!zstr(data)) {
 		mydata = switch_core_session_strdup(member_session, data);
@@ -3196,7 +3195,7 @@ SWITCH_STANDARD_APP(callcenter_function)
 		args.buflen = sizeof(h);
 
 		/* If the bridge didn't break the loop, break out now */
-		if ((p = switch_channel_get_variable(member_channel, "cc_agent_bridged")) && (agent_found = switch_true(p))) {
+		if ((agent_found = switch_channel_var_true(member_channel, "cc_agent_bridged"))) {
 			break;
 		}
 		/* If the member thread set a different reason, we monitor it so we can quit the wait */
@@ -3236,8 +3235,8 @@ SWITCH_STANDARD_APP(callcenter_function)
 	}
 
 	/* Make sure an agent was found, as we might break above without setting it */
-	if (!agent_found && (p = switch_channel_get_variable(member_channel, "cc_agent_found"))) {
-		agent_found = switch_true(p);
+	if (!agent_found) {
+		agent_found = switch_channel_var_true(member_channel, "cc_agent_found");
 	}
 
 	/* Stop member thread */

--- a/src/mod/applications/mod_commands/mod_commands.c
+++ b/src/mod/applications/mod_commands/mod_commands.c
@@ -3003,7 +3003,7 @@ SWITCH_STANDARD_API(transfer_function)
 				switch_core_session_t *tmp = tsession;
 				tsession = other_session;
 				other_session = NULL;
-				if (switch_true(switch_channel_get_variable(channel, "recording_follow_transfer"))) {
+				if (switch_channel_var_true(channel, "recording_follow_transfer")) {
 					switch_ivr_transfer_recordings(tmp, tsession);
 				}
 				switch_core_session_rwunlock(tmp);

--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -187,7 +187,7 @@ void conference_member_update_status_field(conference_member_t *member)
 			}
 
 			cJSON_AddItemToObject(video, "noRecover", cJSON_CreateBool(switch_channel_test_flag(member->channel, CF_NO_RECOVER)));
-			if (switch_true(switch_channel_get_variable_dup(member->channel, "video_screen_share", SWITCH_FALSE, -1))) {
+			if (switch_channel_var_true(member->channel, "video_screen_share")) {
 				cJSON_AddItemToObject(video, "screenShare", cJSON_CreateTrue());
 			}
 
@@ -774,7 +774,7 @@ switch_status_t conference_member_add(conference_obj_t *conference, conference_m
 
 		channel = switch_core_session_get_channel(member->session);
 
-		if (switch_true(switch_channel_get_variable_dup(member->channel, "video_second_screen", SWITCH_FALSE, -1))) {
+		if (switch_channel_var_true(member->channel, "video_second_screen")) {
 			conference_utils_member_set_flag(member, MFLAG_SECOND_SCREEN);
 		}
 
@@ -852,7 +852,7 @@ switch_status_t conference_member_add(conference_obj_t *conference, conference_m
 				member->video_role_id = switch_core_strdup(member->pool, var);
 			}
 
-			if ((var = switch_channel_get_variable(channel, "video_use_dedicated_encoder")) && switch_true(var)) {
+			if (switch_channel_var_true(channel, "video_use_dedicated_encoder")) {
 				conference_utils_member_set_flag_locked(member, MFLAG_NO_MINIMIZE_ENCODING);
 			}
 
@@ -900,7 +900,7 @@ switch_status_t conference_member_add(conference_obj_t *conference, conference_m
 
 		if (conference->count > 1) {
 			if (((conference->moh_sound || conference->tmp_moh_sound) && !conference_utils_test_flag(conference, CFLAG_WAIT_MOD)) ||
-				(conference_utils_test_flag(conference, CFLAG_WAIT_MOD) && !switch_true(switch_channel_get_variable(channel, "conference_permanent_wait_mod_moh")))) {
+				(conference_utils_test_flag(conference, CFLAG_WAIT_MOD) && !switch_channel_var_true(channel, "conference_permanent_wait_mod_moh"))) {
 				/* stop MoH if any */
 				conference_file_stop(conference, FILE_STOP_ASYNC);
 				conference_utils_clear_flag(conference, CFLAG_NO_MOH);
@@ -1328,7 +1328,7 @@ switch_status_t conference_member_del(conference_obj_t *conference, conference_m
 			|| (conference_utils_test_flag(conference, CFLAG_DYNAMIC) && (conference->count + conference->count_ghosts == 0))) {
 			conference_utils_set_flag(conference, CFLAG_DESTRUCT);
 		} else {
-			if (!switch_true(switch_channel_get_variable(channel, "conference_permanent_wait_mod_moh")) && conference_utils_test_flag(conference, CFLAG_WAIT_MOD)) {
+			if (!switch_channel_var_true(channel, "conference_permanent_wait_mod_moh") && conference_utils_test_flag(conference, CFLAG_WAIT_MOD)) {
 				/* Stop MOH if any */
 				conference_file_stop(conference, FILE_STOP_ASYNC);
 			}

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -793,7 +793,7 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 		if (!conference_utils_member_test_flag(imember, MFLAG_NOCHANNEL)) {
 			channel = switch_core_session_get_channel(imember->session);
 
-			if (!switch_false(switch_channel_get_variable(channel, "hangup_after_conference"))) {
+			if (!switch_channel_var_false(channel, "hangup_after_conference")) {
 				/* add this little bit to preserve the bridge cause code in case of an early media call that */
 				/* never answers */
 				if (conference_utils_test_flag(conference, CFLAG_ANSWERED)) {
@@ -1916,7 +1916,7 @@ SWITCH_STANDARD_APP(conference_function)
 	uint32_t *mid;
 
 	if (!switch_channel_test_app_flag_key("conference_silent", channel, CONF_SILENT_DONE) &&
-		(switch_channel_test_flag(channel, CF_RECOVERED) || switch_true(switch_channel_get_variable(channel, "conference_silent_entry")))) {
+		(switch_channel_test_flag(channel, CF_RECOVERED) || switch_channel_var_true(channel, "conference_silent_entry"))) {
 		switch_channel_set_app_flag_key("conference_silent", channel, CONF_SILENT_REQ);
 	}
 
@@ -2135,7 +2135,7 @@ SWITCH_STANDARD_APP(conference_function)
 						switch_channel_answer(channel);
 						switch_ivr_play_file(session, NULL, val, NULL);
 					}
-					if (!switch_false(switch_channel_get_variable(channel, "hangup_after_conference"))) {
+					if (!switch_channel_var_false(channel, "hangup_after_conference")) {
 						switch_channel_hangup(channel, SWITCH_CAUSE_NORMAL_CLEARING);
 					}
 					goto done;

--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -2400,7 +2400,7 @@ SWITCH_STANDARD_APP(sleep_function)
 		char buf[10];
 		switch_input_args_t args = { 0 };
 
-		if (switch_true(switch_channel_get_variable(channel, "sleep_eat_digits"))) {
+		if (switch_channel_var_true(channel, "sleep_eat_digits")) {
 			args.input_callback = on_dtmf;
 			args.buf = buf;
 			args.buflen = sizeof(buf);
@@ -2619,7 +2619,7 @@ void *SWITCH_THREAD_FUNC att_thread_run(switch_thread_t *thread, void *obj)
 	switch_channel_t *channel = switch_core_session_get_channel(session), *peer_channel = NULL;
 	const char *bond = NULL;
 	switch_core_session_t *b_session = NULL;
-	switch_bool_t follow_recording = switch_true(switch_channel_get_variable(channel, "recording_follow_attxfer"));
+	switch_bool_t follow_recording = switch_channel_var_true(channel, "recording_follow_attxfer");
 	const char *attxfer_cancel_key = NULL, *attxfer_hangup_key = NULL, *attxfer_conf_key = NULL;
 
 	att->running = 1;
@@ -3481,7 +3481,7 @@ SWITCH_STANDARD_APP(audio_bridge_function)
 {
 	switch_channel_t *caller_channel = switch_core_session_get_channel(session);
 	switch_core_session_t *peer_session = NULL;
-	const char *v_campon = NULL, *v_campon_retries, *v_campon_sleep, *v_campon_timeout, *v_campon_fallback_exten = NULL;
+	const char *v_campon_retries, *v_campon_sleep, *v_campon_timeout, *v_campon_fallback_exten = NULL;
 	switch_call_cause_t cause = SWITCH_CAUSE_NORMAL_CLEARING;
 	int campon_retries = 100, campon_timeout = 10, campon_sleep = 10, tmp, camping = 0, fail = 0, thread_started = 0;
 	struct camping_stake stake = { 0 };
@@ -3496,7 +3496,7 @@ SWITCH_STANDARD_APP(audio_bridge_function)
 		return;
 	}
 
-	if ((v_campon = switch_channel_get_variable(caller_channel, "campon")) && switch_true(v_campon)) {
+	if (switch_channel_var_true(caller_channel, "campon")) {
 		const char *cid_name = NULL;
 		const char *cid_number = NULL;
 
@@ -3573,7 +3573,7 @@ SWITCH_STANDARD_APP(audio_bridge_function)
 
 			if (!thread_started && fail && moh && !switch_channel_test_flag(caller_channel, CF_PROXY_MODE) &&
 				!switch_channel_test_flag(caller_channel, CF_PROXY_MEDIA) &&
-				!switch_true(switch_channel_get_variable(caller_channel, "bypass_media"))) {
+				!switch_channel_var_true(caller_channel, "bypass_media")) {
 				switch_threadattr_create(&thd_attr, switch_core_session_get_pool(session));
 				switch_threadattr_stacksize_set(thd_attr, SWITCH_THREAD_STACKSIZE);
 				stake.running = 1;
@@ -3644,8 +3644,8 @@ SWITCH_STANDARD_APP(audio_bridge_function)
 	} else {
 
 		switch_channel_t *peer_channel = switch_core_session_get_channel(peer_session);
-		if (switch_true(switch_channel_get_variable(caller_channel, SWITCH_BYPASS_MEDIA_AFTER_BRIDGE_VARIABLE)) ||
-			switch_true(switch_channel_get_variable(peer_channel, SWITCH_BYPASS_MEDIA_AFTER_BRIDGE_VARIABLE))) {
+		if (switch_channel_var_true(caller_channel, SWITCH_BYPASS_MEDIA_AFTER_BRIDGE_VARIABLE) ||
+			switch_channel_var_true(peer_channel, SWITCH_BYPASS_MEDIA_AFTER_BRIDGE_VARIABLE)) {
 			switch_channel_set_flag(caller_channel, CF_BYPASS_MEDIA_AFTER_BRIDGE);
 		}
 
@@ -4769,7 +4769,7 @@ SWITCH_STANDARD_APP(limit_function)
 
 	/* if this is an invalid backend, fallback to db backend */
 	/* TODO: remove this when we can! */
-	if (switch_true(switch_channel_get_variable(channel, "switch_limit_backwards_compat_flag")) &&
+	if (switch_channel_var_true(channel, "switch_limit_backwards_compat_flag") &&
 			!switch_loadable_module_get_limit_interface(backend)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Unknown backend '%s'.  To maintain backwards compatability, falling back on db backend and shifting argumens. Either update your diaplan to include the backend, fix the typo, or load the appropriate limit implementation module.\n", backend);
 		mydata = switch_core_session_sprintf(session, "db %s", data);
@@ -4827,7 +4827,7 @@ SWITCH_STANDARD_APP(limit_hash_function)
 	char *mydata = NULL;
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 
-	if (switch_true(switch_channel_get_variable(channel, "switch_limit_backwards_compat_flag"))) {
+	if (switch_channel_var_true(channel, "switch_limit_backwards_compat_flag")) {
 		mydata = switch_core_session_sprintf(session, "hash %s", data);
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Using deprecated 'limit_hash' api: Please use 'limit hash'.\n");
 		limit_function(session, mydata);
@@ -4859,7 +4859,7 @@ SWITCH_STANDARD_APP(limit_execute_function)
 	}
 
 	/* backwards compat version, if we have 5, just prepend with db and reparse */
-	if (switch_true(switch_channel_get_variable(channel, "switch_limit_backwards_compat_flag")) &&
+	if (switch_channel_var_true(channel, "switch_limit_backwards_compat_flag") &&
 			argc == 5) {
 		mydata = switch_core_session_sprintf(session, "db %s", data);
 		argc = switch_separate_string(mydata, ' ', argv, (sizeof(argv) / sizeof(argv[0])));
@@ -4918,7 +4918,7 @@ SWITCH_STANDARD_APP(limit_hash_execute_function)
 	char *mydata = NULL;
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 
-	if (switch_true(switch_channel_get_variable(channel, "switch_limit_backwards_compat_flag"))) {
+	if (switch_channel_var_true(channel, "switch_limit_backwards_compat_flag")) {
 		mydata = switch_core_session_sprintf(session, "hash %s", data);
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Using deprecated 'limit_hash_execute' api: Please use 'limit_execute hash'.\n");
 		limit_execute_function(session, mydata);

--- a/src/mod/applications/mod_esf/mod_esf.c
+++ b/src/mod/applications/mod_esf/mod_esf.c
@@ -204,7 +204,7 @@ SWITCH_STANDARD_APP(bcast_function)
 	switch_channel_set_variable_printf(channel, "multicast_ttl", "%d", mcast_ttl);
 
 
-	if (switch_true(switch_channel_get_variable(channel, SWITCH_BYPASS_MEDIA_VARIABLE))) {
+	if (switch_channel_var_true(channel, SWITCH_BYPASS_MEDIA_VARIABLE)) {
 		switch_core_session_message_t msg = { 0 };
 
 		ready = SEND_TYPE_NOMEDIA;

--- a/src/mod/applications/mod_fifo/mod_fifo.c
+++ b/src/mod/applications/mod_fifo/mod_fifo.c
@@ -2879,7 +2879,7 @@ SWITCH_STANDARD_APP(fifo_function)
 			switch_mutex_unlock(globals.mutex);
 		}
 
-		if ((switch_true(switch_channel_get_variable(channel, "fifo_caller_exit_to_orbit")) || cd.do_orbit) && cd.orbit_exten) {
+		if ((switch_channel_var_true(channel, "fifo_caller_exit_to_orbit") || cd.do_orbit) && cd.orbit_exten) {
 			if (orbit_ann) {
 				switch_ivr_play_file(session, NULL, orbit_ann, NULL);
 			}
@@ -3660,7 +3660,7 @@ SWITCH_STANDARD_APP(fifo_function)
 		fifo_caller_del(switch_core_session_get_uuid(session));
 	}
 
-	if (switch_true(switch_channel_get_variable(channel, "fifo_destroy_after_use"))) {
+	if (switch_channel_var_true(channel, "fifo_destroy_after_use")) {
 		do_destroy = 1;
 	}
 

--- a/src/mod/applications/mod_spandsp/mod_spandsp_dsp.c
+++ b/src/mod/applications/mod_spandsp/mod_spandsp_dsp.c
@@ -932,7 +932,7 @@ static switch_bool_t callprogress_detector_process_buffer(switch_media_bug_t *bu
 				switch_channel_event_set_data(channel, event);
 				switch_event_fire(&event);
 			}
-			if (switch_true(switch_channel_get_variable(channel, "spandsp_tone_detect_stop_on_tone"))) {
+			if (switch_channel_var_true(channel, "spandsp_tone_detect_stop_on_tone")) {
 				/* all done */
 				return SWITCH_FALSE;
 			}

--- a/src/mod/applications/mod_spandsp/mod_spandsp_fax.c
+++ b/src/mod/applications/mod_spandsp/mod_spandsp_fax.c
@@ -918,7 +918,7 @@ static switch_status_t spanfax_init(pvt_t *pvt, transport_mode_t trans_mode)
 
 		t38_gateway_set_transmit_on_idle(pvt->t38_gateway_state, TRUE);
 
-		if (switch_true(switch_channel_get_variable(channel, "fax_v17_disabled"))) {
+		if (switch_channel_var_true(channel, "fax_v17_disabled")) {
 			t38_gateway_set_supported_modems(pvt->t38_gateway_state, T30_SUPPORT_V29 | T30_SUPPORT_V27TER);
 		} else {
 			t38_gateway_set_supported_modems(pvt->t38_gateway_state, T30_SUPPORT_V17 | T30_SUPPORT_V29 | T30_SUPPORT_V27TER);

--- a/src/mod/applications/mod_voicemail/mod_voicemail.c
+++ b/src/mod/applications/mod_voicemail/mod_voicemail.c
@@ -3721,7 +3721,6 @@ SWITCH_STANDARD_APP(voicemail_function)
 	const char *profile_name = NULL;
 	const char *domain_name = NULL;
 	const char *id = NULL;
-	const char *auth_var = NULL;
 	const char *uuid = NULL;
 	int x = 0, check = 0, auth = 0;
 	switch_channel_t *channel = switch_core_session_get_channel(session);
@@ -3758,7 +3757,7 @@ SWITCH_STANDARD_APP(voicemail_function)
 		id = argv[x++];
 	}
 
-	if ((auth_var = switch_channel_get_variable(channel, "voicemail_authorized")) && switch_true(auth_var)) {
+	if (switch_channel_var_true(channel, "voicemail_authorized")) {
 		auth = 1;
 	}
 

--- a/src/mod/applications/mod_voicemail_ivr/menu.c
+++ b/src/mod/applications/mod_voicemail_ivr/menu.c
@@ -534,11 +534,10 @@ void vmivr_menu_authenticate(switch_core_session_t *session, vmivr_profile_t *pr
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 	vmivr_menu_t menu = { "std_authenticate" };
 	int retry;
-	const char *auth_var = NULL;
 	/* Initialize Menu Configs */
 	menu_init(profile, &menu);
 
-	if (profile->id && (auth_var = switch_channel_get_variable(channel, "voicemail_authorized")) && switch_true(auth_var)) {
+	if (profile->id && switch_channel_var_true(channel, "voicemail_authorized")) {
 		profile->authorized = SWITCH_TRUE;
 	}
 

--- a/src/mod/dialplans/mod_dialplan_xml/mod_dialplan_xml.c
+++ b/src/mod/dialplans/mod_dialplan_xml/mod_dialplan_xml.c
@@ -623,7 +623,6 @@ SWITCH_STANDARD_DIALPLAN(dialplan_hunt)
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 	switch_xml_t alt_root = NULL, cfg, xml = NULL, xcontext, xexten = NULL;
 	char *alt_path = (char *) arg;
-	const char *hunt = NULL;
 
 	if (!caller_profile) {
 		if (!(caller_profile = switch_channel_get_caller_profile(channel))) {
@@ -671,7 +670,7 @@ SWITCH_STANDARD_DIALPLAN(dialplan_hunt)
 		}
 	}
 
-	if ((hunt = switch_channel_get_variable(channel, "auto_hunt")) && switch_true(hunt)) {
+	if (switch_channel_var_true(channel, "auto_hunt")) {
 		xexten = switch_xml_find_child(xcontext, "extension", "name", caller_profile->destination_number);
 	}
 

--- a/src/mod/endpoints/mod_loopback/mod_loopback.c
+++ b/src/mod/endpoints/mod_loopback/mod_loopback.c
@@ -442,7 +442,6 @@ static switch_status_t channel_on_execute(switch_core_session_t *session)
 	switch_channel_t *channel = NULL;
 	loopback_private_t *tech_pvt = NULL;
 	switch_caller_extension_t *exten = NULL;
-	const char *bowout = NULL;
 	int bow = 0;
 
 	channel = switch_core_session_get_channel(session);
@@ -453,7 +452,7 @@ static switch_status_t channel_on_execute(switch_core_session_t *session)
 
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "%s CHANNEL EXECUTE\n", switch_channel_get_name(channel));
 
-	if ((bowout = switch_channel_get_variable(tech_pvt->channel, "loopback_bowout_on_execute")) && switch_true(bowout)) {
+	if (switch_channel_var_true(tech_pvt->channel, "loopback_bowout_on_execute")) {
 		/* loopback_bowout_on_execute variable is set */
 		bow = 1;
 	} else if ((exten = switch_channel_get_caller_extension(channel))) {
@@ -814,7 +813,7 @@ static switch_status_t find_non_loopback_bridge(switch_core_session_t *session, 
 
 			switch_channel_wait_for_state_or_greater(spchan, channel, CS_ROUTING);
 
-			if (switch_false(switch_channel_get_variable(spchan, "loopback_bowout"))) break;
+			if (switch_channel_var_false(spchan, "loopback_bowout")) break;
 
 			tech_pvt = switch_core_session_get_private(sp);
 
@@ -871,13 +870,8 @@ static switch_status_t channel_write_frame(switch_core_session_t *session, switc
 		switch_channel_test_flag(tech_pvt->other_channel, CF_ANSWERED) && --tech_pvt->bowout_frame_count <= 0) {
 		const char *a_uuid = NULL;
 		const char *b_uuid = NULL;
-		const char *vetoa, *vetob;
 
-
-		vetoa = switch_channel_get_variable(tech_pvt->channel, "loopback_bowout");
-		vetob = switch_channel_get_variable(tech_pvt->other_tech_pvt->channel, "loopback_bowout");
-
-		if ((!vetoa || switch_true(vetoa)) && (!vetob || switch_true(vetob))) {
+		if (switch_channel_var_true_or_default(tech_pvt->channel, "loopback_bowout", SWITCH_TRUE) && switch_channel_var_true_or_default(tech_pvt->other_tech_pvt->channel, "loopback_bowout", SWITCH_TRUE)) {
 			switch_core_session_t *br_a, *br_b;
 			switch_channel_t *ch_a = NULL, *ch_b = NULL;
 			int good_to_go = 0;

--- a/src/mod/endpoints/mod_rtmp/rtmp_sig.c
+++ b/src/mod/endpoints/mod_rtmp/rtmp_sig.c
@@ -703,7 +703,7 @@ static switch_status_t three_way_on_soft_execute(switch_core_session_t *other_se
 		/* if my_channel isn't ready, it means something else has control of it, leave it alone */
 		if (switch_channel_ready(my_channel)) {
 			const char *s;
-			if ((s = switch_channel_get_variable(my_channel, SWITCH_PARK_AFTER_BRIDGE_VARIABLE)) && switch_true(s)) {
+			if (switch_channel_var_true(my_channel, SWITCH_PARK_AFTER_BRIDGE_VARIABLE)) {
 				switch_ivr_park_session(my_session);
 			} else if ((s = switch_channel_get_variable(my_channel, SWITCH_TRANSFER_AFTER_BRIDGE_VARIABLE)) && !zstr(s)) {
 				int argc;

--- a/src/mod/endpoints/mod_skypopen/mod_skypopen.c
+++ b/src/mod/endpoints/mod_skypopen/mod_skypopen.c
@@ -937,7 +937,7 @@ static switch_status_t channel_read_frame(switch_core_session_t *session, switch
 			*frame = &tech_pvt->read_frame;
 
 
-			if (switch_true(switch_channel_get_variable(channel, "skype_get_inband_dtmf"))) {
+			if (switch_channel_var_true(channel, "skype_get_inband_dtmf")) {
 
 				frame_16_khz = tech_pvt->read_frame.data;
 
@@ -2199,7 +2199,7 @@ int dtmf_received(private_t *tech_pvt, char *value)
 		if (channel) {
 
 			if (switch_channel_test_flag(channel, CF_BRIDGED)
-				&& !switch_true(switch_channel_get_variable(channel, "skype_add_outband_dtmf_also_when_bridged"))) {
+				&& !switch_channel_var_true(channel, "skype_add_outband_dtmf_also_when_bridged")) {
 
 
 				NOTICA

--- a/src/mod/endpoints/mod_sofia/rtp.c
+++ b/src/mod/endpoints/mod_sofia/rtp.c
@@ -646,7 +646,7 @@ static switch_status_t channel_receive_message(switch_core_session_t *session, s
 										  SWITCH_LOG_DEBUG, "Setting Jitterbuffer to %dms (%d frames) (%d max frames)\n",
 										  len, qlen, maxqlen);
 						switch_channel_set_flag(tech_pvt->channel, CF_JITTERBUFFER);
-						if (!switch_false(switch_channel_get_variable(tech_pvt->channel, "rtp_jitter_buffer_plc"))) {
+						if (!switch_channel_var_false(tech_pvt->channel, "rtp_jitter_buffer_plc")) {
 							switch_channel_set_flag(tech_pvt->channel, CF_JITTERBUFFER_PLC);
 						}
 					} else {

--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -3296,7 +3296,7 @@ static switch_bool_t attended_transfer(switch_core_session_t *session, switch_co
 			switch_core_session_rwunlock(tmp);
 		}
 
-		if (switch_true(switch_channel_get_variable(tech_pvt->channel, "recording_follow_transfer")) &&
+		if (switch_channel_var_true(tech_pvt->channel, "recording_follow_transfer") &&
 			(tmp = switch_core_session_locate(br_a))) {
 			switch_channel_set_variable(switch_core_session_get_channel(tmp), "transfer_disposition", "bridge");
 			switch_ivr_transfer_recordings(session, tmp);
@@ -3304,7 +3304,7 @@ static switch_bool_t attended_transfer(switch_core_session_t *session, switch_co
 		}
 
 
-		if (switch_true(switch_channel_get_variable(b_tech_pvt->channel, "recording_follow_transfer")) &&
+		if (switch_channel_var_true(b_tech_pvt->channel, "recording_follow_transfer") &&
 			(tmp = switch_core_session_locate(br_b))) {
 			switch_ivr_transfer_recordings(b_session, tmp);
 			switch_core_session_rwunlock(tmp);
@@ -3351,7 +3351,7 @@ static switch_bool_t attended_transfer(switch_core_session_t *session, switch_co
 				const char *idest = switch_channel_get_variable(hup_channel, "inline_destination");
 				ext = switch_channel_get_variable(hup_channel, "destination_number");
 
-				if (switch_true(switch_channel_get_variable(hup_channel, "recording_follow_transfer"))) {
+				if (switch_channel_var_true(hup_channel, "recording_follow_transfer")) {
 					switch_ivr_transfer_recordings(hup_session, t_session);
 				}
 
@@ -6133,7 +6133,7 @@ static switch_call_cause_t verto_outgoing_channel(switch_core_session_t *session
 		if (session) {
 			switch_channel_t *ochannel = switch_core_session_get_channel(session);
 
-			if (switch_true(switch_channel_get_variable(ochannel, SWITCH_BYPASS_MEDIA_VARIABLE))) {
+			if (switch_channel_var_true(ochannel, SWITCH_BYPASS_MEDIA_VARIABLE)) {
 				switch_channel_set_flag(channel, CF_PROXY_MODE);
 				switch_channel_set_flag(ochannel, CF_PROXY_MODE);
 				switch_channel_set_cap(channel, CC_BYPASS_MEDIA);

--- a/src/mod/event_handlers/mod_event_socket/mod_event_socket.c
+++ b/src/mod/event_handlers/mod_event_socket/mod_event_socket.c
@@ -523,8 +523,6 @@ SWITCH_STANDARD_APP(socket_function)
 	}
 
 	if (switch_test_flag(listener, LFLAG_ASYNC)) {
-		const char *var;
-
 		if (launch_listener_thread(listener) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Failed to start listener\n");
 			return;
@@ -545,7 +543,7 @@ SWITCH_STANDARD_APP(socket_function)
 
 		if (switch_channel_get_state(channel) != CS_HIBERNATE &&
 			!switch_channel_test_flag(channel, CF_REDIRECT) && !switch_channel_test_flag(channel, CF_TRANSFER) && !switch_channel_test_flag(channel, CF_RESET)
-			&& (switch_test_flag(listener, LFLAG_RESUME) || ((var = switch_channel_get_variable(channel, "socket_resume")) && switch_true(var)))) {
+			&& (switch_test_flag(listener, LFLAG_RESUME) || switch_channel_var_true(channel, "socket_resume")))  {
 			switch_channel_set_state(channel, CS_EXECUTE);
 		}
 
@@ -2636,7 +2634,6 @@ static void *SWITCH_THREAD_FUNC listener_run(switch_thread_t *thread, void *obj)
 	switch_core_session_t *session = NULL;
 	switch_channel_t *channel = NULL;
 	switch_event_t *revent = NULL;
-	const char *var;
 	int locked = 1;
 
 	switch_mutex_lock(globals.listener_mutex);
@@ -2810,7 +2807,7 @@ static void *SWITCH_THREAD_FUNC listener_run(switch_thread_t *thread, void *obj)
 
 	if (channel && switch_channel_get_state(channel) != CS_HIBERNATE &&
 		!switch_channel_test_flag(channel, CF_REDIRECT) && !switch_channel_test_flag(channel, CF_TRANSFER) && !switch_channel_test_flag(channel, CF_RESET) &&
-		(switch_test_flag(listener, LFLAG_RESUME) || ((var = switch_channel_get_variable(channel, "socket_resume")) && switch_true(var)))) {
+		(switch_test_flag(listener, LFLAG_RESUME) || switch_channel_var_true(channel, "socket_resume"))) {
 		switch_channel_set_state(channel, CS_RESET);
 	}
 

--- a/src/mod/event_handlers/mod_odbc_cdr/mod_odbc_cdr.c
+++ b/src/mod/event_handlers/mod_odbc_cdr/mod_odbc_cdr.c
@@ -248,8 +248,7 @@ static switch_status_t odbc_cdr_reporting(switch_core_session_t *session)
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Only logging B-Leg, ignoring A-leg\n");
 		return SWITCH_STATUS_SUCCESS;
 	} else {
-		const char *tmp = NULL;
-		if ((tmp = switch_channel_get_variable(channel, "odbc-cdr-ignore-leg")) && switch_true(tmp)) {
+		if (switch_channel_var_true(channel, "odbc-cdr-ignore-leg")) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "odbc-cdr-ignore-leg set to true, ignoring leg\n");
 			return SWITCH_STATUS_SUCCESS;
 		}

--- a/src/switch_core_media_bug.c
+++ b/src/switch_core_media_bug.c
@@ -804,8 +804,6 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_bug_add(switch_core_session_t 
 	switch_event_t *event;
 	int tap_only = 1, punt = 0, added = 0;
 
-	const char *p;
-
 	if (!zstr(function)) {
 		if ((flags & SMBF_ONE_ONLY)) {
 			switch_thread_rwlock_wrlock(session->bug_rwlock);
@@ -837,7 +835,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_bug_add(switch_core_session_t 
 	*new_bug = NULL;
 
 
-	if ((p = switch_channel_get_variable(session->channel, "media_bug_answer_req")) && switch_true(p)) {
+	if (switch_channel_var_true(session->channel, "media_bug_answer_req")) {
 		flags |= SMBF_ANSWER_REQ;
 	}
 #if 0

--- a/src/switch_core_state_machine.c
+++ b/src/switch_core_state_machine.c
@@ -59,7 +59,7 @@ static void switch_core_standard_on_hangup(switch_core_session_t *session)
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "%s Standard HANGUP, cause: %s\n",
 					  switch_channel_get_name(session->channel), switch_channel_cause2str(switch_channel_get_cause(session->channel)));
 
-	if (switch_true(switch_channel_get_variable(session->channel, "log_audio_stats_on_hangup"))) {
+	if (switch_channel_var_true(session->channel, "log_audio_stats_on_hangup")) {
 		switch_rtp_stats_t *audio_stats = NULL;
 
 		switch_core_media_set_stats(session);
@@ -849,7 +849,7 @@ SWITCH_DECLARE(void) switch_core_session_hangup_state(switch_core_session_t *ses
 
 	if ((hook_var = switch_channel_get_variable(session->channel, SWITCH_API_HANGUP_HOOK_VARIABLE))) {
 
-		if (switch_true(switch_channel_get_variable(session->channel, SWITCH_SESSION_IN_HANGUP_HOOK_VARIABLE))) {
+		if (switch_channel_var_true(session->channel, SWITCH_SESSION_IN_HANGUP_HOOK_VARIABLE)) {
 			use_session = 1;
 		}
 
@@ -933,7 +933,7 @@ SWITCH_DECLARE(void) switch_core_session_reporting_state(switch_core_session_t *
 
 	if ((hook_var = switch_channel_get_variable(session->channel, SWITCH_API_REPORTING_HOOK_VARIABLE))) {
 
-		if (switch_true(switch_channel_get_variable(session->channel, SWITCH_SESSION_IN_HANGUP_HOOK_VARIABLE))) {
+		if (switch_channel_var_true(session->channel, SWITCH_SESSION_IN_HANGUP_HOOK_VARIABLE)) {
 			use_session = 1;
 		}
 
@@ -943,7 +943,7 @@ SWITCH_DECLARE(void) switch_core_session_reporting_state(switch_core_session_t *
 	if (switch_event_create(&event, SWITCH_EVENT_CHANNEL_HANGUP_COMPLETE) == SWITCH_STATUS_SUCCESS) {
 		switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Hangup-Cause", switch_channel_cause2str(cause));
 		switch_channel_event_set_data(session->channel, event);
-		if (switch_true(switch_channel_get_variable(session->channel, "hangup_complete_with_xml"))) {
+		if (switch_channel_var_true(session->channel, "hangup_complete_with_xml")) {
 			switch_xml_t cdr = NULL;
 			char *xml_cdr_text;
 

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -503,7 +503,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 		}
 	}
 
-	bridge_filter_dtmf = switch_true(switch_channel_get_variable(chan_a, "bridge_filter_dtmf"));
+	bridge_filter_dtmf = switch_channel_var_true(chan_a, "bridge_filter_dtmf");
 
 
 	for (;;) {
@@ -661,7 +661,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 			if ((bypass_media_after_bridge || switch_channel_test_flag(chan_b, CF_BYPASS_MEDIA_AFTER_BRIDGE)) && switch_channel_test_flag(chan_a, CF_ANSWERED)
 				&& switch_channel_test_flag(chan_b, CF_ANSWERED)) {
 
-				if (switch_true(switch_channel_get_variable_dup(chan_a, "bypass_media_after_bridge_oldschool", SWITCH_FALSE, -1))) {
+				if (switch_channel_var_true(chan_a, "bypass_media_after_bridge_oldschool")) {
 					switch_ivr_nomedia(switch_core_session_get_uuid(session_a), SMF_REBRIDGE);
 				} else {
 					switch_ivr_3p_nomedia(switch_core_session_get_uuid(session_a), SMF_REBRIDGE);
@@ -715,7 +715,7 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 		if (!switch_channel_test_flag(chan_a, CF_ANSWERED) && answer_limit && switch_epoch_time_now(NULL) > answer_limit) {
 			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG, "Answer timeout hit on %s.\n", switch_channel_get_name(chan_a));
-			if (switch_true(switch_channel_get_variable_dup(chan_a, "continue_on_answer_timeout", SWITCH_FALSE, -1))) {
+			if (switch_channel_var_true(chan_a, "continue_on_answer_timeout")) {
 				data->clean_exit = 1;
 				goto end_of_bridge_loop;
 			} else {
@@ -992,7 +992,7 @@ static switch_status_t audio_bridge_on_exchange_media(switch_core_session_t *ses
 		!switch_channel_test_flag(channel, CF_XFER_ZOMBIE) && bd && !bd->clean_exit && state != CS_PARK && state != CS_ROUTING &&
 		state == CS_EXCHANGE_MEDIA && !switch_channel_test_flag(channel, CF_INNER_BRIDGE)) {
 
-		if (state < CS_HANGUP && switch_true(switch_channel_get_variable(channel, SWITCH_PARK_AFTER_BRIDGE_VARIABLE))) {
+		if (state < CS_HANGUP && switch_channel_var_true(channel, SWITCH_PARK_AFTER_BRIDGE_VARIABLE)) {
 			switch_ivr_park_session(session);
 			return SWITCH_STATUS_FALSE;
 		} else if (state < CS_HANGUP && (var = switch_channel_get_variable(channel, SWITCH_TRANSFER_AFTER_BRIDGE_VARIABLE))) {
@@ -1203,9 +1203,9 @@ static switch_status_t uuid_bridge_on_soft_execute(switch_core_session_t *sessio
 		switch_core_session_reset(session, SWITCH_TRUE, SWITCH_TRUE);
 
 		if (switch_ivr_wait_for_answer(session, other_session) != SWITCH_STATUS_SUCCESS) {
-			if (switch_true(switch_channel_get_variable(channel, "uuid_bridge_continue_on_cancel"))) {
+			if (switch_channel_var_true(channel, "uuid_bridge_continue_on_cancel")) {
 				switch_channel_set_state(channel, CS_EXECUTE);
-			} else if (switch_true(switch_channel_get_variable(channel, "uuid_bridge_park_on_cancel"))) {
+			} else if (switch_channel_var_true(channel, "uuid_bridge_park_on_cancel")) {
 				switch_ivr_park_session(session);
 			} else if (!switch_channel_test_flag(channel, CF_TRANSFER)) {
 				switch_channel_hangup(channel, SWITCH_CAUSE_ORIGINATOR_CANCEL);
@@ -1446,7 +1446,7 @@ static switch_status_t signal_bridge_on_hangup(switch_core_session_t *session)
 			switch_channel_set_variable(other_channel, "call_uuid", switch_core_session_get_uuid(other_session));
 
 			if (switch_channel_up_nosig(other_channel)) {
-				if (switch_true(switch_channel_get_variable(other_channel, SWITCH_PARK_AFTER_BRIDGE_VARIABLE))) {
+				if (switch_channel_var_true(other_channel, SWITCH_PARK_AFTER_BRIDGE_VARIABLE)) {
 					switch_ivr_park_session(other_session);
 					hup = 0;
 				} else if ((var = switch_channel_get_variable(other_channel, SWITCH_TRANSFER_AFTER_BRIDGE_VARIABLE))) {
@@ -1457,7 +1457,7 @@ static switch_status_t signal_bridge_on_hangup(switch_core_session_t *session)
 				if (hup) {
 					if (switch_channel_test_flag(other_channel, CF_BRIDGE_ORIGINATOR)) {
 						if (switch_channel_test_flag(channel, CF_ANSWERED) &&
-							switch_true(switch_channel_get_variable(other_channel, SWITCH_HANGUP_AFTER_BRIDGE_VARIABLE))) {
+							switch_channel_var_true(other_channel, SWITCH_HANGUP_AFTER_BRIDGE_VARIABLE)) {
 
 							if (switch_channel_test_flag(channel, CF_INTERCEPTED)) {
 								switch_channel_set_flag(other_channel, CF_INTERCEPT);
@@ -1822,8 +1822,8 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_multi_threaded_bridge(switch_core_ses
 			}
 
 			if (switch_channel_down_nosig(peer_channel)) {
-				switch_bool_t copy_xml_cdr = switch_true(switch_channel_get_variable(peer_channel, SWITCH_COPY_XML_CDR_VARIABLE));
-				switch_bool_t copy_json_cdr = switch_true(switch_channel_get_variable(peer_channel, SWITCH_COPY_JSON_CDR_VARIABLE));
+				switch_bool_t copy_xml_cdr = switch_channel_var_true(peer_channel, SWITCH_COPY_XML_CDR_VARIABLE);
+				switch_bool_t copy_json_cdr = switch_channel_var_true(peer_channel, SWITCH_COPY_JSON_CDR_VARIABLE);
 
 				if (copy_xml_cdr || copy_json_cdr) {
 					char *cdr_text = NULL;
@@ -1928,8 +1928,8 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_multi_threaded_bridge(switch_core_ses
 
 			if (!switch_channel_test_flag(caller_channel, CF_TRANSFER)) {
 
-				if ((answered && switch_true(switch_channel_get_variable(caller_channel, SWITCH_PARK_AFTER_BRIDGE_VARIABLE))) ||
-					switch_true(switch_channel_get_variable(caller_channel, SWITCH_PARK_AFTER_EARLY_BRIDGE_VARIABLE))) {
+				if ((answered && switch_channel_var_true(caller_channel, SWITCH_PARK_AFTER_BRIDGE_VARIABLE)) ||
+					switch_channel_var_true(caller_channel, SWITCH_PARK_AFTER_EARLY_BRIDGE_VARIABLE)) {
 					switch_ivr_park_session(session);
 				} else if ((answered && (var = switch_channel_get_variable(caller_channel, SWITCH_TRANSFER_AFTER_BRIDGE_VARIABLE))) ||
 						   (var = switch_channel_get_variable(caller_channel, SWITCH_TRANSFER_AFTER_EARLY_BRIDGE_VARIABLE))) {
@@ -2258,7 +2258,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_intercept_session(switch_core_session
 {
 	switch_core_session_t *rsession, *bsession = NULL;
 	switch_channel_t *channel, *rchannel, *bchannel = NULL;
-	const char *buuid, *var;
+	const char *buuid;
 	char brto[SWITCH_UUID_FORMATTED_LENGTH + 1] = "";
 	switch_status_t status = SWITCH_STATUS_FALSE;
 
@@ -2284,14 +2284,14 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_intercept_session(switch_core_session
 		buuid = NULL;
 	}
 
-	if ((var = switch_channel_get_variable(channel, "intercept_unbridged_only")) && switch_true(var)) {
+	if (switch_channel_var_true(channel, "intercept_unbridged_only")) {
 		if ((switch_channel_test_flag(rchannel, CF_BRIDGED))) {
 			switch_core_session_rwunlock(rsession);
 			return status;
 		}
 	}
 
-	if ((var = switch_channel_get_variable(channel, "intercept_unanswered_only")) && switch_true(var)) {
+	if (switch_channel_var_true(channel, "intercept_unanswered_only")) {
 		if ((switch_channel_test_flag(rchannel, CF_ANSWERED))) {
 			switch_core_session_rwunlock(rsession);
 			return status;
@@ -2320,7 +2320,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_intercept_session(switch_core_session
 		switch_channel_set_variable(bchannel, "park_after_bridge", "true");
 	}
 
-	if ((var = switch_channel_get_variable(channel, "intercept_pre_bond")) && switch_true(var)) {
+	if (switch_channel_var_true(channel, "intercept_pre_bond")) {
 		switch_channel_set_variable(channel, SWITCH_SIGNAL_BOND_VARIABLE, uuid);
 		switch_channel_set_variable_partner(channel, SWITCH_SIGNAL_BOND_VARIABLE, switch_core_session_get_uuid(session));
 	}

--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -2124,7 +2124,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 	if (session) {
 		caller_channel = switch_core_session_get_channel(session);
 
-		if (switch_false(switch_channel_get_variable(caller_channel, "preserve_originated_vars"))) {
+		if (switch_channel_var_false(caller_channel, "preserve_originated_vars")) {
 			switch_channel_set_variable(caller_channel, "originated_legs", NULL);
 			switch_channel_set_variable(caller_channel, "originate_causes", NULL);
 		}
@@ -2260,7 +2260,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 	}
 
 	if ((ovars && switch_true(switch_event_get_header(ovars,"origination_nested_vars"))) ||
-		(caller_channel && switch_true(switch_channel_get_variable(caller_channel, "origination_nested_vars")))
+		(caller_channel && switch_channel_var_true(caller_channel, "origination_nested_vars"))
 		|| switch_true(switch_core_get_variable("origination_nested_vars")) || switch_stristr("origination_nested_vars=true", data)) {
 		oglobals.check_vars = SWITCH_FALSE;
 	}
@@ -3036,7 +3036,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 				switch_event_add_header_string(var_event, SWITCH_STACK_BOTTOM, "originate_early_media", oglobals.early_ok ? "true" : "false");
 
 
-				if (caller_channel && switch_true(switch_channel_get_variable(caller_channel, "push_channel_name"))) {
+				if (caller_channel && switch_channel_var_true(caller_channel, "push_channel_name")) {
 					char *new_name = switch_core_session_sprintf(session, "%s__B", switch_channel_get_name(caller_channel));
 					switch_event_add_header_string(var_event, SWITCH_STACK_BOTTOM, "origination_channel_name", new_name);
 					new_name = switch_core_session_sprintf(session, "_%s", switch_channel_get_name(caller_channel));
@@ -3141,7 +3141,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 				if (oglobals.originate_status[i].peer_channel) {
 					const char *vvar;
 
-					if (switch_true(switch_channel_get_variable(oglobals.originate_status[i].peer_channel, "leg_required"))) {
+					if (switch_channel_var_true(oglobals.originate_status[i].peer_channel, "leg_required")) {
 						oglobals.originate_status[i].tagged = 1;
 					}
 
@@ -3793,11 +3793,11 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 
 								switch_channel_set_variable(holding_channel, SWITCH_HANGUP_AFTER_BRIDGE_VARIABLE, "true");
 
-								if (caller_channel && switch_true(switch_channel_get_variable(caller_channel, "recording_follow_transfer"))) {
+								if (caller_channel && switch_channel_var_true(caller_channel, "recording_follow_transfer")) {
 									switch_ivr_transfer_recordings(session, oglobals.originate_status[i].peer_session);
 								}
 
-								if (switch_true(switch_channel_get_variable(holding_channel, "recording_follow_transfer"))) {
+								if (switch_channel_var_true(holding_channel, "recording_follow_transfer")) {
 									switch_ivr_transfer_recordings(holding_session, oglobals.originate_status[i].peer_session);
 								}
 

--- a/src/switch_ivr_play_say.c
+++ b/src/switch_ivr_play_say.c
@@ -51,7 +51,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_phrase_macro_event(switch_core_sessio
 	int pause = 100;
 	const char *group_macro_name = NULL;
 	const char *local_macro_name = macro_name;
-	switch_bool_t sound_prefix_enforced = switch_true(switch_channel_get_variable(channel, "sound_prefix_enforced"));
+	switch_bool_t sound_prefix_enforced = switch_channel_var_true(channel, "sound_prefix_enforced");
 	switch_bool_t local_sound_prefix_enforced = SWITCH_FALSE;
 
 
@@ -1309,10 +1309,8 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_play_file(switch_core_session_t *sess
 		}
 	}
 
-	if ((var = switch_channel_get_variable(channel, "playback_timeout_as_success"))) {
-		if (switch_true(var)) {
-			timeout_as_success = SWITCH_TRUE;
-		}
+	if (switch_channel_var_true(channel, "playback_timeout_as_success")) {
+		timeout_as_success = SWITCH_TRUE;
 	}
 	if ((play_delimiter_val = switch_channel_get_variable(channel, "playback_delimiter"))) {
 		play_delimiter = *play_delimiter_val;
@@ -3043,7 +3041,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_speak_text(switch_core_session_t *ses
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 	switch_speech_handle_t lsh, *sh;
 	switch_speech_flag_t flags = SWITCH_SPEECH_FLAG_NONE;
-	const char *timer_name, *var;
+	const char *timer_name;
 	cached_speech_handle_t *cache_obj = NULL;
 	int need_create = 1, need_alloc = 1;
 	switch_codec_implementation_t read_impl = { 0 };
@@ -3059,7 +3057,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_speak_text(switch_core_session_t *ses
 	codec = &lcodec;
 	timer = &ltimer;
 
-	if ((var = switch_channel_get_variable(channel, SWITCH_CACHE_SPEECH_HANDLES_VARIABLE)) && switch_true(var)) {
+	if (switch_channel_var_true(channel, SWITCH_CACHE_SPEECH_HANDLES_VARIABLE)) {
 		if ((cache_obj = (cached_speech_handle_t *) switch_channel_get_private(channel, SWITCH_CACHE_SPEECH_HANDLES_OBJ_NAME))) {
 			need_create = 0;
 			if (!strcasecmp(cache_obj->tts_name, tts_name)) {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -8507,11 +8507,11 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_enable_vad(switch_rtp_t *rtp_session,
 
 	memset(&rtp_session->vad_data, 0, sizeof(rtp_session->vad_data));
 
-	if (switch_true(switch_channel_get_variable(switch_core_session_get_channel(rtp_session->session), "fire_talk_events"))) {
+	if (switch_channel_var_true(switch_core_session_get_channel(rtp_session->session), "fire_talk_events")) {
 		rtp_session->vad_data.fire_events |= VAD_FIRE_TALK;
 	}
 
-	if (switch_true(switch_channel_get_variable(switch_core_session_get_channel(rtp_session->session), "fire_not_talk_events"))) {
+	if (switch_channel_var_true(switch_core_session_get_channel(rtp_session->session), "fire_not_talk_events")) {
 		rtp_session->vad_data.fire_events |= VAD_FIRE_NOT_TALK;
 	}
 


### PR DESCRIPTION
I've done this back in 2018 or before where I had some memory leak issues and some issues with locking and channel variable not containing the information I expected.

The goal was to replace all the switch_true and switch_false inside freeswitch that used channel variable, so we don't end up with duplicate memory even if that memory would be very small.

It was filled as ticket FS-10533 in the previous bug tracker back in 2018.

This have been in production on my end since 2018 at minimum.