### PR TITLE
[mod_timerfd] Fixed - continue timer loop after receiving a SIGSTOP

### DIFF
--- a/src/mod/timers/mod_timerfd/mod_timerfd.c
+++ b/src/mod/timers/mod_timerfd/mod_timerfd.c
@@ -235,7 +235,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_timerfd_runtime)
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "epoll_wait interrupted by SIGINT, continue...\n");
 				continue;
 			}
-			
+
 			break;
 		}
 

--- a/src/mod/timers/mod_timerfd/mod_timerfd.c
+++ b/src/mod/timers/mod_timerfd/mod_timerfd.c
@@ -30,8 +30,8 @@
  *
  */
 
-#include <errno.h>
 #include <switch.h>
+#include <errno.h>
 #include <sys/timerfd.h>
 #include <sys/epoll.h>
 

--- a/src/mod/timers/mod_timerfd/mod_timerfd.c
+++ b/src/mod/timers/mod_timerfd/mod_timerfd.c
@@ -30,6 +30,7 @@
  *
  */
 
+#include <errno.h>
 #include <switch.h>
 #include <sys/timerfd.h>
 #include <sys/epoll.h>
@@ -228,8 +229,16 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_timerfd_runtime)
 
 	do {
 		r = epoll_wait(interval_poll_fd, e, sizeof(e) / sizeof(e[0]), 1000);
-		if (r < 0)
+		if (r < 0) {
+			/* if we had an interrupted system call due to process pause via SIGSTOP, do not exit the timer loop */
+			if (errno == EINTR) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "epoll_wait interrupted by SIGINT, continue...\n");
+				continue;
+			}
+			
 			break;
+		}
+
 		for (i = 0; i < r; i++) {
 			it = e[i].data.ptr;
 			if ((e[i].events & EPOLLIN) &&


### PR DESCRIPTION
When taking a snapshot of a machine which pauses the process, mod_timerfd runtime thread exits, causing all channels to wait indefinitely.

Check `errno == EINTR` and continue the timer loop.