### PR TITLE
Send event on incoming ACK

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -6634,6 +6634,11 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_sofia_load)
 		switch_goto_status(SWITCH_STATUS_TERM, err);
 	}
 
+	if (switch_event_reserve_subclass(MY_EVENT_ACK_REQUEST) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Couldn't register subclass %s!\n", MY_EVENT_ACK_REQUEST);
+		switch_goto_status(SWITCH_STATUS_TERM, err);
+	}
+
 	switch_find_local_ip(mod_sofia_globals.guess_ip, sizeof(mod_sofia_globals.guess_ip), &mod_sofia_globals.guess_mask, AF_INET);
 	in.s_addr = mod_sofia_globals.guess_mask;
 	switch_set_string(mod_sofia_globals.guess_mask_str, inet_ntoa(in));
@@ -6853,6 +6858,7 @@ void mod_sofia_shutdown_cleanup(void) {
 	switch_event_free_subclass(MY_EVENT_REGISTER);
 	switch_event_free_subclass(MY_EVENT_GATEWAY_ADD);
 	switch_event_free_subclass(MY_EVENT_BYE_RESPONSE);
+	switch_event_free_subclass(MY_EVENT_ACK_REQUEST);
 
 	switch_console_del_complete_func("::sofia::list_profiles");
 	switch_console_set_complete("del sofia");

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -108,6 +108,7 @@ typedef struct private_object private_object_t;
 #define MY_EVENT_INTERCEPTED "sofia::intercepted"
 
 #define MY_EVENT_BYE_RESPONSE "sofia::bye_response"
+#define MY_EVENT_ACK_REQUEST "sofia::ack_request"
 
 #define MULTICAST_EVENT "multicast::event"
 #define SOFIA_REPLACES_HEADER "_sofia_replaces_"

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -1669,6 +1669,7 @@ static void our_sofia_event_callback(nua_event_t event,
 		{
 			if (channel && sip) {
 				const char *r_sdp = NULL;
+				switch_event_t *event;
 				sofia_glue_store_session_id(session, profile, sip, 0);
 
 				if (sip->sip_payload && sip->sip_payload->pl_data) {
@@ -1749,6 +1750,10 @@ static void our_sofia_event_callback(nua_event_t event,
 
 				}
 
+				if (switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, MY_EVENT_ACK_REQUEST) == SWITCH_STATUS_SUCCESS) {
+					switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "ack_received", "true");
+					switch_event_fire(&event);
+				}
 
 			}
 		}


### PR DESCRIPTION
For some use cases it would beneficial to have event when ACK message is received. This PR adds support for that.