### PR TITLE
Improve fsctl recover logic

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -1050,7 +1050,6 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 	sofia_destination_t *dst = NULL;
 	sofia_cid_type_t cid_type = tech_pvt->profile->cid_type;
 	sip_cseq_t *cseq = NULL;
-	const char *invite_record_route = switch_channel_get_variable(tech_pvt->channel, "sip_invite_record_route");
 	const char *invite_route_uri = switch_channel_get_variable(tech_pvt->channel, "sip_invite_route_uri");
 	const char *invite_full_from = switch_channel_get_variable(tech_pvt->channel, "sip_invite_full_from");
 	const char *invite_full_to = switch_channel_get_variable(tech_pvt->channel, "sip_invite_full_to");
@@ -1060,8 +1059,6 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 	const char *force_full_to = switch_channel_get_variable(tech_pvt->channel, "sip_force_full_to");
 	const char *content_encoding = switch_channel_get_variable(tech_pvt->channel, "sip_content_encoding");
 	char *mp = NULL, *mp_type = NULL;
-	char *record_route = NULL;
-	const char *recover_via = NULL;
 	int require_timer = 1;
 	uint8_t is_t38 = 0;
 	const char *hold_char = "*";
@@ -1082,11 +1079,6 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 
 	if (switch_channel_test_flag(tech_pvt->channel, CF_RECOVERING)) {
 		const char *recover_contact = switch_channel_get_variable(tech_pvt->channel, "sip_recover_contact");
-		recover_via = switch_channel_get_variable(tech_pvt->channel, "sip_recover_via");
-
-		if (!zstr(invite_record_route)) {
-			record_route = switch_core_session_sprintf(session, "Record-Route: %s", invite_record_route);
-		}
 
 		if (recover_contact) {
 			char *tmp = switch_core_session_strdup(session, recover_contact);
@@ -1408,7 +1400,6 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 		if (!(tech_pvt->nh = nua_handle(tech_pvt->profile->nua, NULL,
 										NUTAG_URL(url_str),
 										TAG_IF(call_id, SIPTAG_CALL_ID_STR(call_id)),
-										TAG_IF(!zstr(record_route), SIPTAG_HEADER_STR(record_route)),
 #ifdef NUTAG_CALL_TLS_ORQ_CONNECT_TIMEOUT
 										/* Per call tls outgoing request connect timeout */
 										TAG_IF(sip_call_tls_orq_connect_timeout_str, NUTAG_CALL_TLS_ORQ_CONNECT_TIMEOUT(sip_call_tls_orq_connect_timeout)),
@@ -1686,7 +1677,6 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 				   TAG_IF(invite_full_from, SIPTAG_FROM_STR(invite_full_from)),
 				   TAG_IF(invite_full_to, SIPTAG_TO_STR(invite_full_to)),
 				   TAG_IF(tech_pvt->redirected, NUTAG_URL(tech_pvt->redirected)),
-				   TAG_IF(!zstr(recover_via), SIPTAG_VIA_STR(recover_via)),
 				   TAG_IF(!zstr(tech_pvt->user_via), SIPTAG_VIA_STR(tech_pvt->user_via)),
 				   TAG_IF(!zstr(tech_pvt->rpid), SIPTAG_REMOTE_PARTY_ID_STR(tech_pvt->rpid)),
 				   TAG_IF(!zstr(tech_pvt->preferred_id), SIPTAG_P_PREFERRED_IDENTITY_STR(tech_pvt->preferred_id)),
@@ -1726,7 +1716,6 @@ switch_status_t sofia_glue_do_invite(switch_core_session_t *session)
 				   TAG_IF(invite_full_from, SIPTAG_FROM_STR(invite_full_from)),
 				   TAG_IF(invite_full_to, SIPTAG_TO_STR(invite_full_to)),
 				   TAG_IF(tech_pvt->redirected, NUTAG_URL(tech_pvt->redirected)),
-				   TAG_IF(!zstr(recover_via), SIPTAG_VIA_STR(recover_via)),
 				   TAG_IF(!zstr(tech_pvt->user_via), SIPTAG_VIA_STR(tech_pvt->user_via)),
 				   TAG_IF(!zstr(tech_pvt->rpid), SIPTAG_REMOTE_PARTY_ID_STR(tech_pvt->rpid)),
 				   TAG_IF(!zstr(tech_pvt->preferred_id), SIPTAG_P_PREFERRED_IDENTITY_STR(tech_pvt->preferred_id)),


### PR DESCRIPTION
I have tried to test call recovering logic, and i have found some problems.

The current logic includes some anomalies regarding SIP logic.

Actually, FS on RE-Invite, includes SIP in a "wrong way":
- `Old Via header`;
- `Record-Route's`;

This causes troubles in the RE-Invite transaction, because if we have `Proxies` in the middle, this generates loops in the middle. As FS is the UA that origintaes the RE-Invite, must put only Route headers that belong to the dialog there, RR must not be added.
Adding the old Via header its also a bad practice, this is a new transaction...

Example of actual behaviour:

<img width="1651" height="947" alt="image" src="https://github.com/user-attachments/assets/97579a63-9aa7-45ed-9326-9260502357b3" />

**More people report similar problems/questions?**
Yes.
https://github.com/signalwire/freeswitch/issues/2403

**What includes the PR:**
- Removed Old Via(s);
- Removed RR;

**Tested and Works fine:**
Yes.
Mid-Req's working on both ends.
Example:

<img width="1132" height="957" alt="image" src="https://github.com/user-attachments/assets/6cb8eec0-7c27-45bd-83f1-9dfff88b8e37" />
<img width="877" height="455" alt="image" src="https://github.com/user-attachments/assets/74e340c5-d585-4f4c-8393-242664cd1e60" />


