### PR TITLE
[core] allow setting caller profile variables that shouldn't clone

### DIFF
--- a/src/switch_caller.c
+++ b/src/switch_caller.c
@@ -162,6 +162,10 @@ SWITCH_DECLARE(switch_caller_profile_t *) switch_caller_profile_dup(switch_memor
 		for (pn = tocopy->soft; pn; pn = pn->next) {
 			profile_node_t *pp, *n = switch_core_alloc(profile->pool, sizeof(*n));
 
+			if (pn->var && !strncasecmp(pn->var, "local:", 6)) {
+				continue;
+			}
+
 			n->var = switch_core_strdup(profile->pool, pn->var);
 			n->val = switch_core_strdup(profile->pool, pn->val);
 


### PR DESCRIPTION
This allows setting a profile variable with a `local:` prefix so the variable won't be cloned to subsequent cloned profiles. This is particularly useful for setting information on a caller profile for cdr use.