### PR TITLE
Add RTP bug flag "RTP_BUG_CHANGE_SSRC_ON_MARKER_ALSO_WHEN_SECURE" to allow SSRC change when using SRTP

### DIFF
--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -964,12 +964,19 @@ typedef enum {
 	*/
 
 
-	RTP_BUG_ALWAYS_AUTO_ADJUST = (1 << 12)
+	RTP_BUG_ALWAYS_AUTO_ADJUST = (1 << 12),
 
 	/*
 	  Leave the auto-adjust behavior enableed permenantly rather than only at appropriate times.  (IMPLICITLY sets RTP_BUG_ACCEPT_ANY_PACKETS)
 
 	 */
+
+
+	RTP_BUG_CHANGE_SSRC_ON_MARKER_ALSO_WHEN_SECURE = (1 << 13),
+
+	/*
+	  Allow SSRC change when using SRTP.
+	*/
 
 } switch_rtp_bug_flag_t;
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -1010,6 +1010,14 @@ SWITCH_DECLARE(void) switch_core_media_parse_rtp_bugs(switch_rtp_bug_flag_t *fla
 		*flag_pole &= ~RTP_BUG_CHANGE_SSRC_ON_MARKER;
 	}
 
+	if (switch_stristr("CHANGE_SSRC_ON_MARKER_ALSO_WHEN_SECURE", str)) {
+		*flag_pole |= RTP_BUG_CHANGE_SSRC_ON_MARKER_ALSO_WHEN_SECURE;
+	}
+
+	if (switch_stristr("~CHANGE_SSRC_ON_MARKER_ALSO_WHEN_SECURE", str)) {
+		*flag_pole &= ~RTP_BUG_CHANGE_SSRC_ON_MARKER_ALSO_WHEN_SECURE;
+	}
+
 	if (switch_stristr("FLUSH_JB_ON_DTMF", str)) {
 		*flag_pole |= RTP_BUG_FLUSH_JB_ON_DTMF;
 	}

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -8215,7 +8215,7 @@ static int rtp_common_write(switch_rtp_t *rtp_session,
 			int delta = rtp_session->ts - rtp_session->last_write_ts;
 
 			if (!rtp_session->flags[SWITCH_RTP_FLAG_UDPTL] &&
-				((!rtp_session->flags[SWITCH_RTP_FLAG_RESET] && (abs(delta) > rtp_session->samples_per_interval * 10))
+				((rtp_session->flags[SWITCH_RTP_FLAG_RESET] && (abs(delta) > rtp_session->samples_per_interval * 10))
 				|| rtp_session->ts == rtp_session->samples_per_interval)) {
 				m++;
 			}
@@ -8251,7 +8251,8 @@ static int rtp_common_write(switch_rtp_t *rtp_session,
 		}
 
 		/* If the marker was set, and the timestamp seems to have started over - set a new SSRC, to indicate this is a new stream */
-		if (m && !switch_rtp_test_flag(rtp_session, SWITCH_RTP_FLAG_SECURE_SEND) && (rtp_session->rtp_bugs & RTP_BUG_CHANGE_SSRC_ON_MARKER) &&
+		if (m && (rtp_session->rtp_bugs & RTP_BUG_CHANGE_SSRC_ON_MARKER) &&
+			(!switch_rtp_test_flag(rtp_session, SWITCH_RTP_FLAG_SECURE_SEND) || rtp_session->rtp_bugs & RTP_BUG_CHANGE_SSRC_ON_MARKER_ALSO_WHEN_SECURE) &&
 			(rtp_session->flags[SWITCH_RTP_FLAG_RESET] || (rtp_session->ts <= rtp_session->last_write_ts && rtp_session->last_write_ts > 0))) {
 			switch_rtp_set_ssrc(rtp_session, (uint32_t) ((intptr_t) rtp_session + (switch_time_t) switch_epoch_time_now(NULL)));
 		}


### PR DESCRIPTION
Fixes signalwire/freeswitch#2361, where a jump backwards in RTP timestamps caused silence at the start of calls when switching from generated ringback to remote media.