### PR TITLE
[mod_opusfile] New featuress:  bitrate settings for each samplerate, appending to existing ogg-opus, etc.

### DIFF
--- a/conf/vanilla/autoload_configs/opusfile.conf.xml
+++ b/conf/vanilla/autoload_configs/opusfile.conf.xml
@@ -1,0 +1,18 @@
+<configuration name="opusfile.conf">
+    <settings>
+        <!-- bitrate is in kbps, per channel, so an entry of 96 is 96 kbps -->
+        <!-- Narrowband (8000 Hz) bitrate -->
+        <param name="bitrate-nb" value="12"/>
+        <!-- Wideband (16000 Hz) bitrate -->
+        <param name="bitrate-wb" value="20"/>
+        <!-- Ultrawideband (32000 Hz) bitrate -->
+        <param name="bitrate-uwb" value="36"/>
+        <!-- Fullband (48000 Hz) bitrate -->
+        <param name="bitrate-fb" value="40"/>
+        <param name="complexity" value="5"/>
+        <!-- Channel format, impacts stereo recordings.  Options are ambix, discrete, and default -->
+        <param name="channel-format" value="discrete"/>
+        <!-- The global maximum samplerate for ALL recorded files in kHz.  Options are 8, 16, 32, and 48 -->
+        <param name="maximum-samplerate" value="48"/>
+    </settings>
+</configuration>


### PR DESCRIPTION
It is now possible to:

-Append to an existing recorded file.  Each appended stream becomes an additional audio stream in the ogg container.
-The ability to set different target bitrates for NB, WB, UWB, and FB, with defaults within the ranges suggested in RFC 6716 sec 2.1.1.
-The ability to limit the maximum sample sample rate for recording file, which can further limit anything set with record_sample_rate .  Thus a g711u call will not be upsampled to 48 kHz, and instead can use the lower necessary bitrate for NB.
-Metadata as defined by switch_audio_col_t now gets added to the ogg container's comments.