### PR TITLE
[GHA] Use `ubuntu-24.04-arm` runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,9 +136,9 @@ jobs:
           - name: amd64
             runner: ubuntu-latest
           - name: arm32v7
-            runner: linux-arm64-4-core-public
+            runner: ubuntu-24.04-arm
           - name: arm64v8
-            runner: linux-arm64-4-core-public
+            runner: ubuntu-24.04-arm
         release:
           - ${{ needs.preconfig.outputs.release }}
         exclude: ${{ fromJson(needs.preconfig.outputs.deb) }}


### PR DESCRIPTION
According to https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ new Arm runners have been added as public preview, this PR tests this runner.