### PR TITLE
[mod_sofia] clean up passive presence database entries

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_presence.c
+++ b/src/mod/endpoints/mod_sofia/sofia_presence.c
@@ -5070,9 +5070,9 @@ void sofia_presence_check_subscriptions(sofia_profile_t *profile, time_t now)
 	if (now) {
 		struct pres_sql_cb cb = {profile, 0};
 
-		if (profile->pres_type != PRES_TYPE_FULL) {
+		if (profile->pres_type == PRES_TYPE_NONE) {
 			if (mod_sofia_globals.debug_presence > 0) {
-				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "check_subs: %s is passive, skipping\n", (char *) profile->name);
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "check_subs: %s is not presence enabled, skipping\n", (char *) profile->name);
 			}
 			return;
 		}


### PR DESCRIPTION
sofia_presence_check_subscriptions() only deletes database entries for the main profile and leaves entries that are for any passive profiles behind. As these never get deleted otherwise, they accumulate and slow things down and use up table space. This should fix issue 2277.