### PR TITLE
fixed eavesdrop channel management via ESL

### DIFF
--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -2816,6 +2816,9 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_eavesdrop_session(switch_core_session
 				}
 				switch_buffer_unlock(ep->buffer);
 			}
+
+			switch_ivr_parse_all_events(session);
+
 		}
 
 	  end_loop:


### PR DESCRIPTION
The current `switch_ivr_eavesdrop_session` implementation does not call `switch_ivr_parse_all_events` and leads to the case when executing `eavesdrop` application blocks any command execution sent via ESL.

This PR fix this.
I have tested locally.