### PR TITLE
RFC 3261 Compliance: Preserve sip: Prefix in RPID for Polycom User-Ag…

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -254,9 +254,17 @@ char *generate_pai_str(private_object_t *tech_pvt)
 	callee_number = switch_sanitize_number(switch_core_session_strdup(session, callee_number));
 	callee_name = switch_sanitize_number(switch_core_session_strdup(session, callee_name));
 
+/* Not RFC 3261 compliant
 	if (!zstr(callee_number) && (zstr(ua) || !switch_stristr("poly", ua))) {
 		callee_number = switch_core_session_sprintf(session, "sip:%s@%s", callee_number, host);
 	}
+*/
+	
+if (!zstr(callee_number)) {
+    if (strncasecmp(callee_number, "sip:", 4)) {
+        callee_number = switch_core_session_sprintf(session, "sip:%s@%s", callee_number, host);
+    }
+}
 
 	header = (tech_pvt->cid_type == CID_TYPE_RPID && !switch_stristr("aastra", ua)) ? "Remote-Party-ID" : "P-Asserted-Identity";
 


### PR DESCRIPTION
This change restores RFC 3261 compliance for Remote-Party-ID header construction.

Previously, when the User-Agent string contained “Poly” or “Polycom,” FreeSWITCH intentionally omitted the sip: prefix in the RPID <addr-spec> to accommodate legacy Polycom firmware display issues. Those early devices would incorrectly render the full SIP URI on-screen.

Modern Poly/Polycom firmware has resolved this behavior. To ensure proper interoperability with RFC-compliant SBCs (e.g., Sansay VSXi, Ribbon, BroadWorks) and strict SIP stacks, we now always include the sip: prefix in the RPID while retaining all other Polycom-specific logic and formatting.