### PR TITLE
Fix the wrong type passed into iks_stack_delete

### DIFF
--- a/libs/iksemel/tools/hash.c
+++ b/libs/iksemel/tools/hash.c
@@ -138,7 +138,7 @@ hash_print (hash *h, char *title_fmt, char *line_fmt)
 void
 hash_delete (hash *h)
 {
-	iks_stack_delete (h->s);
+	iks_stack_delete (&h->s);
 	free (h->table);
 	free (h);
 }


### PR DESCRIPTION
iks_stack_delete expects a ikstack **, but ikstack * is passed instead. I believe it's a bug, which showed itself, because gcc 14 treats wrong pointer types warnings as errors now.