### PR TITLE
Add "record-wait-mod" flag to control auto recording behavior

### DIFF
--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -903,6 +903,9 @@ switch_status_t conference_member_add(conference_obj_t *conference, conference_m
 			conference_utils_clear_flag(conference, CFLAG_WAIT_MOD);
 		}
 
+		if (conference_utils_test_flag(conference, CFLAG_RECORD_WAIT_MOD) && conference_utils_member_test_flag(member, MFLAG_MOD)) {
+			conference_utils_clear_flag(conference, CFLAG_RECORD_WAIT_MOD);
+		}
 		if (conference->count > 1) {
 			if (((conference->moh_sound || conference->tmp_moh_sound) && !conference_utils_test_flag(conference, CFLAG_WAIT_MOD)) ||
 				(conference_utils_test_flag(conference, CFLAG_WAIT_MOD) && !switch_true(switch_channel_get_variable(channel, "conference_permanent_wait_mod_moh")))) {

--- a/src/mod/applications/mod_conference/conference_utils.c
+++ b/src/mod/applications/mod_conference/conference_utils.c
@@ -190,6 +190,8 @@ void conference_utils_set_cflags(const char *flags, conference_flag_t *f)
 		for (i = 0; i < argc && argv[i]; i++) {
 			if (!strcasecmp(argv[i], "wait-mod")) {
 				f[CFLAG_WAIT_MOD] = 1;
+			} else if (!strcasecmp(argv[i], "record-wait-mod")) {
+				f[CFLAG_RECORD_WAIT_MOD] = 1;
 			} else if (!strcasecmp(argv[i], "video-floor-only")) {
 				f[CFLAG_VID_FLOOR] = 1;
 			} else if (!strcasecmp(argv[i], "audio-always")) {

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -433,7 +433,7 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 		}
 
 		/* Start auto recording if there's the minimum number of required participants. */
-		if (conference->auto_record && !conference->auto_recording && (conference->count >= conference->min_recording_participants)) {
+		if (conference->auto_record && !conference->auto_recording && (conference->count >= conference->min_recording_participants) && !conference_utils_test_flag(conference, CFLAG_RECORD_WAIT_MOD)) {
 			conference->auto_recording++;
 			conference->record_count++;
 			imember = conference->members;
@@ -1173,6 +1173,10 @@ void conference_xlist(conference_obj_t *conference, switch_xml_t x_conference, i
 
 	if (conference_utils_test_flag(conference, CFLAG_WAIT_MOD)) {
 		switch_xml_set_attr_d(x_conference, "wait_mod", "true");
+	}
+
+	if (conference_utils_test_flag(conference, CFLAG_RECORD_WAIT_MOD)) {
+		switch_xml_set_attr_d(x_conference, "record_wait_mod", "true");
 	}
 
 	if (conference_utils_test_flag(conference, CFLAG_AUDIO_ALWAYS)) {

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -258,6 +258,7 @@ typedef enum {
 	CFLAG_NO_MOH,
 	CFLAG_DED_VID_LAYER_AUDIO_FLOOR,
 	CFLAG_BREAKABLE,
+	CFLAG_RECORD_WAIT_MOD,
 	/////////////////////////////////
 	CFLAG_MAX
 } conference_flag_t;


### PR DESCRIPTION
Introduced a new conference flag, CFLAG_RECORD_WAIT_MOD, to delay auto recording until a moderator joins. Updated relevant logic to test and clear this flag based on moderator presence and participant count. This enhances flexibility in managing recording settings for moderated conferences.