### PR TITLE
[mod_pgsql] Add support for PGRES_TUPLES_CHUNK in PostgreSQL 17+

### DIFF
--- a/src/mod/databases/mod_pgsql/mod_pgsql.c
+++ b/src/mod/databases/mod_pgsql/mod_pgsql.c
@@ -606,6 +606,10 @@ switch_status_t database_handle_exec_string(switch_database_interface_handle_t *
 		case PGRES_SINGLE_TUPLE:
 			/* Added in PostgreSQL 9.2 */
 #endif
+#if PG_VERSION_NUM >= 170000
+		case PGRES_TUPLES_CHUNK:
+			/* Added in PostgreSQL 17 */
+#endif
 		case PGRES_COMMAND_OK:
 		case PGRES_TUPLES_OK:
 			break;
@@ -766,6 +770,10 @@ switch_status_t pgsql_next_result_timed(switch_pgsql_handle_t *handle, switch_pg
 #if PG_VERSION_NUM >= 90002
 		case PGRES_SINGLE_TUPLE:
 			/* Added in PostgreSQL 9.2 */
+#endif
+#if PG_VERSION_NUM >= 170000
+		case PGRES_TUPLES_CHUNK:
+			/* Added in PostgreSQL 17 */
 #endif
 		case PGRES_TUPLES_OK:
 		{


### PR DESCRIPTION
Extend the database module to handle the PGRES_TUPLES_CHUNK case introduced in PostgreSQL 17. This ensures compatibility with the latest PostgreSQL version and prevents potential issues when processing query results.