### PR TITLE
mod_callcenter: fix agent zombie call

### DIFF
--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -1771,7 +1771,7 @@ static void *SWITCH_THREAD_FUNC outbound_agent_thread_run(switch_thread_t *threa
 
 		dialstr = switch_channel_expand_variables(member_channel, h->originate_string);
 		switch_channel_set_app_flag_key(CC_APP_KEY, member_channel, CC_APP_AGENT_CONNECTING);
-		status = switch_ivr_originate(NULL, &agent_session, &cause, dialstr, globals.agent_originate_timeout, NULL, cid_name ? cid_name : h->member_cid_name, cid_number ? cid_number : h->member_cid_number, NULL, ovars, SOF_NONE, NULL, NULL);
+		status = switch_ivr_originate(member_session, &agent_session, &cause, dialstr, globals.agent_originate_timeout, NULL, cid_name ? cid_name : h->member_cid_name, cid_number ? cid_number : h->member_cid_number, NULL, ovars, SOF_NONE, NULL, NULL);
 
 		/* Search for loopback agent */
 		if (status == SWITCH_STATUS_SUCCESS) {


### PR DESCRIPTION
try to fix #2529 

Passing the member_session to the originate, when the dialstring is return to the originate it hangups the call, not sure if is the right solution, but it solves the issue about making the call to the agent. 

```

2024-07-11 18:10:00.706322 99.20% [INFO] switch_cpp.cpp:1466 fetching dialstring for 1000@default.com 

2024-07-11 18:10:00.706322 99.20% [INFO] switch_cpp.cpp:1466 user.lua start sleep
2024-07-11 18:10:01.546299 99.17% [DEBUG] switch_rtp.c:1930 rtcp_stats_init: audio ssrc[1649471371] base_seq[0]
2024-07-11 18:10:01.546299 99.17% [DEBUG] switch_rtp.c:7695 Correct audio ip/port confirmed.
2024-07-11 18:10:01.566796 99.17% [DEBUG] sofia.c:7493 Channel sofia/main/1002@default.com entering state [ready][200]
2024-07-11 18:10:04.166829 99.00% [NOTICE] sofia.c:1065 Hangup sofia/main/1002@default.com [CS_EXECUTE] [NORMAL_CLEARING]
2024-07-11 18:10:04.166829 99.00% [DEBUG] mod_hash.c:293 Usage for total_account:1002@default.com is now 0
2024-07-11 18:10:04.166829 99.00% [DEBUG] mod_callcenter.c:3262 Member 1002 <1002> abandoned waiting in queue prueba
2024-07-11 18:10:04.166829 99.00% [DEBUG] mod_callcenter.c:3295 Member "1002" <1002> exit queue prueba due to BREAK_OUT
2024-07-11 18:10:04.166829 99.00% [DEBUG] mod_callcenter.c:3390 Queue has 0 waiting calls.
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_session.c:2979 sofia/main/1002@default.com skip receive message [APPLICATION_EXEC_COMPLETE] (channel is hungup already)
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:647 (sofia/main/1002@default.com) State EXECUTE going to sleep
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:581 (sofia/main/1002@default.com) Running State Change CS_HANGUP (Cur 1 Tot 9)
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:844 (sofia/main/1002@default.com) Callstate Change RING_WAIT -> HANGUP
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:846 (sofia/main/1002@default.com) State HANGUP
2024-07-11 18:10:04.166829 99.00% [DEBUG] mod_sofia.c:469 Channel sofia/main/1002@default.com hanging up, cause: NORMAL_CLEARING
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:59 sofia/main/1002@default.com Standard HANGUP, cause: NORMAL_CLEARING
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:846 (sofia/main/1002@default.com) State HANGUP going to sleep
2024-07-11 18:10:04.166829 99.00% [INFO] switch_cpp.cpp:1466 execute on hangup 
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:777 Hangup Command with no Session lua(execute_on_hangup.lua):

2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:616 (sofia/main/1002@default.com) State Change CS_HANGUP -> CS_REPORTING
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:581 (sofia/main/1002@default.com) Running State Change CS_REPORTING (Cur 1 Tot 9)
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:932 (sofia/main/1002@default.com) State REPORTING
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:168 sofia/main/1002@default.com Standard REPORTING, cause: NORMAL_CLEARING
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:932 (sofia/main/1002@default.com) State REPORTING going to sleep
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_state_machine.c:607 (sofia/main/1002@default.com) State Change CS_REPORTING -> CS_DESTROY
2024-07-11 18:10:04.166829 99.00% [DEBUG] switch_core_session.c:1744 Session 9 (sofia/main/1002@default.com) Locked, Waiting on external entities
2024-07-11 18:10:10.686908 98.97% [INFO] switch_cpp.cpp:1466 user.lua done sleep
2024-07-11 18:10:10.686908 98.97% [INFO] switch_cpp.cpp:1466 user.lua dialstring [cm_limit_id=account:1000@default.com,cm_limit_total=4,cm_limit_inbound=-1,cm_limit_outbound=-1,cm_limit_busy=-1]sofia/main/sip:1000@192.168.10.103:5064;fs_nat=yes 

2024-07-11 18:10:10.686908 98.97% [DEBUG] switch_cpp.cpp:1210 sofia/main/1002@default.com destroy/unlink session from object
2024-07-11 18:10:10.726908 98.97% [DEBUG] switch_ivr_originate.c:2301 Parsing global variables
2024-07-11 18:10:10.726908 98.97% [DEBUG] switch_ivr_originate.c:2863 Parsing session specific variables
2024-07-11 18:10:10.726908 98.97% [DEBUG] switch_ivr_originate.c:4056 Originate Resulted in Error Cause: 16 [NORMAL_CLEARING]
2024-07-11 18:10:10.726908 98.97% [NOTICE] switch_ivr_originate.c:3059 Cannot create outgoing channel of type [user] cause: [NORMAL_CLEARING]
2024-07-11 18:10:10.726908 98.97% [DEBUG] switch_ivr_originate.c:4056 Originate Resulted in Error Cause: 16 [NORMAL_CLEARING]
2024-07-11 18:10:10.726908 98.97% [DEBUG] mod_callcenter.c:2139 Agent agent-1000 Origination Canceled : NORMAL_CLEARING

```


attach the call log after applying the change.
[freeswitch_afterpatch.log](https://github.com/user-attachments/files/16180499/freeswitch_afterpatch.log)



I notice in past commits that the member_session was included in the originate and then removed:
included:
https://github.com/signalwire/freeswitch/commit/b4ada1b849d526e3d808fd22626b7d618289c537
removed: 
https://github.com/signalwire/freeswitch/commit/ec44f5adf27fe0f030627b875e042db3dd5bee0a

i try to reproduce the issue "Do not kick member out on timeout if originating to an agent" after my change, and i couldn't, the call is ok.

