### PR TITLE
[mod_httpapi] Fix possible segfault when HEAD request fails

### DIFF
--- a/src/mod/applications/mod_httapi/mod_httapi.c
+++ b/src/mod/applications/mod_httapi/mod_httapi.c
@@ -2676,7 +2676,13 @@ static switch_status_t fetch_cache_data(http_file_context_t *context, const char
 		if (err_msg) {
 			*err_msg = "response code != 200";
 		}
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "caching: url:%s to %s failed with HTTP response code %d\n", url, save_path, (int)code);
+		
+		if (save_path) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "caching: url:%s to %s failed with HTTP response code %d\n", url, save_path, (int)code);
+		} else {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "head: url:%s failed with HTTP response code %d\n", url, (int)code);
+		}
+
 		status = SWITCH_STATUS_FALSE;
 		break;
 	}


### PR DESCRIPTION
When HEAD request fails with status code different from `404 NOT FOUND` then NULL pointer passed to `%s` because `save_path` is NULL.

```
 "caching: url:%s to %s failed with HTTP response code %d\n", url, save_path, (int)code
```

I do some tests with my backend witch return `400 BAD REQUEST`. Logs:
```
caching: url:... to (null) failed with HTTP response code 400
```
It's glibc behavior, but this is UB by standart and may lead to SegFault. [StackOverflow Question](https://stackoverflow.com/questions/11589342/what-is-the-behavior-of-printing-null-with-printfs-s-specifier)