### PR TITLE
Add chmod +x to docker-entrypoint.sh

### DIFF
--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -44,6 +44,7 @@ RUN wget --no-verbose --http-user=signalwire --http-password=${TOKEN} \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
 # Add anything else here
 
 ## Ports


### PR DESCRIPTION
This is needed in order to avoid a `crun: open executable: Permission denied: OCI permission denied` error running in podman after building with buildah.

***Note. I have only tested this with podman, using [GitHub Actions buildah-build](https://github.com/marketplace/actions/buildah-build) for container creation.