### PR TITLE
mod_commands: fix nullptr crash in uuid_record when argc=4

### DIFF
--- a/src/mod/applications/mod_commands/mod_commands.c
+++ b/src/mod/applications/mod_commands/mod_commands.c
@@ -4776,7 +4776,7 @@ SWITCH_STANDARD_API(session_record_function)
 	}
 
 	if (!strcasecmp(action, "start")) {
-		if(argc > 3) {
+		if(argc > 4) {
 			switch_url_decode(argv[4]);
 			switch_event_create_brackets(argv[4], '{', '}',',', &vars, &new_fp, SWITCH_FALSE);
 		}


### PR DESCRIPTION
## Description

This PR fixes a **null pointer crash** in `mod_commands.c` when executing the `uuid_record` API command.

The bug was caused by an incorrect argument count check:
- Original code used `if (argc > 3)` and accessed `argv[4]` directly
- When `argc == 4`, `argv[4]` is NULL, passing a null pointer to `switch_url_decode()`
- This leads to an immediate crash in `switch_url_decode` at `src/switch_utils.c:3540`

Fix: Changed the condition from `argc > 3` to `argc > 4` to ensure `argv[4]` is valid before accessing it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

No existing issue reported; this bug was discovered via production crash stack trace.

## Testing

- [ ] Added/updated unit tests
- [x] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

Manual testing verification:
1. Test `uuid_record` with 4 arguments (argc=4) → No crash, works safely
2. Test `uuid_record` with 5 arguments (argc=5) → Functions as expected
3. Verified the original crash scenario no longer occurs

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] All existing tests pass

## Additional Notes

Crash stack trace: