### PR TITLE
resolve [Core] add channel var rtp_2833_payload to overwrite rfc2833-…

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -10424,6 +10424,12 @@ SWITCH_DECLARE(void) switch_core_media_gen_local_sdp(switch_core_session_t *sess
 			for (i = 0; i < smh->num_rates; i++) {
 				if (smh->rates[i] == 8000 || smh->num_rates == 1) {
 					smh->dtmf_ianacodes[i] = smh->mparams->te;
+
+					val = switch_channel_get_variable(session->channel, "rtp_2833_payload");
+					if (!zstr(val)) {
+						smh->dtmf_ianacodes[i] = atoi(val); 
+					}
+
 					smh->cng_ianacodes[i] = smh->mparams->cng_pt;
 				} else {
 					int j = 0;


### PR DESCRIPTION
…pt in sip profile

The DTMF transmission for bridged calls has been problematic for some time now, particularly when the setting "bypass_media_after_bridge=true" is used. This issue arises when the destination PBX utilizes a different PT value for RFC2833 than what is configured in the sofia profile.

To address this challenge, we have implemented a workaround that involves parsing the PT from the switch_r_sdp on the A leg and using a profile with the same value set as rfc2833-pt. For example, if the PT value is 101 on the A-Leg, we use the profile "sofia/outbound101", and if it is 103, we use "sofia/outbound103". This workaround has effectively resolved our DTMF transmission issues.

However, this solution requires extensive configuration and coding on our end, which some customers may not find favorable. Additionally, each profile must utilize a different source UDP Port, further complicating the matter.

It would be beneficial if there was a channel variable for "rtp_2833_payload" that takes precedence over the profile setting when it is set.