### PR TITLE
[core] Fix bug on originate_delay_start delays more than once

### DIFF
--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -2330,6 +2330,8 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 				tmp--;
 			}
 		}
+
+		switch_event_del_header(var_event, "originate_delay_start");
 	}
 
 	if (oglobals.session) {


### PR DESCRIPTION
When `switch_ivr_originate` is called with endpoints as the user endpoint that also calls `switch_ivr_originate`, freeswitch will wait for the `originate_delay_start` duration every time `switch_ivr_originate` is called.