### PR TITLE
fix mod_httapi caching files as binary on windows (e.g. when using WAV files)

### DIFF
--- a/src/mod/applications/mod_httapi/mod_httapi.c
+++ b/src/mod/applications/mod_httapi/mod_httapi.c
@@ -2501,7 +2501,11 @@ static switch_status_t fetch_cache_data(http_file_context_t *context, const char
 
 	if (save_path) {
 		while(--tries && (client->fd == 0 || client->fd == -1)) {
+			#ifdef WIN32
+			client->fd = open(save_path, O_CREAT | O_WRONLY | O_TRUNC | O_BINARY, S_IRUSR | S_IWUSR);
+			#else
 			client->fd = open(save_path, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+			#endif
 		}
 
 		if (client->fd < 0) {


### PR DESCRIPTION
On Windows it's not possible to cache binary files (e.g. WAV files) in mod_httapi due to interpretation of line endings.
This fix will solve the problem by creating files with the O_BINARY flag on Windows.