### PR TITLE
[mod_lua] Add Dbh:query_rows

### DIFF
--- a/src/mod/languages/mod_lua/freeswitch.i
+++ b/src/mod/languages/mod_lua/freeswitch.i
@@ -61,6 +61,11 @@
 %include "typemaps.i"
 %apply int *OUTPUT { int *len };
 
+%typemap(out) DbhQueryRowsReturn {
+    SWIG_arg += result;
+}
+
+
 /**
  * tell swig to grok everything defined in these header files and
  * build all sorts of c wrappers and lua shadows of the c wrappers.
@@ -115,6 +120,7 @@ class Dbh {
     bool connected();
     bool test_reactive(char *test_sql, char *drop_sql = NULL, char *reactive_sql = NULL);
     bool query(char *sql, SWIGLUA_FN lua_fun);
+    DbhQueryRowsReturn query_rows(lua_State* L, char *sql);
     int affected_rows();
     char *last_error();
     void clear_error();

--- a/src/mod/languages/mod_lua/freeswitch_lua.h
+++ b/src/mod/languages/mod_lua/freeswitch_lua.h
@@ -28,6 +28,7 @@ typedef struct{
 
 #define SWIGLUA_TABLE_GET(fn) {lua_pushvalue(fn.L,fn.idx);}
 
+typedef int DbhQueryRowsReturn;
 
 namespace LUA {
 	class Session:public CoreSession {
@@ -76,6 +77,7 @@ namespace LUA {
       bool connected();
       bool test_reactive(char *test_sql, char *drop_sql = NULL, char *reactive_sql = NULL);
       bool query(char *sql, SWIGLUA_FN lua_fun);
+      DbhQueryRowsReturn query_rows(lua_State* L, char *sql);
       int affected_rows();
       char *last_error();
       void clear_error();

--- a/src/mod/languages/mod_lua/hack.diff
+++ b/src/mod/languages/mod_lua/hack.diff
@@ -1,6 +1,6 @@
---- mod_lua_wrap.cpp.old	2015-06-16 12:27:19.024000000 -0500
-+++ mod_lua_wrap.cpp	2015-06-16 12:34:51.540000000 -0500
-@@ -4242,7 +4242,7 @@ static int _wrap_Stream_read(lua_State* L) {
+--- mod_lua_wrap.cpp.old	2025-01-15 13:22:48.705853645 +0000
++++ mod_lua_wrap.cpp	2025-01-15 13:23:33.161847705 +0000
+@@ -4242,7 +4242,7 @@
    }
    
    result = (char *)(arg1)->read(arg2);
@@ -9,7 +9,7 @@
    lua_pushnumber(L, (lua_Number) *arg2); SWIG_arg++;
    return SWIG_arg;
    
-@@ -8304,7 +8304,7 @@ static int _wrap_new_Session__SWIG_0(lua_State* L) {
+@@ -8336,7 +8336,7 @@
    
    SWIG_check_num_args("LUA::Session::Session",0,0)
    result = (LUA::Session *)new LUA::Session();
@@ -18,7 +18,7 @@
    return SWIG_arg;
    
    if(0) SWIG_fail;
-@@ -8331,7 +8331,7 @@ static int _wrap_new_Session__SWIG_1(lua_State* L) {
+@@ -8363,7 +8363,7 @@
    }
    
    result = (LUA::Session *)new LUA::Session(arg1,arg2);
@@ -27,7 +27,7 @@
    return SWIG_arg;
    
    if(0) SWIG_fail;
-@@ -8351,7 +8351,7 @@ static int _wrap_new_Session__SWIG_2(lua_State* L) {
+@@ -8383,7 +8383,7 @@
    if(!SWIG_lua_isnilstring(L,1)) SWIG_fail_arg("LUA::Session::Session",1,"char *");
    arg1 = (char *)lua_tostring(L, 1);
    result = (LUA::Session *)new LUA::Session(arg1);
@@ -36,7 +36,7 @@
    return SWIG_arg;
    
    if(0) SWIG_fail;
-@@ -8375,7 +8375,7 @@ static int _wrap_new_Session__SWIG_3(lua_State* L) {
+@@ -8407,7 +8407,7 @@
    }
    
    result = (LUA::Session *)new LUA::Session(arg1);
@@ -45,7 +45,7 @@
    return SWIG_arg;
    
    if(0) SWIG_fail;
-@@ -9485,6 +9485,7 @@ static int _wrap_Dbh_test_reactive__SWIG_0(lua_State* L) {
+@@ -9517,6 +9517,7 @@
    arg2 = (char *)lua_tostring(L, 2);
    arg3 = (char *)lua_tostring(L, 3);
    arg4 = (char *)lua_tostring(L, 4);
@@ -53,7 +53,7 @@
    result = (bool)(arg1)->test_reactive(arg2,arg3,arg4);
    lua_pushboolean(L,(int)(result!=0)); SWIG_arg++;
    return SWIG_arg;
-@@ -9516,6 +9516,7 @@ static int _wrap_Dbh_test_reactive__SWIG_1(lua_State* L) {
+@@ -9547,6 +9548,7 @@
    
    arg2 = (char *)lua_tostring(L, 2);
    arg3 = (char *)lua_tostring(L, 3);
@@ -61,7 +61,7 @@
    result = (bool)(arg1)->test_reactive(arg2,arg3);
    lua_pushboolean(L,(int)(result!=0)); SWIG_arg++;
    return SWIG_arg;
-@@ -9543,6 +9544,7 @@ static int _wrap_Dbh_test_reactive__SWIG_2(lua_State* L) {
+@@ -9574,6 +9576,7 @@
    }
    
    arg2 = (char *)lua_tostring(L, 2);
@@ -69,7 +69,7 @@
    result = (bool)(arg1)->test_reactive(arg2);
    lua_pushboolean(L,(int)(result!=0)); SWIG_arg++;
    return SWIG_arg;
-@@ -9672,6 +9673,7 @@ static int _wrap_Dbh_query(lua_State* L) {
+@@ -9704,6 +9707,7 @@
        (&arg3)->idx = 3;
      }
    }
@@ -77,7 +77,15 @@
    result = (bool)(arg1)->query(arg2,arg3);
    lua_pushboolean(L,(int)(result!=0)); SWIG_arg++;
    return SWIG_arg;
-@@ -9695,7 +9697,7 @@ static int _wrap_Dbh_affected_rows(lua_State* L) {
+@@ -9733,6 +9737,7 @@
+   }
+   
+   arg3 = (char *)lua_tostring(L, 2);
++  switch_assert(arg1);
+   result = (arg1)->query_rows(arg2,arg3);
+   {
+     SWIG_arg += result;
+@@ -9758,7 +9763,7 @@
    if (!SWIG_IsOK(SWIG_ConvertPtr(L,1,(void**)&arg1,SWIGTYPE_p_LUA__Dbh,0))){
      SWIG_fail_ptr("Dbh_affected_rows",1,SWIGTYPE_p_LUA__Dbh);
    }
@@ -86,7 +94,7 @@
    result = (int)(arg1)->affected_rows();
    lua_pushnumber(L, (lua_Number) result); SWIG_arg++;
    return SWIG_arg;
-@@ -9719,7 +9721,7 @@ static int _wrap_Dbh_last_error(lua_State* L) {
+@@ -9782,7 +9787,7 @@
    if (!SWIG_IsOK(SWIG_ConvertPtr(L,1,(void**)&arg1,SWIGTYPE_p_LUA__Dbh,0))){
      SWIG_fail_ptr("Dbh_last_error",1,SWIGTYPE_p_LUA__Dbh);
    }
@@ -95,7 +103,7 @@
    result = (char *)(arg1)->last_error();
    lua_pushstring(L,(const char *)result); SWIG_arg++;
    return SWIG_arg;
-@@ -9742,7 +9744,7 @@ static int _wrap_Dbh_clear_error(lua_State* L) {
+@@ -9805,7 +9810,7 @@
    if (!SWIG_IsOK(SWIG_ConvertPtr(L,1,(void**)&arg1,SWIGTYPE_p_LUA__Dbh,0))){
      SWIG_fail_ptr("Dbh_clear_error",1,SWIGTYPE_p_LUA__Dbh);
    }
@@ -104,7 +112,7 @@
    (arg1)->clear_error();
    
    return SWIG_arg;
-@@ -9770,6 +9772,7 @@ static int _wrap_Dbh_load_extension(lua_State* L) {
+@@ -9833,6 +9838,7 @@
    }
    
    arg2 = (char *)lua_tostring(L, 2);
@@ -112,7 +120,7 @@
    result = (int)(arg1)->load_extension((char const *)arg2);
    lua_pushnumber(L, (lua_Number) result); SWIG_arg++;
    return SWIG_arg;
-@@ -9869,6 +9872,7 @@ static int _wrap_JSON_decode(lua_State* L) {
+@@ -9933,6 +9939,7 @@
    }
    
    arg2 = (char *)lua_tostring(L, 2);
@@ -120,7 +128,7 @@
    result = (cJSON *)(arg1)->decode((char const *)arg2);
    {
      SWIG_arg += LUA::JSON::cJSON2LuaTable(L, result);
-@@ -9902,6 +9906,7 @@ static int _wrap_JSON_encode(lua_State* L) {
+@@ -9966,6 +9973,7 @@
      (&arg2)->L = L;
      (&arg2)->idx = 2;
    }
@@ -128,7 +136,7 @@
    result = (arg1)->encode(arg2);
    lua_pushlstring(L,(&result)->data(),(&result)->size()); SWIG_arg++;
    return SWIG_arg;
-@@ -9929,6 +9934,7 @@ static int _wrap_JSON_execute__SWIG_0(lua_State* L) {
+@@ -9993,6 +10001,7 @@
    }
    
    arg2 = (char *)lua_tostring(L, 2);
@@ -136,7 +144,7 @@
    result = (cJSON *)(arg1)->execute((char const *)arg2);
    {
      SWIG_arg += LUA::JSON::cJSON2LuaTable(L, result);
-@@ -9962,6 +9968,7 @@ static int _wrap_JSON_execute__SWIG_1(lua_State* L) {
+@@ -10026,6 +10035,7 @@
      (&arg2)->L = L;
      (&arg2)->idx = 2;
    }
@@ -144,7 +152,7 @@
    result = (cJSON *)(arg1)->execute(arg2);
    {
      SWIG_arg += LUA::JSON::cJSON2LuaTable(L, result);
-@@ -10046,6 +10053,7 @@ static int _wrap_JSON_execute2__SWIG_0(lua_State* L) {
+@@ -10110,6 +10120,7 @@
    }
    
    arg2 = (char *)lua_tostring(L, 2);
@@ -152,7 +160,7 @@
    result = (arg1)->execute2((char const *)arg2);
    lua_pushlstring(L,(&result)->data(),(&result)->size()); SWIG_arg++;
    return SWIG_arg;
-@@ -10076,6 +10084,7 @@ static int _wrap_JSON_execute2__SWIG_1(lua_State* L) {
+@@ -10140,6 +10151,7 @@
      (&arg2)->L = L;
      (&arg2)->idx = 2;
    }
@@ -160,7 +168,7 @@
    result = (arg1)->execute2(arg2);
    lua_pushlstring(L,(&result)->data(),(&result)->size()); SWIG_arg++;
    return SWIG_arg;
-@@ -10156,6 +10165,7 @@ static int _wrap_JSON_encode_empty_table_as_object(lua_State* L) {
+@@ -10220,6 +10232,7 @@
    }
    
    arg2 = (lua_toboolean(L, 2)!=0);
@@ -168,7 +176,7 @@
    (arg1)->encode_empty_table_as_object(arg2);
    
    return SWIG_arg;
-@@ -10182,6 +10192,7 @@ static int _wrap_JSON_return_unformatted_json(lua_State* L) {
+@@ -10246,6 +10259,7 @@
    }
    
    arg2 = (lua_toboolean(L, 2)!=0);

--- a/src/mod/languages/mod_lua/mod_lua_wrap.cpp
+++ b/src/mod/languages/mod_lua/mod_lua_wrap.cpp
@@ -9720,6 +9720,38 @@ fail:
 }
 
 
+static int _wrap_Dbh_query_rows(lua_State* L) {
+  int SWIG_arg = 0;
+  LUA::Dbh *arg1 = (LUA::Dbh *) 0 ;
+  lua_State *arg2 = (lua_State *) 0 ;
+  char *arg3 = (char *) 0 ;
+  DbhQueryRowsReturn result;
+  
+  arg2 = L;
+  SWIG_check_num_args("LUA::Dbh::query_rows",2,2)
+  if(!SWIG_isptrtype(L,1)) SWIG_fail_arg("LUA::Dbh::query_rows",1,"LUA::Dbh *");
+  if(!SWIG_lua_isnilstring(L,2)) SWIG_fail_arg("LUA::Dbh::query_rows",2,"char *");
+  
+  if (!SWIG_IsOK(SWIG_ConvertPtr(L,1,(void**)&arg1,SWIGTYPE_p_LUA__Dbh,0))){
+    SWIG_fail_ptr("Dbh_query_rows",1,SWIGTYPE_p_LUA__Dbh);
+  }
+  
+  arg3 = (char *)lua_tostring(L, 2);
+  switch_assert(arg1);
+  result = (arg1)->query_rows(arg2,arg3);
+  {
+    SWIG_arg += result;
+  }
+  return SWIG_arg;
+  
+  if(0) SWIG_fail;
+  
+fail:
+  lua_error(L);
+  return SWIG_arg;
+}
+
+
 static int _wrap_Dbh_affected_rows(lua_State* L) {
   int SWIG_arg = 0;
   LUA::Dbh *arg1 = (LUA::Dbh *) 0 ;
@@ -9839,6 +9871,7 @@ static swig_lua_method swig_Dbh_methods[]= {
     { "connected", _wrap_Dbh_connected},
     { "test_reactive", _wrap_Dbh_test_reactive},
     { "query", _wrap_Dbh_query},
+    { "query_rows", _wrap_Dbh_query_rows},
     { "affected_rows", _wrap_Dbh_affected_rows},
     { "last_error", _wrap_Dbh_last_error},
     { "clear_error", _wrap_Dbh_clear_error},


### PR DESCRIPTION
The added method, query_rows, allows the retrieval of rows from a database without the need for a callback function, it fetches the rows and returns 3 arguments as show below.

```lua
local success, rows, err = dbh:query_rows(sql)
```

This function performs better with large number of rows. Test results below 50k rows returned.

dbh:query(sql, callback) - 0.335949 seconds
dbh:query_rows(sql) - 0.253178 seconds