### PR TITLE
[switch_msrp.c] This commit fixes a leak in switch_msrp.c

### DIFF
--- a/src/switch_msrp.c
+++ b/src/switch_msrp.c
@@ -1264,6 +1264,7 @@ static void *SWITCH_THREAD_FUNC msrp_worker(switch_thread_t *thread, void *obj)
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "MSRP_METHOD_AUTH\n");
 		} else {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Parse initial message error!\n");
+			switch_msrp_msg_destroy(&msrp_msg);
 			goto end;
 		}
 


### PR DESCRIPTION
The purpose of this PR is to fix a memory leak.
Consider this scenario:
- msrp_parse_buffer is invoked and it fails to process to parse the message (see line 894) and it leaves the message in the MSRP_ST_WAIT_HEADER state
- On line 1258 when the message state is analyzed, processing will fall through to the default error case logging ("Parse initial message error!") and then will jump to "end" without destroying the msrg_msg buffer.  This will cause a memory leak.

The problem is that in that error check, the msg state is in the MSRP_ST_WAIT_HEADER state which is not explicitly checked and the function exits to "end" without de-allocating the msrp_msg buffer. 