### PR TITLE
[mod_amr, mod_amrwb] Fix input data corruption

### DIFF
--- a/src/mod/codecs/mod_amr/mod_amr.c
+++ b/src/mod/codecs/mod_amr/mod_amr.c
@@ -288,12 +288,15 @@ static switch_status_t switch_amr_init(switch_codec_t *codec, switch_codec_flag_
 			switch_assert(fmtp_dup);
 
 			argc = switch_separate_string(fmtp_dup, ';', argv, (sizeof(argv) / sizeof(argv[0])));
+
 			for (x = 0; x < argc; x++) {
 				char *data = argv[x];
 				char *arg;
+
 				while (*data && *data == ' ') {
 					data++;
 				}
+
 				if ((arg = strchr(data, '='))) {
 					*arg++ = '\0';
 					if (!strcasecmp(data, "octet-align")) {
@@ -329,13 +332,16 @@ static switch_status_t switch_amr_init(switch_codec_t *codec, switch_codec_flag_
 					} else if (!strcasecmp(data, "mode-set")) {
 						int y, m_argc;
 						char *m_argv[SWITCH_AMR_MODES-1];
+
 						m_argc = switch_separate_string(arg, ',', m_argv, (sizeof(m_argv) / sizeof(m_argv[0])));
+
 						for (y = 0; y < m_argc; y++) {
 							context->enc_modes |= (1 << atoi(m_argv[y]));
 						}
 					}
 				}
 			}
+
 			free(fmtp_dup);
 		}
 
@@ -483,11 +489,7 @@ static switch_status_t switch_amr_decode(switch_codec_t *codec,
 	unsigned char buf[SWITCH_AMR_OUT_MAX_SIZE];
 	uint8_t tmp[SWITCH_AMR_OUT_MAX_SIZE];
 
-	if (!context) {
-		return SWITCH_STATUS_FALSE;
-	}
-
-	if (encoded_data_len > SWITCH_AMR_OUT_MAX_SIZE) {
+	if (!context || encoded_data_len > SWITCH_AMR_OUT_MAX_SIZE) {
 		return SWITCH_STATUS_FALSE;
 	}
 

--- a/src/mod/codecs/mod_amrwb/mod_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/mod_amrwb.c
@@ -227,12 +227,15 @@ static switch_status_t switch_amrwb_init(switch_codec_t *codec, switch_codec_fla
 			switch_assert(fmtp_dup);
 
 			argc = switch_separate_string(fmtp_dup, ';', argv, (sizeof(argv) / sizeof(argv[0])));
+
 			for (x = 0; x < argc; x++) {
 				char *data = argv[x];
 				char *arg;
+
 				while (*data && *data == ' ') {
 					data++;
 				}
+
 				if ((arg = strchr(data, '='))) {
 					*arg++ = '\0';
 					if (!strcasecmp(data, "octet-align")) {
@@ -268,7 +271,9 @@ static switch_status_t switch_amrwb_init(switch_codec_t *codec, switch_codec_fla
 					} else if (!strcasecmp(data, "mode-set")) {
 						int y, m_argc;
 						char *m_argv[SWITCH_AMRWB_MODES-1]; /* AMRWB has 9 modes */
+
 						m_argc = switch_separate_string(arg, ',', m_argv, (sizeof(m_argv) / sizeof(m_argv[0])));
+
 						for (y = 0; y < m_argc; y++) {
 							context->enc_modes |= (1 << atoi(m_argv[y]));
 							context->enc_mode = atoi(m_argv[y]);
@@ -276,6 +281,7 @@ static switch_status_t switch_amrwb_init(switch_codec_t *codec, switch_codec_fla
 					}
 				}
 			}
+
 			free(fmtp_dup);
 		}
 
@@ -409,11 +415,7 @@ static switch_status_t switch_amrwb_decode(switch_codec_t *codec,
 	unsigned char buf[SWITCH_AMRWB_OUT_MAX_SIZE];
 	uint8_t tmp[SWITCH_AMRWB_OUT_MAX_SIZE];
 
-	if (!context) {
-		return SWITCH_STATUS_FALSE;
-	}
-
-	if (encoded_data_len > SWITCH_AMRWB_OUT_MAX_SIZE) {
+	if (!context || encoded_data_len > SWITCH_AMRWB_OUT_MAX_SIZE) {
 		return SWITCH_STATUS_FALSE;
 	}
 


### PR DESCRIPTION
Two similar problems with AMR and AMRWB are fixed here:
1. decode() function calls switch_amr_unpack_be/switch_amr_unpack_oa which unpacks the data in-place, thus corrupting the frame being decoded. If a READ media bug is present in the session (e.g. when using record_session), the same incoming AMR frame is decoded twice: first time for passing to the media bug and second time for passing to B-party. This results to the recorded audio being clear, but B-party hearing a distorted sound. This is described in #2134 .
The solution is to work on a copy of original encoded data.
2. init() function calls switch_separate_string() on codec->fmtp_in, which corrupts the fmtp string as a side effect. So when switch_core_codec_copy() is called, the resulting copy has different settings. The solution is to work on a copy of fmtp_in like other codecs do.