### PR TITLE
Add 'm4a' to supported VLC file formats

### DIFF
--- a/src/mod/formats/mod_vlc/mod_vlc.c
+++ b/src/mod/formats/mod_vlc/mod_vlc.c
@@ -2631,6 +2631,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_vlc_load)
 	vlc_file_supported_formats[argc++] = "m4v";
 	vlc_file_supported_formats[argc++] = "rtmp";
 	vlc_file_supported_formats[argc++] = "youtube";
+	vlc_file_supported_formats[argc++] = "m4a";
 
 	file_interface = switch_loadable_module_create_interface(*module_interface, SWITCH_FILE_INTERFACE);
 	file_interface->interface_name = modname;


### PR DESCRIPTION
When using .m4a format, I need to prefix url with vlc://. This causes mod_http_cache to fail `http_cache://vlc://https://url.dot/file.m4a`

`Failed to download URL vlc://https://`

When m4a is recognized in formats (`fs_cli -x "show file"`), `http_cache://https://url.dot/file.m4a` works fine.