### PR TITLE
[utils] fix various typos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1681,11 +1681,11 @@ SAC_OPENSSL
 if test x$HAVE_OPENSSL = x1; then
 	openssl_CFLAGS="$openssl_CFLAGS -DHAVE_OPENSSL";
 	APR_ADDTO(SWITCH_AM_CFLAGS, -DHAVE_OPENSSL)
-	AC_CHECK_LIB(ssl, SSL_CTX_set_tlsext_use_srtp, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLS_SRTP, 1, HAVE_OPENSSL_DTLS_SRTP), AC_MSG_ERROR([OpenSSL >= 1.0.1e and associated developement headers required]))
-	AC_CHECK_LIB(ssl, DTLSv1_method, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLS, 1, HAVE_OPENSSL_DTLS), AC_MSG_ERROR([OpenSSL >= 1.0.1e and associaed developement headers required]))
+	AC_CHECK_LIB(ssl, SSL_CTX_set_tlsext_use_srtp, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLS_SRTP, 1, HAVE_OPENSSL_DTLS_SRTP), AC_MSG_ERROR([OpenSSL >= 1.0.1e and associated development headers required]))
+	AC_CHECK_LIB(ssl, DTLSv1_method, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLS, 1, HAVE_OPENSSL_DTLS), AC_MSG_ERROR([OpenSSL >= 1.0.1e and associated development headers required]))
 	AC_CHECK_LIB(ssl, DTLSv1_2_method, AC_DEFINE_UNQUOTED(HAVE_OPENSSL_DTLSv1_2_method, 1, [DTLS version 1.2 is available]))
 else
-	AC_MSG_ERROR([OpenSSL >= 1.0.1e and associated developement headers required])
+	AC_MSG_ERROR([OpenSSL >= 1.0.1e and associated development headers required])
 fi
 
 AX_CHECK_JAVA

--- a/freeswitch.spec
+++ b/freeswitch.spec
@@ -964,7 +964,7 @@ Requires:        %{name} = %{version}-%{release}
 Russian language phrases module and directory structure for say module and voicemail
 
 %package lang-fr
-Summary:        Provides french language dependend modules and speech config for the FreeSWITCH Open Source telephone platform.
+Summary:        Provides french language dependent modules and speech config for the FreeSWITCH Open Source telephone platform.
 Group:          System/Libraries
 Requires:        %{name} = %{version}-%{release}
 
@@ -972,7 +972,7 @@ Requires:        %{name} = %{version}-%{release}
 French language phrases module and directory structure for say module and voicemail
 
 %package lang-de
-Summary:        Provides german language dependend modules and speech config for the FreeSWITCH Open Source telephone platform.
+Summary:        Provides german language dependent modules and speech config for the FreeSWITCH Open Source telephone platform.
 Group:          System/Libraries
 Requires:        %{name} = %{version}-%{release}
 
@@ -980,7 +980,7 @@ Requires:        %{name} = %{version}-%{release}
 German language phrases module and directory structure for say module and voicemail
 
 %package lang-he
-Summary:        Provides hebrew language dependend modules and speech config for the FreeSWITCH Open Source telephone platform.
+Summary:        Provides hebrew language dependent modules and speech config for the FreeSWITCH Open Source telephone platform.
 Group:          System/Libraries
 Requires:        %{name} = %{version}-%{release}
 
@@ -988,7 +988,7 @@ Requires:        %{name} = %{version}-%{release}
 Hebrew language phrases module and directory structure for say module and voicemail
 
 %package lang-es
-Summary:        Provides Spanish language dependend modules and speech config for the FreeSWITCH Open Source telephone platform.
+Summary:        Provides Spanish language dependent modules and speech config for the FreeSWITCH Open Source telephone platform.
 Group:          System/Libraries
 Requires:        %{name} = %{version}-%{release}
 
@@ -996,7 +996,7 @@ Requires:        %{name} = %{version}-%{release}
 Spanish language phrases module and directory structure for say module and voicemail
 
 %package lang-pt
-Summary:        Provides Portuguese language dependend modules and speech config for the FreeSWITCH Open Source telephone platform.
+Summary:        Provides Portuguese language dependent modules and speech config for the FreeSWITCH Open Source telephone platform.
 Group:          System/Libraries
 Requires:        %{name} = %{version}-%{release}
 
@@ -1004,7 +1004,7 @@ Requires:        %{name} = %{version}-%{release}
 Portuguese language phrases module and directory structure for say module and voicemail
 
 %package lang-sv
-Summary:        Provides Swedish language dependend modules and speech config for the FreeSWITCH Open Source telephone platform.
+Summary:        Provides Swedish language dependent modules and speech config for the FreeSWITCH Open Source telephone platform.
 Group:          System/Libraries
 Requires:        %{name} = %{version}-%{release}
 


### PR DESCRIPTION
Found via `codespell -q 3 -D ../dictionary.txt -S "*.yuv,ChangeLog" -L anull,clen,exceptionn,exten,ine,ist,leadin,leapyear,offsetp,pevent,seh,strat,te`