### PR TITLE
mod_verto: add user_chat_context variable

### DIFF
--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -3869,7 +3869,9 @@ static switch_bool_t verto__info_func(const char *method, cJSON *params, jsock_t
 
 		switch_mutex_lock(jsock->flag_mutex);
 
-		if (!(context = switch_event_get_header(jsock->vars, "user_context"))) {
+
+		if (!(context = switch_event_get_header(jsock->vars, "user_chat_context"))
+			&& !(context = switch_event_get_header(jsock->vars, "user_context"))) {
 			context = switch_either(jsock->context, jsock->profile->context);
 		}
 


### PR DESCRIPTION
use a different context for chat messages with the variable "user_chat_context".

example:

```
<variables>
<variable name="user_context" value="outgoing" />
<variable name="user_chat_context" value="default" />
</variables>
```

