### PR TITLE
mod_spandsp fax_header and fax_ident _undef_ not being respected

### DIFF
--- a/src/mod/applications/mod_spandsp/mod_spandsp_fax.c
+++ b/src/mod/applications/mod_spandsp/mod_spandsp_fax.c
@@ -1421,8 +1421,12 @@ static pvt_t *pvt_init(switch_core_session_t *session, mod_spandsp_fax_applicati
 	if ((tmp = switch_channel_get_variable(channel, "fax_ident"))) {
 		char *data = NULL;
 
-		data = strdup(tmp);
-		switch_url_decode(data);
+		if (!strcmp(tmp, "_undef_")) {
+			data = strdup("");
+		} else {
+			data = strdup(tmp);
+			switch_url_decode(data);
+		}
 		pvt->ident = switch_core_session_strdup(session, data);
 
 		switch_safe_free(data);
@@ -1433,8 +1437,12 @@ static pvt_t *pvt_init(switch_core_session_t *session, mod_spandsp_fax_applicati
 	if ((tmp = switch_channel_get_variable(channel, "fax_header"))) {
 		char *data = NULL;
 
-		data = strdup(tmp);
-		switch_url_decode(data);
+		if (!strcmp(tmp, "_undef_")) {
+			data = strdup("");
+		} else {
+			data = strdup(tmp);
+			switch_url_decode(data);
+		}
 		pvt->header = switch_core_session_strdup(session, data);
 
 		switch_safe_free(data);


### PR DESCRIPTION
According to the documentation (https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Modules/mod_spandsp_6587021/)
we can suppress the fax header line (txfax) if we set 
```
fax_header=_undef_
```

However, the code in mod_spandsp_fax.c doesn't have code to handle this (neither for fax_ident):
https://github.com/signalwire/freeswitch/blob/d22aec67c66aed6630787adb262d631e2cefb0e4/src/mod/applications/mod_spandsp/mod_spandsp_fax.c#L1433

So the fax is sent with header and ident as:
```
_undef_
```

The value 
```
_undef_
```
 only works in the general configuration of mod_spandsp parameters header and ident:
```
<configuration name="spandsp.conf" description="FAX application configuration">
 <fax-settings>
   <param name="ident" value="_undef_"/>
   <param name="header" value="_undef_"/>
 </fax-settings>
</configuration>
``` 
This PR addresses this issue.