### PR TITLE
[core] add Heartbeat-Interval value in send_heartbeat

### DIFF
--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -121,6 +121,7 @@ static void send_heartbeat(void)
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Session-Peak-Max", "%u", runtime.sessions_peak);
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Session-Peak-FiveMin", "%u", runtime.sessions_peak_fivemin);
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Idle-CPU", "%f", switch_core_idle_cpu());
+		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "Heartbeat-Interval", "%d", runtime.event_heartbeat_interval);
 		switch_event_fire(&event);
 	}
 }


### PR DESCRIPTION
## Summary

- Adds the `Heartbeat-Interval` header to the `HEARTBEAT` event fired by `send_heartbeat()`, exposing `runtime.event_heartbeat_interval` (the value configured via `event-heartbeat-interval` in `switch.conf`) directly in the event.

This makes heartbeat-driven liveness detection self-describing: a consumer receiving the event knows exactly how long to wait before considering FreeSWITCH unresponsive, without having to read the config separately or hard-code the 20-second default.

Already in production use on our side and consumed by [`freeswitch-esl-tokio`](https://github.com/ticpu/freeswitch-esl-tokio) as a liveness signal — see the [`HeartbeatInterval`](https://github.com/ticpu/freeswitch-esl-tokio/blob/master/freeswitch-types/src/headers.rs) header definition and the [liveness detection rationale](https://github.com/ticpu/freeswitch-esl-tokio/blob/master/docs/design-rationale.md).