### PR TITLE
Add support for UUID v4 and v7 generation

### DIFF
--- a/src/include/switch_apr.h
+++ b/src/include/switch_apr.h
@@ -563,6 +563,14 @@ SWITCH_DECLARE(void) switch_uuid_format(char *buffer, const switch_uuid_t *uuid)
 SWITCH_DECLARE(void) switch_uuid_get(switch_uuid_t *uuid);
 
 /**
+ *
+ * @param uuid
+ * @param version
+ * @return switch_status_t
+ */
+SWITCH_DECLARE(switch_status_t) switch_uuid_generate_version(switch_uuid_t *uuid, int version);
+
+/**
  * Parse a standard-format string into a UUID
  * @param uuid The resulting UUID
  * @param uuid_str The formatted UUID

--- a/src/include/switch_utils.h
+++ b/src/include/switch_utils.h
@@ -1422,6 +1422,7 @@ SWITCH_DECLARE(const char *) switch_inet_ntop(int af, void const *src, char *dst
 #endif
 
 SWITCH_DECLARE(char *) switch_uuid_str(char *buf, switch_size_t len);
+SWITCH_DECLARE(char *) switch_uuid_str_version(char *buf, switch_size_t len, int version);
 SWITCH_DECLARE(char *) switch_format_number(const char *num);
 
 SWITCH_DECLARE(unsigned int) switch_atoui(const char *nptr);

--- a/src/mod/applications/mod_commands/mod_commands.c
+++ b/src/mod/applications/mod_commands/mod_commands.c
@@ -3173,11 +3173,21 @@ SWITCH_STANDARD_API(tone_detect_session_function)
 	return SWITCH_STATUS_SUCCESS;
 }
 
+#define UUID_GENERATE_SYNTAX "<create_uuid> [4|7]"
 SWITCH_STANDARD_API(uuid_function)
 {
 	char uuid_str[SWITCH_UUID_FORMATTED_LENGTH + 1];
 
-	switch_uuid_str(uuid_str, sizeof(uuid_str));
+	int version = 0;
+	if (!zstr(cmd)) {
+		version = atoi(cmd);
+	}
+
+	if (version) {
+		switch_uuid_str_version(uuid_str, sizeof(uuid_str), version);
+	} else {
+		switch_uuid_str(uuid_str, sizeof(uuid_str));
+	}
 
 	stream->write_function(stream, "%s", uuid_str);
 	return SWITCH_STATUS_SUCCESS;
@@ -7609,7 +7619,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_commands_load)
 	SWITCH_ADD_API(commands_api_interface, "cond", "Evaluate a conditional", cond_function, "<expr> ? <true val> : <false val>");
 	SWITCH_ADD_API(commands_api_interface, "console_complete", "", console_complete_function, "<line>");
 	SWITCH_ADD_API(commands_api_interface, "console_complete_xml", "", console_complete_xml_function, "<line>");
-	SWITCH_ADD_API(commands_api_interface, "create_uuid", "Create a uuid", uuid_function, UUID_SYNTAX);
+	SWITCH_ADD_API(commands_api_interface, "create_uuid", "Create a uuid", uuid_function, UUID_GENERATE_SYNTAX);
 	SWITCH_ADD_API(commands_api_interface, "db_cache", "Manage db cache", db_cache_function, "status");
 	SWITCH_ADD_API(commands_api_interface, "domain_data", "Find domain data", domain_data_function, "<domain> [var|param|attr] <name>");
 	SWITCH_ADD_API(commands_api_interface, "domain_exists", "Check if a domain exists", domain_exists_function, "<domain>");

--- a/src/switch_utils.c
+++ b/src/switch_utils.c
@@ -4139,6 +4139,21 @@ SWITCH_DECLARE(char *) switch_uuid_str(char *buf, switch_size_t len)
 	return buf;
 }
 
+SWITCH_DECLARE(char *) switch_uuid_str_version(char *buf, switch_size_t len, int version)
+{
+	switch_uuid_t uuid;
+
+	if (len < (SWITCH_UUID_FORMATTED_LENGTH + 1)) {
+		switch_snprintf(buf, len, "INVALID");
+	} else if (switch_uuid_generate_version(&uuid, version) != SWITCH_STATUS_SUCCESS) {
+		switch_snprintf(buf, len, "INVALID");
+	} else {
+		switch_uuid_format(buf, &uuid);
+	}
+
+	return buf;
+}
+
 
 SWITCH_DECLARE(char *) switch_format_number(const char *num)
 {


### PR DESCRIPTION
Provide functionality to generate UUIDs of specific versions (4 and 7) via the new `switch_uuid_generate_version` API. Enhances the `create_uuid` command to allow specifying the desired UUID version, ensuring greater flexibility for UUID generation.