### PR TITLE
Ensure that member hold api implements deafness along with muteness

### DIFF
--- a/src/mod/applications/mod_conference/conference_api.c
+++ b/src/mod/applications/mod_conference/conference_api.c
@@ -360,6 +360,8 @@ switch_status_t conference_api_sub_unhold(conference_member_t *member, switch_st
 		return SWITCH_STATUS_GENERR;
 
 	conference_utils_member_clear_flag_locked(member, MFLAG_HOLD);
+	conference_utils_member_set_flag_locked(member, MFLAG_CAN_HEAR);
+	conference_utils_member_set_flag(member, MFLAG_INDICATE_UNDEAF);
 
 	if (member->session && !conference_utils_member_test_flag(member, MFLAG_MUTE_DETECT)) {
 		switch_core_media_hard_mute(member->session, SWITCH_FALSE);
@@ -424,6 +426,8 @@ switch_status_t conference_api_sub_hold(conference_member_t *member, switch_stre
 		switch_core_media_hard_mute(member->session, SWITCH_TRUE);
 	}
 
+	conference_utils_member_clear_flag_locked(member, MFLAG_CAN_HEAR);
+	conference_utils_member_set_flag(member, MFLAG_INDICATE_DEAF);
 	conference_utils_member_set_flag(member, MFLAG_HOLD);
 	
 	conference_member_set_score_iir(member, 0);


### PR DESCRIPTION
It is fix for the problem mentioned in https://github.com/signalwire/freeswitch/issues/796

Currently the conference member is only muted when put on hold, but the member can hear the conference.

This patch ensures that the hold api implements both deafness and muteness. 