### PR TITLE
Handle fire of DETECTED_SPEECH events using a global variable

### DIFF
--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -5511,7 +5511,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_detect_speech(switch_core_session_t *
 	}
 
 	if (check_fire_asr_events(channel)) {
-		switch_set_flag(ah, SWITCH_ASR_FLAG_FIRE_EVENTS);
+		switch_set_flag(sth->ah, SWITCH_ASR_FLAG_FIRE_EVENTS);
 	}
 
 	return SWITCH_STATUS_SUCCESS;


### PR DESCRIPTION
At this point, we can only handle the fire of `DETECTED_SPEECH` events, by setting `fire_asr_events` in the channel.

This works, but its not feasible, if we want to fire the events always and for all channels.

-------

So, in this PR, it was introduced a logic that:

- Allows the fire of `DETECTED_SPEECH` events if `fire_asr_events` is setted as a global var;
- The remaining logic was kept as is;
  - If we don't have the global var setted, the channel check for `fire_asr_events` is done;
 
--------

Tests:

Oh, yes.

- global var and channel var not setted;
  - Events not fired;
- channel var setted to true:
  - Events fired;
- Global var setted to true:
  - Events fired;
