### PR TITLE
Correcly handle route uri parsing from contact, fixes #1897

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -3057,6 +3057,21 @@ sofia_destination_t *sofia_glue_get_destination(char *data)
 				*p = '\0';
 			} while ((--p > route_uri) && *p == ' ');
 		}
+		if ((strlen(route_uri) > 1) && (p = strchr(route_uri, '<'))) {
+		    for (;p && *p; p++) {
+				if (*p == '>' || *p == ';') {
+					*p = '\0';
+					break;
+				}
+			}
+			p = route_uri;
+			if (!(route_uri = strdup(p + 1))) {
+				goto mem_fail;
+			}
+			if (p) {
+				switch_safe_free(p);
+			}
+		}
 	}
 
 	if (!(to = strdup(data))) {


### PR DESCRIPTION
When the Path header contains `<>`, it will get stored along the contact, but we cannot send as-is into the route_uri params, because is used as an outbound proxy val (normally in NUTAG_PROXY which expects an uri), so we are extracting from the `<>` containing route param the correct uri to use.