### PR TITLE
[Build-System, ldns] config.h change to not define inline under Windows to avoid clash with Windows winsock2.h inline usage. Use updated ldns tarball on Windows.

### DIFF
--- a/libs/win32/ldns/ldns-lib/config.h
+++ b/libs/win32/ldns/ldns-lib/config.h
@@ -260,7 +260,9 @@
 /* Define to `__inline__' or `__inline' if that's what the C compiler
    calls it, or to nothing if 'inline' is not supported under any name.  */
 #ifndef __cplusplus
-#define inline
+#ifndef _WIN32
+#define inline /* Do not define inline for Windows to avoid warnings/errors with winsock2.h usage of inline within the latest Windows SDKs */
+#endif
 #endif
 
 #if _MSC_VER >= 1900

--- a/libs/win32/ldns/ldns-lib/ldns-lib.2017.vcxproj
+++ b/libs/win32/ldns/ldns-lib/ldns-lib.2017.vcxproj
@@ -95,7 +95,7 @@
       <DisableSpecificWarnings>4013;4101;4996;4267;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <PreBuildEvent>
-      <Command>type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
+      <Command>if not exist "$(ProjectDir)..\..\..\ldns\ldns\config.h" type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\util.h" type "$(ProjectDir)\util.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\util.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\net.h"</Command>
     </PreBuildEvent>
@@ -115,7 +115,7 @@ if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" 
       <DisableSpecificWarnings>4013;4101;4996;4267;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <PreBuildEvent>
-      <Command>type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
+      <Command>if not exist "$(ProjectDir)..\..\..\ldns\ldns\config.h" type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\util.h" type "$(ProjectDir)\util.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\util.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\net.h"</Command>
     </PreBuildEvent>
@@ -142,7 +142,7 @@ if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" 
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
+      <Command>if not exist "$(ProjectDir)..\..\..\ldns\ldns\config.h" type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\util.h" type "$(ProjectDir)\util.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\util.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\net.h"</Command>
     </PreBuildEvent>
@@ -169,7 +169,7 @@ if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" 
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
+      <Command>if not exist "$(ProjectDir)..\..\..\ldns\ldns\config.h" type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\util.h" type "$(ProjectDir)\util.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\util.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\net.h"</Command>
     </PreBuildEvent>

--- a/libs/win32/ldns/ldns-lib/ldns-lib.2017.vcxproj
+++ b/libs/win32/ldns/ldns-lib/ldns-lib.2017.vcxproj
@@ -95,7 +95,7 @@
       <DisableSpecificWarnings>4013;4101;4996;4267;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <PreBuildEvent>
-      <Command>if not exist "$(ProjectDir)..\..\..\ldns\ldns\config.h" type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
+      <Command>type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\util.h" type "$(ProjectDir)\util.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\util.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\net.h"</Command>
     </PreBuildEvent>
@@ -115,7 +115,7 @@ if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" 
       <DisableSpecificWarnings>4013;4101;4996;4267;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <PreBuildEvent>
-      <Command>if not exist "$(ProjectDir)..\..\..\ldns\ldns\config.h" type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
+      <Command>type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\util.h" type "$(ProjectDir)\util.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\util.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\net.h"</Command>
     </PreBuildEvent>
@@ -142,7 +142,7 @@ if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" 
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>if not exist "$(ProjectDir)..\..\..\ldns\ldns\config.h" type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
+      <Command>type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\util.h" type "$(ProjectDir)\util.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\util.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\net.h"</Command>
     </PreBuildEvent>
@@ -169,7 +169,7 @@ if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" 
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>if not exist "$(ProjectDir)..\..\..\ldns\ldns\config.h" type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
+      <Command>type "$(ProjectDir)\config.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\config.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\util.h" type "$(ProjectDir)\util.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\util.h"
 if not exist "$(ProjectDir)..\..\..\ldns\ldns\net.h" type "$(ProjectDir)\net.h" &gt; "$(ProjectDir)..\..\..\ldns\ldns\net.h"</Command>
     </PreBuildEvent>

--- a/w32/download_LDNS.props
+++ b/w32/download_LDNS.props
@@ -29,7 +29,7 @@
 
   <Target Name="LDNSDownloadTarget" BeforeTargets="CustomBuild;PreBuildEvent;" DependsOnTargets="7za">
       <DownloadPackageTask
-           package="http://files.freeswitch.org/downloads/libs/ldns-1.6.9-1-win.tar.gz"
+           package="http://files.freeswitch.org/downloads/libs/ldns-1.6.9-2-win.tar.gz"
            expectfileordirectory="$(BaseDir)libs\ldns\configure.ac"
            outputfolder=""
            outputfilename=""


### PR DESCRIPTION
Based on the open Issue (https://github.com/signalwire/freeswitch/issues/2172) this is the PR to resolve this issue.

This is all around the fact that the latest Windows SDK, containing winsock2.h, makes use of inline which clashes with the declaration of inline inside the ldns config.h.  This then causes LNK2004 warnings when ldns is built and hence the LNK2005 errors with mod_enum that uses ldns.

~~Also I needed to modify the windows ldns project file to force overwrite of libs\ldns\ldns\config.h with libs\win32\ldns\ldns-lib\config.h when ldns is compiled.~~

