### PR TITLE
[mod_amqp] Adjusting to Appropriate Log Level for Message

### DIFF
--- a/src/mod/event_handlers/mod_amqp/mod_amqp_command.c
+++ b/src/mod/event_handlers/mod_amqp/mod_amqp_command.c
@@ -231,7 +231,7 @@ static void mod_amqp_command_response(mod_amqp_command_profile_t *profile, char 
 	}
 
 	/* Construct the api response */
-	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Preparing api command response: [%s]\n", (char *)stream.data);
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG1, "Preparing api command response: [%s]\n", (char *)stream.data);
 	message = cJSON_CreateObject();
 
 	cJSON_AddItemToObject(message, "output", cJSON_CreateString((const char *) stream.data));

--- a/src/mod/event_handlers/mod_amqp/mod_amqp_command.c
+++ b/src/mod/event_handlers/mod_amqp/mod_amqp_command.c
@@ -231,7 +231,7 @@ static void mod_amqp_command_response(mod_amqp_command_profile_t *profile, char 
 	}
 
 	/* Construct the api response */
-	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Preparing api command response: [%s]\n", (char *)stream.data);
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Preparing api command response: [%s]\n", (char *)stream.data);
 	message = cJSON_CreateObject();
 
 	cJSON_AddItemToObject(message, "output", cJSON_CreateString((const char *) stream.data));


### PR DESCRIPTION
Refined Logging Level for FreeSWITCH's mod_amqp: The logging level for the AMQP module in FreeSWITCH has been updated from 'warning' to 'debug'. This adjustment ensures a more suitable level for the log message and eliminates any potential impact on production environments. Previously, the 'warning' level would lead to unnecessary log entries for each individual message, although there was no actual warning condition. This change improves logging efficiency and appropriateness for mod_amqp's operations within FreeSWITCH.