### PR TITLE
[mod_shout] fix build with new clang on macOS

### DIFF
--- a/src/mod/formats/mod_shout/mod_shout.c
+++ b/src/mod/formats/mod_shout/mod_shout.c
@@ -619,7 +619,11 @@ static void *SWITCH_THREAD_FUNC write_stream_thread(switch_thread_t *thread, voi
 			}
 		} else {
 			memset(mp3buf, 0, 128);
-			shout_send(context->shout, mp3buf, 128);
+			ret = shout_send(context->shout, mp3buf, 128);
+			if (ret != SHOUTERR_SUCCESS) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Send error: %s\n", shout_get_error(context->shout));
+				goto error;
+			}
 		}
 
 		shout_sync(context->shout);


### PR DESCRIPTION
fix error: ignoring return value of function declared with warn_unused_result attribute [-Werror,-Wunused-result] Apple clang version 15.0.0 (clang-1500.1.0.2.5)