### PR TITLE
Update remote_codec_rate before codec comparation

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5512,6 +5512,9 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					}
 				}
 
+				if (fmtp_remote_codec_rate) {
+					remote_codec_rate = fmtp_remote_codec_rate;
+				}
 				for (i = 0; i < smh->mparams->num_codecs && i < total_codecs; i++) {
 					const switch_codec_implementation_t *imp = codec_array[i];
 					uint32_t bit_rate = imp->bits_per_second;
@@ -5529,10 +5532,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					} else {
 						match = (!strcasecmp(rm_encoding, imp->iananame) &&
 								 ((map->rm_pt < 96 && imp->ianacode < 96) || (map->rm_pt > 95 && imp->ianacode > 95)) &&
-								 (remote_codec_rate == codec_rate || fmtp_remote_codec_rate == imp->actual_samples_per_second)) ? 1 : 0;
-						if (fmtp_remote_codec_rate) {
-							remote_codec_rate = fmtp_remote_codec_rate;
-						}
+								 (remote_codec_rate == codec_rate || remote_codec_rate == imp->actual_samples_per_second)) ? 1 : 0;
 					}
 
 					if (match && bit_rate && map_bit_rate && map_bit_rate != bit_rate && strcasecmp(map->rm_encoding, "ilbc") &&


### PR DESCRIPTION
## Issue:
When the configured candidates are OPUS 48kHz, PCMA,..., the negotiation unexpectedly matches OPUS 16k with OPUS 48kHz. This occurs because the implementation updates the remote sample rate after the initial media negotiation (cooperation loop), leading to incorrect matching.

## Solution:
Move the sample rate update to occur before negotiation loop, ensuring sample rate is updated from the beginning.
## Freeswitch log:
```2025-07-04 15:56:19.826475 96.27% [DEBUG] sofia.c:7576 Channel sofia/iregistrar/infra_component_test_kuyRTLx@52.76.213.59 entering state [received][100]
2025-07-04 15:56:19.826475 96.27% [DEBUG] sofia.c:7586 Remote SDP:
v=0
o=- 3960604579 3960604579 IN IP4 52.76.213.59
s=pjmedia
b=AS:50
t=0 0
a=X-nat:0
m=audio 24598 RTP/AVP 96 120
c=IN IP4 52.76.213.59
b=TIAS:32000
a=rtpmap:96 opus/48000/2
a=fmtp:96 useinbandfec=1;maxplaybackrate=16000;sprop-maxcapturerate=16000
a=rtpmap:120 telephone-event/48000
a=fmtp:120 0-16
a=ssrc:184830022 cname:742327632f371b3d
a=rtcp:24599

2025-07-04 15:56:19.826475 96.27% [DEBUG] switch_core_media.c:5526 Audio Codec Compare [opus:96:48000:20:0:1]/[opus:116:48000:20:0:1]
2025-07-04 15:56:19.826475 96.27% [DEBUG] switch_core_media.c:5569 Audio Codec Compare [opus:116:48000:20:0:1] is saved as a near-match
2025-07-04 15:56:19.826475 96.27% [DEBUG] switch_core_media.c:5526 Audio Codec Compare [opus:96:16000:20:0:1]/[PCMU:0:8000:20:64000:1]
2025-07-04 15:56:19.826475 96.27% [DEBUG] switch_core_media.c:5526 Audio Codec Compare [opus:96:16000:20:0:1]/[G729:18:8000:20:8000:1]
2025-07-04 15:56:19.826475 96.27% [DEBUG] switch_core_media.c:5526 Audio Codec Compare [opus:96:16000:20:0:1]/[GSM:3:8000:20:13200:1]```
