### PR TITLE
[Core, mod_cidlookup, mod_curl, mod_httapi, mod_http_cache, mod_kazoo, mod_shout] Add new switch_curl_mime APIs replacing switch_curl_process_form_post_params() and make code be compatible with libcurl>=7.87.0

### DIFF
--- a/src/include/switch_curl.h
+++ b/src/include/switch_curl.h
@@ -40,6 +40,9 @@ typedef int switch_CURLINFO;
 typedef int switch_CURLcode;
 typedef int switch_CURLoption;
 
+#define HAVE_SWITCH_CURL_MIME
+typedef void switch_curl_mime;
+
 SWITCH_DECLARE(switch_CURL *) switch_curl_easy_init(void);
 SWITCH_DECLARE(switch_CURLcode) switch_curl_easy_perform(switch_CURL *handle);
 SWITCH_DECLARE(switch_CURLcode) switch_curl_easy_getinfo(switch_CURL *curl, switch_CURLINFO info, ... );
@@ -50,7 +53,9 @@ SWITCH_DECLARE(switch_CURLcode) switch_curl_easy_setopt(CURL *handle, switch_CUR
 SWITCH_DECLARE(const char *) switch_curl_easy_strerror(switch_CURLcode errornum );
 SWITCH_DECLARE(void) switch_curl_init(void);
 SWITCH_DECLARE(void) switch_curl_destroy(void);
-SWITCH_DECLARE(switch_status_t) switch_curl_process_form_post_params(switch_event_t *event, switch_CURL *curl_handle, struct curl_httppost **formpostp);
+SWITCH_DECLARE(switch_status_t) switch_curl_process_mime(switch_event_t *event, switch_CURL *curl_handle, switch_curl_mime **mimep);
+SWITCH_DECLARE(void) switch_curl_mime_free(switch_curl_mime **mimep);
+SWITCH_DECLARE(switch_CURLcode) switch_curl_easy_setopt_mime(switch_CURL *curl_handle, switch_curl_mime *mime);
 #define switch_curl_easy_setopt curl_easy_setopt
 
 SWITCH_END_EXTERN_C

--- a/src/mod/applications/mod_cidlookup/mod_cidlookup.c
+++ b/src/mod/applications/mod_cidlookup/mod_cidlookup.c
@@ -347,7 +347,7 @@ static size_t file_callback(void *ptr, size_t size, size_t nmemb, void *data)
 	return realsize;
 }
 
-static long do_lookup_url(switch_memory_pool_t *pool, switch_event_t *event, char **response, const char *query, struct curl_httppost *post,
+static long do_lookup_url(switch_memory_pool_t *pool, switch_event_t *event, char **response, const char *query, switch_curl_mime *post,
 						  switch_curl_slist_t *headers, int timeout)
 {
 	switch_time_t start_time = switch_micro_time_now();
@@ -373,7 +373,7 @@ static long do_lookup_url(switch_memory_pool_t *pool, switch_event_t *event, cha
 		switch_curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYHOST, 0);
 	}
 	if (post) {
-		switch_curl_easy_setopt(curl_handle, CURLOPT_HTTPPOST, post);
+		switch_curl_easy_setopt_mime(curl_handle, post);
 	} else {
 		switch_curl_easy_setopt(curl_handle, CURLOPT_HTTPGET, 1);
 	}

--- a/src/mod/applications/mod_httapi/mod_httapi.c
+++ b/src/mod/applications/mod_httapi/mod_httapi.c
@@ -1419,7 +1419,7 @@ static switch_status_t httapi_sync(client_t *client)
 	switch_status_t status = SWITCH_STATUS_FALSE;
 	int get_style_method = 0;
 	char *method = NULL;
-	struct curl_httppost *formpost=NULL;
+	switch_curl_mime *formpost = NULL;
 	switch_event_t *save_params = NULL;
 	const char *put_file;
 	FILE *fd = NULL;
@@ -1476,7 +1476,7 @@ static switch_status_t httapi_sync(client_t *client)
 	}
 
 	if (!put_file) {
-		switch_curl_process_form_post_params(client->params, curl_handle, &formpost);
+		switch_curl_process_mime(client->params, curl_handle, &formpost);
 	}
 
 	if (formpost) {
@@ -1588,7 +1588,7 @@ static switch_status_t httapi_sync(client_t *client)
 		curl_easy_setopt(curl_handle, CURLOPT_READFUNCTION, put_file_read);
 
 	} else if (formpost) {
-		curl_easy_setopt(curl_handle, CURLOPT_HTTPPOST, formpost);
+		switch_curl_easy_setopt_mime(curl_handle, formpost);
 	} else {
 		switch_curl_easy_setopt(curl_handle, CURLOPT_POST, !get_style_method);
 	}
@@ -1670,9 +1670,7 @@ static switch_status_t httapi_sync(client_t *client)
 	switch_curl_easy_cleanup(curl_handle);
 	switch_curl_slist_free_all(headers);
 
-	if (formpost) {
-		curl_formfree(formpost);
-	}
+	switch_curl_mime_free(&formpost);
 
 	if (client->err) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error encountered! [%s]\ndata: [%s]\n", client->profile->url, data);

--- a/src/mod/applications/mod_http_cache/azure.c
+++ b/src/mod/applications/mod_http_cache/azure.c
@@ -279,7 +279,11 @@ switch_status_t azure_blob_finalise_put(http_profile_t *profile, const char *url
 		goto done;
 	}
 
+#if defined(LIBCURL_VERSION_NUM) && (LIBCURL_VERSION_NUM >= 0x070c01)
+	switch_curl_easy_setopt(curl_handle, CURLOPT_UPLOAD, 1);
+#else
 	switch_curl_easy_setopt(curl_handle, CURLOPT_PUT, 1);
+#endif
 	switch_curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1);
 	switch_curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
 	switch_curl_easy_setopt(curl_handle, CURLOPT_URL, full_url);

--- a/src/mod/applications/mod_http_cache/mod_http_cache.c
+++ b/src/mod/applications/mod_http_cache/mod_http_cache.c
@@ -393,7 +393,9 @@ static switch_status_t http_put(url_cache_t *cache, http_profile_t *profile, swi
 			goto done;
 		}
 		switch_curl_easy_setopt(curl_handle, CURLOPT_UPLOAD, 1);
+#if !defined(LIBCURL_VERSION_NUM) || (LIBCURL_VERSION_NUM < 0x070c01)
 		switch_curl_easy_setopt(curl_handle, CURLOPT_PUT, 1);
+#endif
 		switch_curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1);
 		switch_curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
 		switch_curl_easy_setopt(curl_handle, CURLOPT_URL, full_url);

--- a/src/mod/event_handlers/mod_kazoo/kazoo_commands.c
+++ b/src/mod/event_handlers/mod_kazoo/kazoo_commands.c
@@ -366,7 +366,9 @@ SWITCH_STANDARD_API(kz_http_put)
 		goto done;
 	}
 	switch_curl_easy_setopt(curl_handle, CURLOPT_UPLOAD, 1);
+#if !defined(LIBCURL_VERSION_NUM) || (LIBCURL_VERSION_NUM < 0x070c01)
 	switch_curl_easy_setopt(curl_handle, CURLOPT_PUT, 1);
+#endif
 	switch_curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1);
 	switch_curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, headers);
 	switch_curl_easy_setopt(curl_handle, CURLOPT_URL, url);

--- a/src/switch_curl.c
+++ b/src/switch_curl.c
@@ -58,11 +58,16 @@ SWITCH_DECLARE(void) switch_curl_destroy(void)
 	curl_global_cleanup();
 }
 
-SWITCH_DECLARE(switch_status_t) switch_curl_process_form_post_params(switch_event_t *event, switch_CURL *curl_handle, struct curl_httppost **formpostp)
+SWITCH_DECLARE(switch_status_t) switch_curl_process_mime(switch_event_t *event, switch_CURL *curl_handle, switch_curl_mime **mimep)
 {
-
+#if defined(LIBCURL_VERSION_NUM) && (LIBCURL_VERSION_NUM >= 0x073800)
+	curl_mime *mime = NULL;
+	curl_mimepart *part = NULL;
+	uint8_t added = 0;
+#else
 	struct curl_httppost *formpost=NULL;
 	struct curl_httppost *lastptr=NULL;
+#endif
 	switch_event_header_t *hp;
 	int go = 0;
 
@@ -77,39 +82,85 @@ SWITCH_DECLARE(switch_status_t) switch_curl_process_form_post_params(switch_even
 		return SWITCH_STATUS_FALSE;
 	}
 
-	for (hp = event->headers; hp; hp = hp->next) {
+#if defined(LIBCURL_VERSION_NUM) && (LIBCURL_VERSION_NUM >= 0x073800)
+	mime = curl_mime_init(curl_handle);
+#endif
 
+	for (hp = event->headers; hp; hp = hp->next) {
 		if (!strncasecmp(hp->name, "attach_file:", 12)) {
 			char *pname = strdup(hp->name + 12);
 
 			if (pname) {
 				char *fname = strchr(pname, ':');
+
 				if (fname) {
 					*fname++ = '\0';
 
+#if defined(LIBCURL_VERSION_NUM) && (LIBCURL_VERSION_NUM >= 0x073800)
+					part = curl_mime_addpart(mime);
+					curl_mime_name(part, pname);
+					curl_mime_filename(part, fname);
+					curl_mime_filedata(part, hp->value);
+					added++;
+#else
 					curl_formadd(&formpost,
 								 &lastptr,
 								 CURLFORM_COPYNAME, pname,
 								 CURLFORM_FILENAME, fname,
 								 CURLFORM_FILE, hp->value,
 								 CURLFORM_END);
+#endif
 				}
+
 				free(pname);
 			}
 		} else {
+#if defined(LIBCURL_VERSION_NUM) && (LIBCURL_VERSION_NUM >= 0x073800)
+			part = curl_mime_addpart(mime);
+			curl_mime_name(part, hp->name);
+			curl_mime_data(part, hp->value, CURL_ZERO_TERMINATED);
+			added++;
+#else
 			curl_formadd(&formpost,
 						 &lastptr,
 						 CURLFORM_COPYNAME, hp->name,
 						 CURLFORM_COPYCONTENTS, hp->value,
 						 CURLFORM_END);
-
+#endif
 		}
 	}
 
-	*formpostp = formpost;
+#if defined(LIBCURL_VERSION_NUM) && (LIBCURL_VERSION_NUM >= 0x073800)
+	if (!added) {
+		curl_mime_free(mime);
+		mime = NULL;
+	}
+#endif
+
+	*mimep = mime;
 
 	return SWITCH_STATUS_SUCCESS;
+}
 
+SWITCH_DECLARE(void) switch_curl_mime_free(switch_curl_mime **mimep)
+{
+	if (mimep && *mimep) {
+#if defined(LIBCURL_VERSION_NUM) && (LIBCURL_VERSION_NUM >= 0x073800)
+		curl_mime_free(*mimep);
+#else
+		curl_formfree(*mimep);
+#endif
+		mimep = NULL;
+	}
+}
+
+SWITCH_DECLARE(switch_CURLcode) switch_curl_easy_setopt_mime(switch_CURL *curl_handle, switch_curl_mime *mime)
+{
+#if defined(LIBCURL_VERSION_NUM) && (LIBCURL_VERSION_NUM >= 0x073800)
+	return curl_easy_setopt(curl_handle, CURLOPT_MIMEPOST, mime);
+#else
+	return curl_easy_setopt(curl_handle, CURLOPT_HTTPPOST, mime);
+#endif
 }
 
 /* For Emacs:


### PR DESCRIPTION
Following https://github.com/signalwire/freeswitch/pull/1981