### PR TITLE
[mod_avmd] adding avmd report variables

### DIFF
--- a/src/mod/applications/mod_avmd/mod_avmd.c
+++ b/src/mod/applications/mod_avmd/mod_avmd.c
@@ -21,6 +21,7 @@
  *
  * Eric des Courtis <eric.des.courtis@benbria.com>
  * Piotr Gregor <piotrgregor@rsyncme.org>
+ * Evgenii Buchnev <evgenii.buchnev@yabbr.io>
  *
  * mod_avmd.c -- Advanced Voicemail Detection Module
  *
@@ -1978,6 +1979,9 @@ static void avmd_report_detection(avmd_session_t *s, enum avmd_detection_mode mo
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(s->session), SWITCH_LOG_INFO, "<<< AVMD - Beep Detected [%u][%u][%u][%u]: amplitude = [%f](max [%f]) variance = [%f], detection time [%" PRId64 "] [us] >>>\n",
 						mode, b->resolution, b->offset, d->idx, sma_amp_b->sma, b->amplitude_max, v_amp, detection_time);
 			}
+			switch_channel_set_variable_printf(channel, "avmd_report_amplitude", "%f", sma_amp_b->sma);
+			switch_channel_set_variable_printf(channel, "avmd_report_amplitude_max", "%f", b->amplitude_max);
+			switch_channel_set_variable_printf(channel, "avmd_report_amplitude_variance", "%f", v_amp);
 			break;
 
 		case AVMD_DETECT_FREQ:
@@ -1988,6 +1992,8 @@ static void avmd_report_detection(avmd_session_t *s, enum avmd_detection_mode mo
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(s->session), SWITCH_LOG_INFO, "<<< AVMD - Beep Detected [%u][%u][%u][%u]: f = [%f] variance = [%f], detection time [%" PRId64 "] [us] >>>\n",
 						mode, b->resolution, b->offset, d->idx, AVMD_TO_HZ(s->rate, f_sma), v_fir, detection_time);
 			}
+			switch_channel_set_variable_printf(channel, "avmd_report_frequency", "%f", AVMD_TO_HZ(s->rate, f_sma));
+			switch_channel_set_variable_printf(channel, "avmd_report_frequency_variance", "%f", v_fir);
 			break;
 
 		case AVMD_DETECT_BOTH:
@@ -1999,11 +2005,21 @@ static void avmd_report_detection(avmd_session_t *s, enum avmd_detection_mode mo
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(s->session), SWITCH_LOG_INFO, "<<< AVMD - Beep Detected [%u][%u][%u][%u]: f = [%f] variance = [%f], amplitude = [%f](max [%f]) variance = [%f], detection time [%" PRId64 "] [us] >>>\n",
 						mode, b->resolution, b->offset, d->idx, AVMD_TO_HZ(s->rate, f_sma), v_fir, sma_amp_b->sma, b->amplitude_max, v_amp, detection_time);
 			}
+			switch_channel_set_variable_printf(channel, "avmd_report_amplitude", "%f", sma_amp_b->sma);
+			switch_channel_set_variable_printf(channel, "avmd_report_amplitude_max", "%f", b->amplitude_max);
+			switch_channel_set_variable_printf(channel, "avmd_report_amplitude_variance", "%f", v_amp);
+			switch_channel_set_variable_printf(channel, "avmd_report_frequency", "%f", AVMD_TO_HZ(s->rate, f_sma));
+			switch_channel_set_variable_printf(channel, "avmd_report_frequency_variance", "%f", v_fir);
 			break;
 
 		default:
 			break;
 	}
+	switch_channel_set_variable_printf(channel, "avmd_report_mode", "%u", mode);
+	switch_channel_set_variable_printf(channel, "avmd_report_resolution", "%u", b->resolution);
+	switch_channel_set_variable_printf(channel, "avmd_report_offset", "%u", b->offset);
+	switch_channel_set_variable_printf(channel, "avmd_report_idx", "%u", d->idx);
+	switch_channel_set_variable_printf(channel, "avmd_report_detection_time", "%" PRId64, detection_time);
 	s->state.beep_state = BEEP_DETECTED;
 }
 


### PR DESCRIPTION
Added the following variables to be added to the channel on success of detection:

- avmd_report_amplitude
- avmd_report_amplitude_max
- avmd_report_amplitude_variance
- avmd_report_detection_time
- avmd_report_frequency
- avmd_report_frequency_variance
- avmd_report_idx
- avmd_report_mode
- avmd_report_offset
- avmd_report_resolution