### PR TITLE
mod_verto: fix segfault in verto bye

### DIFF
--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -3076,9 +3076,11 @@ static switch_bool_t verto__bye_func(const char *method, cJSON *params, jsock_t 
 
 	if ((session = switch_core_session_locate(call_id))) {
 		verto_pvt_t *tech_pvt = switch_core_session_get_private_class(session, SWITCH_PVT_SECONDARY);
-		tech_pvt->remote_hangup_cause = cause;
-		switch_channel_set_variable(tech_pvt->channel, "verto_hangup_disposition", "recv_bye");
-		switch_channel_hangup(tech_pvt->channel, cause);
+		if (tech_pvt) {
+			tech_pvt->remote_hangup_cause = cause;
+			switch_channel_set_variable(tech_pvt->channel, "verto_hangup_disposition", "recv_bye");
+			switch_channel_hangup(tech_pvt->channel, cause);
+		}
 
 		cJSON_AddItemToObject(obj, "message", cJSON_CreateString("CALL ENDED"));
 		cJSON_AddItemToObject(obj, "causeCode", cJSON_CreateNumber(cause));


### PR DESCRIPTION
it happens when verto couldn't create the channel but it receives a bye. 
Checking `tech_pvt` solves the issue. 


BT:
```
program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f3915f27591 in verto__bye_func (method=<optimized out>, params=<optimized out>, jsock=<optimized out>, response=<optimized out>) at mod_verto.c:3141
3141	mod_verto.c: No such file or directory.
[Current thread is 1 (Thread 0x7f3915994700 (LWP 1799715))]
(gdb) bt
#0  0x00007f3915f27591 in verto__bye_func (method=<optimized out>, params=<optimized out>, jsock=<optimized out>, response=<optimized out>) at mod_verto.c:3141
#1  0x00007f3915f31e7f in process_jrpc (jsock=0x55874b21e028, json=<optimized out>) at mod_verto.c:1556
#2  0x00007f3915f32867 in process_input (bytes=<optimized out>, data=<optimized out>, jsock=0x55874b21e028) at mod_verto.c:1602
#3  client_run (jsock=0x55874b21e028) at mod_verto.c:2177
#4  0x00007f3915f339bf in client_thread (thread=<optimized out>, obj=0x55874b21e028) at mod_verto.c:2221
#5  0x00007f392208087e in switch_core_session_thread_pool_worker (thread=0x55874c326280, obj=<optimized out>) at src/switch_core_session.c:1792
#6  0x00007f3921fc5ea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f3921ce1acf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

```