### PR TITLE
Add old_calls cli command

### DIFF
--- a/src/mod/applications/mod_commands/mod_commands.c
+++ b/src/mod/applications/mod_commands/mod_commands.c
@@ -5893,6 +5893,7 @@ SWITCH_STANDARD_API(show_function)
 		} else if (!strcasecmp(command, "old_calls")) {
 			int age = 14400; // default 4 hours
 			time_t now = time(NULL);
+			time_t threshold_epoch;
 			int format_arg_index = 1;
 
 			if (argv[1] && isdigit(*argv[1])) {
@@ -5900,7 +5901,7 @@ SWITCH_STANDARD_API(show_function)
 				format_arg_index = 2;
 			}
 
-			time_t threshold_epoch = now - age;
+			threshold_epoch = now - age;
 
 			switch_snprintfv(sql, sizeof(sql),
 				"SELECT * FROM calls WHERE hostname='%q' AND call_created_epoch < %ld ORDER BY call_created_epoch",


### PR DESCRIPTION
In multiple cases, its useful to have a cli command that show calls older than a specific time threshold.

At this time, we don't have a easy way to do that.
We can do the query directly to DB or parse the `show calls|channels` output.
But its boring, and hard to mantain in monitoring tools.

---------

Added a new cli command:

- `show old_calls <time_threshold_seconds> [as] [json|xml|...]`
  - `time_threshold_seconds` its optional - must be defined in seconds;
    - Example: 1 hour --> 360 seconds;
    - By default , the threshold is 1440 seconds (4 hours);

---------

Tests:

Oh, yes.

- Without passing time threshold;
- Passing custom time threshold;
- Return `as json|xml`;

<img width="1914" height="81" alt="image" src="https://github.com/user-attachments/assets/277538d8-569b-4049-9876-681acbf4f1ea" />

<img width="1198" height="313" alt="image" src="https://github.com/user-attachments/assets/193cf5ab-7960-47c2-9122-ed8304c5935a" />
