### PR TITLE
[mod_sofia] Fixing deadlock in issue #2290

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -1482,6 +1482,9 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 			sofia_clear_flag(tech_pvt, TFLAG_EARLY_MEDIA);
 		}
 		goto end;
+	case SWITCH_MESSAGE_INDICATE_TRANSCODING_NECESSARY:
+		// There doesn't seem to be anything needing to be done, so let's skip the mutex deadlock in issue 2290
+		goto end;
 	case SWITCH_MESSAGE_INDICATE_ANSWER:
 	case SWITCH_MESSAGE_INDICATE_PROGRESS:
 		{


### PR DESCRIPTION
I cannot certify that on SWITCH_MESSAGE_INDICATE_TRANSCODING_NECESSARY that we should be following this code path, but it does not look like there's anything that gets changed when we enter sofia_receive_message() in this case.  Thus there's no sense in locking tech_pvt->sofia_mutex , thus avoiding the deadlock described in issue #2290.