### PR TITLE
hashtable memset issue fix

### DIFF
--- a/src/switch_hashtable.c
+++ b/src/switch_hashtable.c
@@ -126,7 +126,7 @@ hashtable_expand(switch_hashtable_t *h)
 				realloc(h->table, newsize * sizeof(struct entry *));
 			if (NULL == newtable) { (h->primeindex)--; return 0; }
 			h->table = newtable;
-			memset(newtable[h->tablelength], 0, newsize - h->tablelength);
+			memset(&newtable[h->tablelength], 0, ((newsize - h->tablelength) * sizeof(struct entry*)));
 			for (i = 0; i < h->tablelength; i++) {
 				for (pE = &(newtable[i]), e = *pE; e != NULL; e = *pE) {
 					index = indexFor(newsize,e->h);


### PR DESCRIPTION
Hi there, here seems is a mistake:
```c
switch_hashtable.c:129:
memset(newtable[h->tablelength], 0, newsize - h->tablelength);
```

if plan-b have ever happen, that lead to permanent crash, should be:
```c
memset(&newtable[h->tablelength], 0, ((newsize - h->tablelength) * sizeof(struct entry*)));
```