### PR TITLE
updates for the Debian Dockerfile

### DIFF
--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -66,11 +66,9 @@ VOLUME ["/tmp"]
 COPY    build/freeswitch.limits.conf /etc/security/limits.d/
 
 # Healthcheck to make sure the service is running
-SHELL       ["/bin/bash"]
+SHELL       ["/bin/bash", "-c"]
 HEALTHCHECK --interval=15s --timeout=5s \
     CMD  fs_cli -x status | grep -q ^UP || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-
-
 CMD ["freeswitch"]

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-ARG DEBIAN_VERSION=buster
+ARG DEBIAN_VERSION=bookworm
 FROM debian:${DEBIAN_VERSION}
 ARG TOKEN
 

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -1,6 +1,10 @@
 # vim:set ft=dockerfile:
 ARG DEBIAN_VERSION=bookworm
 FROM debian:${DEBIAN_VERSION}
+
+# ARGs are cleared after every FROM
+# see: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG DEBIAN_VERSION
 ARG TOKEN
 
 # Source Dockerfile:
@@ -9,31 +13,22 @@ ARG TOKEN
 # explicitly set user/group IDs
 RUN groupadd -r freeswitch --gid=999 && useradd -r -g freeswitch --uid=999 freeswitch
 
-# grab gosu for easy step-down from root
-RUN apt-get update && apt-get install -y --no-install-recommends dirmngr gnupg2 ca-certificates wget \
-    && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 655DA1341B5207915210AFE936B4249FA7B0FB03 \
-    && gpg2 --output /usr/share/keyrings/signalwire-freeswitch-repo.gpg --export 655DA1341B5207915210AFE936B4249FA7B0FB03 \
-    && rm -rf /var/lib/apt/lists/* \
-    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
-    && gpg --verify /usr/local/bin/gosu.asc \
-    && rm /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    && apt-get purge -y --auto-remove ca-certificates wget dirmngr gnupg2
-
 # make the "en_US.UTF-8" locale so freeswitch will be utf-8 enabled by default
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg2 gosu locales wget \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
 # https://freeswitch.org/confluence/display/FREESWITCH/Debian
 
-RUN apt-get update && apt-get install ca-certificates lsb-release -y --no-install-recommends \
+RUN wget --no-verbose --http-user=signalwire --http-password=${TOKEN} \
+      -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg \
+      https://freeswitch.signalwire.com/repo/deb/debian-release/signalwire-freeswitch-repo.gpg \
     && echo "machine freeswitch.signalwire.com login signalwire password ${TOKEN}" > /etc/apt/auth.conf \
-    && echo "deb [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ `lsb_release -sc` main" > /etc/apt/sources.list.d/freeswitch.list \
-    && apt-get update && apt-get install -y freeswitch-all \
-    && apt-get purge -y --auto-remove ca-certificates lsb-release \
+    && echo "deb [signed-by=/usr/share/keyrings/signalwire-freeswitch-repo.gpg] https://freeswitch.signalwire.com/repo/deb/debian-release/ ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/freeswitch.list \
+    && apt-get -qq update \
+    && apt-get install -y ${FS_META_PACKAGE} \
+    && apt-get purge -y --auto-remove \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY docker-entrypoint.sh /

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -7,6 +7,15 @@ FROM debian:${DEBIAN_VERSION}
 ARG DEBIAN_VERSION
 ARG TOKEN
 
+# By default, install the full set of FreeSWITCH packages.  Specify an alternative with:
+#   --build-arg="FS_META_PACKAGE=freeswitch-meta-vanilla"
+# alternatives include:
+#   freeswitch-meta-bare
+#   freeswitch-meta-vanilla
+#   freeswitch-meta-sorbet
+#   freeswitch-meta-all-dbg
+ARG FS_META_PACKAGE=freeswitch-meta-all
+
 # Source Dockerfile:
 # https://github.com/docker-library/postgres/blob/master/9.4/Dockerfile
 
@@ -20,6 +29,7 @@ RUN apt-get update -qq \
 ENV LANG en_US.utf8
 
 # https://freeswitch.org/confluence/display/FREESWITCH/Debian
+# https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Installation/Linux/Debian_67240088/
 
 RUN wget --no-verbose --http-user=signalwire --http-password=${TOKEN} \
       -O /usr/share/keyrings/signalwire-freeswitch-repo.gpg \
@@ -35,16 +45,16 @@ COPY docker-entrypoint.sh /
 # Add anything else here
 
 ## Ports
-# Open the container up to the world.
-### 8021 fs_cli, 5060 5061 5080 5081 sip and sips, 64535-65535 rtp
+# Document ports used by this container
+### 8021 fs_cli, 5060 5061 5080 5081 sip and sips, 5066 ws, 7443 wss, 8081 8082 verto, 16384-32768, 64535-65535 rtp
 EXPOSE 8021/tcp
 EXPOSE 5060/tcp 5060/udp 5080/tcp 5080/udp
 EXPOSE 5061/tcp 5061/udp 5081/tcp 5081/udp
+EXPOSE 5066/tcp
 EXPOSE 7443/tcp
-EXPOSE 5070/udp 5070/tcp
+EXPOSE 8081/tcp 8082/tcp
 EXPOSE 64535-65535/udp
 EXPOSE 16384-32768/udp
-
 
 # Volumes
 ## Freeswitch Configuration


### PR DESCRIPTION
Hi, I'm not 100% sure what context(s) this Dockerfile is used in, but it appeared to be the right starting place for building images based on the package in the SignalWire repo.  The goals of the PR:

- default to Debian bookworm
- drop the dependency on `lsb-release` since `DEBIAN_VERSION` is supplied as an ARG (although `lsb-release` has gotten much smaller starting in bookworm)
- use Debian's [gosu](https://tracker.debian.org/pkg/gosu) package; it is available since at least buster
- add a `FS_META_PACKAGE` build-arg to make it easy to build other meta package-based variants
- add the `-c` argument to `SHELL`;  without this, a docker build `RUN` using this image as a base would fail with an exec error

I've tested building and running several variants like so:
``` sh
docker build --build-arg="TOKEN=${SIGNALWIRE_PAT}" \
    --build-arg="FS_META_PACKAGE=freeswitch-meta-vanilla" . -t fs:deb-vanilla
```

Creating a derived image:
```Dockerfile
# dockerfile that installs mod_switchwire
FROM fs:deb-vanilla
RUN apt-get update && apt-get install -y freeswitch-mod-signalwire
```

And then running it like so:
```sh
docker run -it \
    --network host \
    --volume="/etc/freeswitch:/etc/freeswitch:rw" \
    --volume="/var/lib/freeswitch:/var/lib/freeswitch:rw" \
    --volume="/var/log/freeswitch:/var/log/freeswitch:rw" \
    --volume="/usr/share/freeswitch:/usr/share/freeswitch:ro" \
    fs:deb-vanilla
```

I'm happy to split up the PR if you'd like it composed differently.   Thank you for maintaining FreeSWITCH!