### PR TITLE
Fix segfault when merging variables

### DIFF
--- a/src/mod/applications/mod_conference/conference_event.c
+++ b/src/mod/applications/mod_conference/conference_event.c
@@ -748,7 +748,9 @@ switch_status_t conference_event_add_data(conference_obj_t *conference, switch_e
 	switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Conference-Ghosts", "%u", conference->count_ghosts);
 	switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Conference-Profile-Name", conference->profile_name);
 	switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Conference-Unique-ID", conference->uuid_str);
+	switch_mutex_lock(conference->flag_mutex);
 	switch_event_merge(event, conference->variables);
+	switch_mutex_unlock(conference->flag_mutex);
 
 	return status;
 }


### PR DESCRIPTION
We have an occasional segfault on FreeSWITCH [here](https://github.com/signalwire/freeswitch/blob/7f9dd270b492907ddd063be18003e18719bdb80b/src/switch_event.c#L1329). 

I analysed the core dump, and it seems that the `hp` is an invalid reference, so I suspect it was deleted by another thread while this was running.

I have no proof, but while analysing the code it seemed pretty straightforward that this lock is missing here.



