### PR TITLE
[mod_event_socket] Check if listener is running before pushing more logs or events to its queue

### DIFF
--- a/src/mod/event_handlers/mod_event_socket/mod_event_socket.c
+++ b/src/mod/event_handlers/mod_event_socket/mod_event_socket.c
@@ -173,7 +173,7 @@ static switch_status_t socket_logger(const switch_log_node_t *node, switch_log_l
 	switch_status_t qstatus;
 	switch_mutex_lock(globals.listener_mutex);
 	for (l = listen_list.listeners; l; l = l->next) {
-		if (switch_test_flag(l, LFLAG_LOG) && l->level >= node->level) {
+		if (switch_test_flag(l, LFLAG_LOG) && l->level >= node->level && switch_test_flag(l, LFLAG_RUNNING)) {
 			switch_log_node_t *dnode = switch_log_node_dup(node);
 			qstatus = switch_queue_trypush(l->log_queue, dnode); 
 			if (qstatus == SWITCH_STATUS_SUCCESS) {
@@ -302,7 +302,7 @@ static void event_handler(switch_event_t *event)
 			}
 		}
 
-		if (l->expire_time || !switch_test_flag(l, LFLAG_EVENTS)) {
+		if (l->expire_time || !switch_test_flag(l, LFLAG_EVENTS) || !switch_test_flag(l, LFLAG_RUNNING)) {
 			last = l;
 			continue;
 		}


### PR DESCRIPTION
This fixes a possibility for MAX_MISSED to be exceeded if more logs are attempted to be pushed to the listener's queue after running kill_listener but before the listener thread gets CPU time and removes itself.

On a heavily loaded system with a lot of logs in the event dispatch queue these excessive logs may prove fatal since socket_logger itself will produce logs about the full queue, resulting in a circular situation of never-ending logs.

The same logic was applied to event_handler after finding the same behaviour mentioned in signalwire/freeswitch#2143.