### PR TITLE
Fix fspr_socket_recv when receiving UDP with no data

### DIFF
--- a/libs/apr/network_io/beos/sendrecv.c
+++ b/libs/apr/network_io/beos/sendrecv.c
@@ -117,8 +117,9 @@ APR_DECLARE(fspr_status_t) fspr_socket_recv(fspr_socket_t *sock, char *buf,
         return errno;
     }
     (*len) = rv;
-    if (rv == 0)
+    if (rv == 0 && sock->type == SOCK_STREAM)
         return APR_EOF;
+
     return APR_SUCCESS;
 }
 
@@ -205,7 +206,7 @@ APR_DECLARE(fspr_status_t) fspr_socket_recvfrom(fspr_sockaddr_t *from,
     }
 
     (*len) = rv;
-    if (rv == 0)
+    if (rv == 0 && sock->type == SOCK_STREAM)
         return APR_EOF;
 
     return APR_SUCCESS;

--- a/libs/apr/network_io/os2/sendrecv.c
+++ b/libs/apr/network_io/os2/sendrecv.c
@@ -100,7 +100,10 @@ APR_DECLARE(fspr_status_t) fspr_socket_recv(fspr_socket_t *sock, char *buf,
     }
 
     (*len) = rv;
-    return rv == 0 ? APR_EOF : APR_SUCCESS;
+    if (rv == 0 && sock->type == SOCK_STREAM)
+        return APR_EOF;
+
+    return APR_SUCCESS;
 }
 
 

--- a/libs/apr/network_io/unix/sendrecv.c
+++ b/libs/apr/network_io/unix/sendrecv.c
@@ -105,9 +105,10 @@ do_select:
         sock->options |= APR_INCOMPLETE_READ;
     }
     (*len) = rv;
-    if (rv == 0) {
+    if (rv == 0 && sock->type == SOCK_STREAM) {
         return APR_EOF;
     }
+
     return APR_SUCCESS;
 }
 

--- a/libs/apr/network_io/win32/sendrecv.c
+++ b/libs/apr/network_io/win32/sendrecv.c
@@ -90,7 +90,10 @@ APR_DECLARE(fspr_status_t) fspr_socket_recv(fspr_socket_t *sock, char *buf,
     }
 
     *len = dwBytes;
-    return dwBytes == 0 ? APR_EOF : APR_SUCCESS;
+    if (rv == 0 && sock->type == SOCK_STREAM)
+        return APR_EOF;
+
+    return APR_SUCCESS;
 }
 
 


### PR DESCRIPTION
Function fspr_socket_recv should check socket type same way as fspr_socket_recvfrom does - receiving empty UDP packet should not be treated as an error.
For BeOS this check was also missing from fspr_socket_recvfrom function.
This fixes https://github.com/signalwire/freeswitch/issues/1884 (mod_event_multicast silently terminating after receiving UDP datagram with 0-length data).