### PR TITLE
Fix #2383: [switch_core_media] Fix audio mode when SDP has recvonly in Session Attribute(a) instead of Media Attribute(a)

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5279,7 +5279,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					switch_channel_set_variable(session->channel, "media_audio_mode", "recvonly");
 				} else if (sendonly < 2 && !strcasecmp(attr->a_name, "inactive")) {
 					switch_channel_set_variable(session->channel, "media_audio_mode", "inactive");
-				} else if (!strcasecmp(attr->a_name, "recvonly")) {
+				} else if (!strcasecmp(attr->a_name, "recvonly") &&  m->m_mode != SWITCH_MEDIA_FLOW_RECVONLY;) {
 					switch_channel_set_variable(session->channel, "media_audio_mode", "sendonly");
 					recvonly = 1;
 


### PR DESCRIPTION

The switch_core_media_negotiate_sdp function was setting the media_audio_mode to sendonly when the SDP had a recvonly attribute, regardless of the current media mode. This caused one-way audio issues when renegotiating SDP while unhold. This patch adds an extra check to avoid overriding the existing media mode.