### PR TITLE
[mod_dptools] explicit ordering eavesdrop all

### DIFF
--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -954,7 +954,7 @@ SWITCH_STANDARD_APP(eavesdrop_function)
 			switch_cache_db_handle_t *db = NULL;
 			char *errmsg = NULL;
 			struct e_data e_data = { {0} };
-			char *sql = switch_mprintf("select uuid from channels where uuid != '%q'", switch_core_session_get_uuid(session));
+			char *sql = switch_mprintf("select uuid from channels where uuid != '%q' order by created_epoch desc", switch_core_session_get_uuid(session));
 			const char *file = NULL;
 			int x = 0;
 			char buf[2] = "";


### PR DESCRIPTION
I propose this change from my implementations for call centers, where a supervisor wants to listen from the last call to first. Without that sometimes eavesdrop doesn't work as expected.