### PR TITLE
[mod_verto] Fix memory leak by correctly freeing regex

### DIFF
--- a/src/mod/endpoints/mod_verto/mod_verto.c
+++ b/src/mod/endpoints/mod_verto/mod_verto.c
@@ -1893,10 +1893,12 @@ authed:
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
 								  "%d request [%s] matched expr [%s]\n", proceed, request->uri, expression);
 				request->uri = rule->value;
+				switch_regex_safe_free(re);
 				break;
 			}
 
 			rule = rule->next;
+			switch_regex_safe_free(re);
 		}
 	}
 


### PR DESCRIPTION
For mod_verto regex was never freed and was actually leaking memory. Correctly free the compiled regex to fix the memory leak.