### PR TITLE
mod_xml_curl: Add gateway-unix-socket-path option for direct UNIX socket connection

### DIFF
--- a/conf/vanilla/autoload_configs/xml_curl.conf.xml
+++ b/conf/vanilla/autoload_configs/xml_curl.conf.xml
@@ -3,6 +3,8 @@
     <binding name="example">
       <!-- Allow to bind on a particular IP for requests sent -->
       <!--<param name="bind-local" value="$${local_ip_v4}" />-->
+      <!-- Connect directly to unixsockect -->
+      <!-- <param name="gateway-unix-socket-path" value="/run/lighttpd.socket"/>-->
       <!-- The url to a gateway cgi that can generate xml similar to
 	   what's in this file only on-the-fly (leave it commented if you dont
 	   need it) -->


### PR DESCRIPTION
to use if you are serving the configuration in the same machine and avoid the tcp connection to localhost.