### PR TITLE
[mod_sofia] Prevent unnecessary re-processing of unmodified SDP

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -8503,7 +8503,7 @@ static void sofia_handle_sip_i_state(switch_core_session_t *session, int status,
 			/* sdp changed since 18X w sdp, we're supposed to ignore it but we, of course, were pressured into supporting it */
 			uint8_t match = 0;
 
-			sofia_clear_flag(tech_pvt, TFLAG_NEW_SDP);
+
 			switch_channel_set_flag(tech_pvt->channel, CF_REINVITE);
 
 
@@ -8531,6 +8531,7 @@ static void sofia_handle_sip_i_state(switch_core_session_t *session, int status,
 
 			}
 		}
+		sofia_clear_flag(tech_pvt, TFLAG_NEW_SDP);
 
 		if (r_sdp && sofia_test_flag(tech_pvt, TFLAG_NOSDP_REINVITE)) {
 			sofia_clear_flag_locked(tech_pvt, TFLAG_NOSDP_REINVITE);


### PR DESCRIPTION
Always clear flag TFLAG_NEW_SDP. 

This prevents re-processing of unmodified SDP during re-INVITEs. Before this change a remote party's UNMODIFIED answer to a re-INVITE would always be re-processed once, due to TFLAG_NEW_SDP still being set. Any subsequent re-INVITE thereafter would then behave as expected, as TFLAG_NEW_SDP would then have been cleared.