### PR TITLE
[mod_curl] Increase argument limit and enforce max args constraint

### DIFF
--- a/src/mod/applications/mod_curl/mod_curl.c
+++ b/src/mod/applications/mod_curl/mod_curl.c
@@ -57,6 +57,10 @@ static char *SYNTAX = "curl url [headers|json|content-type <mime-type>|connect-t
 #define HTTP_MAX_APPEND_HEADERS 10
 #define HTTP_DEFAULT_MAX_BYTES 64000
 
+#ifndef MOD_CURL_MAX_ARGS
+#define MOD_CURL_MAX_ARGS 30
+#endif
+
 static struct {
 	switch_memory_pool_t *pool;
 	switch_event_node_t *node;
@@ -866,7 +870,7 @@ SWITCH_STANDARD_APP(curl_app_function)
 {
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 
-	char *argv[10] = { 0 };
+	char *argv[MOD_CURL_MAX_ARGS + 1] = { 0 };
 	int argc;
 	char *mydata = NULL;
 
@@ -894,6 +898,9 @@ SWITCH_STANDARD_APP(curl_app_function)
 	if ((argc = switch_separate_string(mydata, ' ', argv, (sizeof(argv) / sizeof(argv[0]))))) {
 		if (argc == 0) {
 			switch_goto_status(SWITCH_STATUS_SUCCESS, usage);
+		} else if (argc >= MOD_CURL_MAX_ARGS) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Max args exceeded: %d\n", MOD_CURL_MAX_ARGS);
+			switch_goto_status(SWITCH_STATUS_FALSE, done);
 		}
 
 		url = switch_core_strdup(pool, argv[0]);
@@ -982,7 +989,7 @@ SWITCH_STANDARD_APP(curl_app_function)
 SWITCH_STANDARD_API(curl_function)
 {
 	switch_status_t status;
-	char *argv[10] = { 0 };
+	char *argv[MOD_CURL_MAX_ARGS + 1] = { 0 };
 	int argc;
 	char *mydata = NULL;
 	char *url = NULL;
@@ -1014,6 +1021,9 @@ SWITCH_STANDARD_API(curl_function)
 	if ((argc = switch_separate_string(mydata, ' ', argv, (sizeof(argv) / sizeof(argv[0]))))) {
 		if (argc < 1) {
 			switch_goto_status(SWITCH_STATUS_SUCCESS, usage);
+		} else if (argc >= MOD_CURL_MAX_ARGS) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Max args exceeded: %d\n", MOD_CURL_MAX_ARGS);
+			switch_goto_status(SWITCH_STATUS_FALSE, done);
 		}
 
 		url = switch_core_strdup(pool, argv[0]);


### PR DESCRIPTION
Introduced a macro `MOD_CURL_MAX_ARGS` for the number of arguments for mod_curl functions with a default of 30. Adjusted the code to handle scenarios exceeding this limit by logging an error and returning failure. This improves flexibility and prevents potential overflow issues.