### PR TITLE
[mod_dialplan_xml] new attribute to not break from nested conditions

### DIFF
--- a/src/mod/dialplans/mod_dialplan_xml/mod_dialplan_xml.c
+++ b/src/mod/dialplans/mod_dialplan_xml/mod_dialplan_xml.c
@@ -573,9 +573,15 @@ static int parse_exten(switch_core_session_t *session, switch_caller_profile_t *
 		}
 		switch_regex_safe_free(re);
 
-		if (((anti_action == SWITCH_FALSE && do_break_i == BREAK_ON_TRUE) ||
-			 (anti_action == SWITCH_TRUE && do_break_i == BREAK_ON_FALSE)) || do_break_i == BREAK_ALWAYS) {
-			break;
+		if (switch_xml_child(xcond, "condition") && switch_xml_attr(xexten, "break-from-nested") && switch_false(switch_xml_attr(xexten, "break-from-nested"))) {
+			if ((anti_action == SWITCH_TRUE && do_break_i == BREAK_ON_FALSE)) {
+				break;
+			}
+		} else {
+			if (((anti_action == SWITCH_FALSE && do_break_i == BREAK_ON_TRUE) ||
+				(anti_action == SWITCH_TRUE && do_break_i == BREAK_ON_FALSE)) || do_break_i == BREAK_ALWAYS) {
+				break;
+			}
 		}
 
 		if (proceed) {
@@ -587,6 +593,12 @@ static int parse_exten(switch_core_session_t *session, switch_caller_profile_t *
 					goto done;
 				}
 			}
+		}
+
+		/* need to recheck this if we didn't break ealier because of break-from-nested */
+		if (((anti_action == SWITCH_FALSE && do_break_i == BREAK_ON_TRUE) ||
+			(anti_action == SWITCH_TRUE && do_break_i == BREAK_ON_FALSE)) || do_break_i == BREAK_ALWAYS) {
+			break;
 		}
 	}
 


### PR DESCRIPTION
The default behavior is to always break from proceeding to nested conditions even if a condition matches, besides when `break="never"`.

Common sense says when a condition matches and `break` is set to `on-true` to proceed to nested conditions, and `break` should only apply to the subsequent conditions.

This commit introduces a new extension attribute, `break-from-nested` that can be set to `false` to not break from nested conditions if the condition matches; besides, if `break="on-false"`

The default behavior will be `break-from-nested=true`, so it won't break any existing systems.

Example:
```xml
<extension name="break-from-nested-test" continue="true" break-from-nested="false">
	<condition>
		<action application="set" data="var1=true" inline="true"/>
	</condition>

	<condition field="${var1}" expression="^true$" break="on-true">
		<action application="log" data="err external condition" inline="true"/>

		<condition>
			<action application="log" data="err I will only log if break-from-nested is set to false" inline="true"/>
		</condition>
	</condition>

	<condition>
		<action application="log" data="err I will only log if previous conditions did not break" inline="true"/>
	</condition>
</extension>
```