### PR TITLE
Fix DTMF capture break #2968

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,4 +275,3 @@ src/mod/codecs/mod_amrwb/test/test_amrwb
 src/mod/endpoints/mod_sofia/test/sipp-based-tests
 
 .DS_Store
-.idea/


### PR DESCRIPTION
No break handling was defined inside of while loop for dtmf capture. This pattern for break handling is present in multiple places in this file.
More info about the bug here: https://github.com/signalwire/freeswitch/issues/2968
