### PR TITLE
Increase AMR-NB and AMR-WB max decode buffer size by one byte

### DIFF
--- a/src/mod/codecs/mod_amr/mod_amr.c
+++ b/src/mod/codecs/mod_amr/mod_amr.c
@@ -142,7 +142,7 @@ static struct {
 
 const int switch_amr_frame_sizes[] = {12,13,15,17,19,20,26,31,5,0,0,0,0,0,0,1};
 
-#define SWITCH_AMR_OUT_MAX_SIZE 32
+#define SWITCH_AMR_OUT_MAX_SIZE 33
 #define SWITCH_AMR_MODES 9 /* plus SID */
 
 static switch_bool_t switch_amr_unpack_oa(unsigned char *buf, uint8_t *tmp, int encoded_data_len)

--- a/src/mod/codecs/mod_amrwb/mod_amrwb.c
+++ b/src/mod/codecs/mod_amrwb/mod_amrwb.c
@@ -94,7 +94,7 @@ static struct {
 
 const int switch_amrwb_frame_sizes[] = {17, 23, 32, 36, 40, 46, 50, 58, 60, 5, 0, 0, 0, 0, 1, 1};
 
-#define SWITCH_AMRWB_OUT_MAX_SIZE 61
+#define SWITCH_AMRWB_OUT_MAX_SIZE 62
 #define SWITCH_AMRWB_MODES 10 /* Silence Indicator (SID) included */
 
 #define invalid_frame_type (index > SWITCH_AMRWB_MODES && index != 0xe && index != 0xf) /* include SPEECH_LOST and NO_DATA*/


### PR DESCRIPTION
In testing AMR-NB and AMR-WB at the maximum bit rate, I noticed every packet decode would throw an error similar to this:
[ERR] switch_core_io.c:633 Codec RAW Signed Linear (16 bit) decoder error! [1]

Packet encoding worked fine, but I noticed the encoded_data_len size was larger than the SWITCH_AMRWB_OUT_MAX_SIZE.
[DEBUG] mod_amrwb.c:179 AMRWB encoder (OA): AMRWB encoded voice payload sz: [60] : | encoded_data_len: [62]

Modified the SWITCH_AMR_OUT_MAX_SIZE and SWITCH_AMRWB_OUT_MAX_SIZE constants to align decoding with encoding.