### PR TITLE
[Docker] Change default freeswitch UID and GID to 499 in docker/master/Dockerfile

### DIFF
--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -20,7 +20,9 @@ ARG FS_META_PACKAGE=freeswitch-meta-all
 # https://github.com/docker-library/postgres/blob/master/9.4/Dockerfile
 
 # explicitly set user/group IDs
-RUN groupadd -r freeswitch --gid=999 && useradd -r -g freeswitch --uid=999 freeswitch
+ARG FREESWITCH_UID=499
+ARG FREESWITCH_GID=499
+RUN groupadd -r freeswitch --gid=${FREESWITCH_GID} && useradd -r -g freeswitch --uid=${FREESWITCH_UID} freeswitch
 
 # make the "en_US.UTF-8" locale so freeswitch will be utf-8 enabled by default
 RUN apt-get update -qq \


### PR DESCRIPTION
On several installs on recent Debian and Ubuntu systems, I have noticed that GID 999 is already allocated on the system running the container, making it a minor hassle to share a common freeswitch UID and GID between the Docker host and the container.

The conflicting group id varies, but is typically either one of the systemd groups or polkitd, which are dynamically created when those packages are installed.  The behavior stems from the range of system GIDs being between 100-999 ([see Debian Policy 9.2.2](https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes)) and the fact that system installation dynamically allocates from this range.  I didn't track down exactly why these daemons are allocating from the top of the range, since the default behavior of `adduser` and `addgroup` ([link](https://salsa.debian.org/debian/adduser/-/blob/6c04aa701a2ca09efbff9094ab07e7dae14554fc/adduser#L1255-1269)) is to search from the bottom of the range, and the manpage for `groupadd` says that it's default is also to use the smallest id, but perhaps it is (also) an attempt to avoid conflicts.

The approach taken in this PR is to default to 499, more in the middle of the range, which should reduce the chance of conflicting with an existing system UID and GID.  The values are also now exposed as ARGs and so can be explicitly set during the build with `--build-arg="FREESWITCH_UID=xxx"` and `--build-arg="FREESWITCH_GID=yyy"` if desired.

(I didn't find other references to UID/GID 999 in the documentation, but it's certainly possible that I missed something.)