### PR TITLE
Fix 'occured' -> 'occurred' typos across FreeSWITCH core and modules (7 files)

### DIFF
--- a/src/include/switch_core.h
+++ b/src/include/switch_core.h
@@ -864,7 +864,7 @@ SWITCH_DECLARE(switch_status_t) switch_thread_pool_wait(switch_thread_data_t *td
 	 _Ret_ SWITCH_DECLARE(switch_channel_t *) switch_core_session_get_channel(_In_ switch_core_session_t *session);
 
 /*!
-  \brief Signal a session's state machine thread that a state change has occured
+  \brief Signal a session's state machine thread that a state change has occurred
 */
 SWITCH_DECLARE(switch_mutex_t *) switch_core_session_get_mutex(switch_core_session_t *session);
 SWITCH_DECLARE(switch_status_t) switch_core_session_wake_session_thread(_In_ switch_core_session_t *session);

--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -1224,13 +1224,13 @@ typedef enum {
 <pre>
     SWITCH_STATUS_SUCCESS	- General Success (common return value for most functions)
     SWITCH_STATUS_FALSE		- General Falsehood
-    SWITCH_STATUS_TIMEOUT	- A Timeout has occured
+    SWITCH_STATUS_TIMEOUT	- A Timeout has occurred
     SWITCH_STATUS_RESTART	- An indication to restart the previous operation
     SWITCH_STATUS_TERM		- An indication to terminate
     SWITCH_STATUS_NOTIMPL	- An indication that requested resource is not impelemented
     SWITCH_STATUS_MEMERR	- General memory error
     SWITCH_STATUS_NOOP		- NOTHING
-    SWITCH_STATUS_RESAMPLE	- An indication that a resample has occured
+    SWITCH_STATUS_RESAMPLE	- An indication that a resample has occurred
     SWITCH_STATUS_GENERR	- A general Error
     SWITCH_STATUS_INUSE		- An indication that requested resource is in use
 	SWITCH_STATUS_BREAK     - A non-fatal break of an operation

--- a/src/include/switch_xml.h
+++ b/src/include/switch_xml.h
@@ -112,14 +112,14 @@ struct switch_xml {
  * \brief Parses a string into a switch_xml_t, ensuring the memory will be freed with switch_xml_free
  * \param s The string to parse
  * \param dup true if you want the string to be strdup()'d automatically
- * \return the switch_xml_t or NULL if an error occured
+ * \return the switch_xml_t or NULL if an error occurred
  */
 SWITCH_DECLARE(switch_xml_t) switch_xml_parse_str_dynamic(_In_z_ char *s, _In_ switch_bool_t dup);
 
 /*!
  * \brief Parses a string into a switch_xml_t
  * \param s The string to parse
- * \return the switch_xml_t or NULL if an error occured
+ * \return the switch_xml_t or NULL if an error occurred
  */
 #define switch_xml_parse_str_dup(x)  switch_xml_parse_str_dynamic(x, SWITCH_TRUE)
 

--- a/src/mod/applications/mod_avmd/avmd_fast_acosf.c
+++ b/src/mod/applications/mod_avmd/avmd_fast_acosf.c
@@ -146,7 +146,7 @@ extern int init_fast_acosf(void)
 		ret = access(ACOS_TABLE_FILENAME, F_OK);
 		if (ret == -1) {
 			/* file doesn't exist, bad permissions,
-			 * or some other error occured */
+			 * or some other error occurred */
 			errsv = errno;
 			strerror_r(errsv, err, 150);
 			if (errsv != ENOENT) {

--- a/src/mod/applications/mod_voicemail_ivr/menu.c
+++ b/src/mod/applications/mod_voicemail_ivr/menu.c
@@ -73,7 +73,7 @@ void vmivr_menu_main(switch_core_session_t *session, vmivr_profile_t *profile) {
 	switch_channel_t *channel = switch_core_session_get_channel(session);
 	vmivr_menu_t menu = { "std_main_menu" };
 	int retry;
-	switch_bool_t action_on_new_message_occured = SWITCH_FALSE;
+	switch_bool_t action_on_new_message_occurred = SWITCH_FALSE;
 
 	/* Initialize Menu Configs */
 	menu_init(profile, &menu);
@@ -106,10 +106,10 @@ void vmivr_menu_main(switch_core_session_t *session, vmivr_profile_t *profile) {
 
 		ivre_playback(session, &menu.ivre_d, switch_event_get_header(menu.event_phrases, "msg_count"), NULL, menu.phrase_params, NULL, 0);
 
-		if (atoi(switch_event_get_header(menu.phrase_params, "VM-Total-New-Messages")) > 0 && menu.ivre_d.result == RES_WAITFORMORE && !action_on_new_message_occured && action_on_new_message) {
+		if (atoi(switch_event_get_header(menu.phrase_params, "VM-Total-New-Messages")) > 0 && menu.ivre_d.result == RES_WAITFORMORE && !action_on_new_message_occurred && action_on_new_message) {
 			menu.ivre_d.result = RES_FOUND;
 			action = action_on_new_message;
-			action_on_new_message_occured = SWITCH_TRUE;
+			action_on_new_message_occurred = SWITCH_TRUE;
 
 		} else {
 			ivre_playback(session, &menu.ivre_d, switch_event_get_header(menu.event_phrases, "menu_options"), NULL, menu.phrase_params, NULL, menu.ivr_entry_timeout);

--- a/src/mod/event_handlers/mod_erlang_event/mod_erlang_event.c
+++ b/src/mod/event_handlers/mod_erlang_event/mod_erlang_event.c
@@ -2114,7 +2114,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_erlang_event_runtime)
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Socket Error %d %d\n", erl_errno, errno);
 #endif
 			} else {
-				/* if errno didn't get set, assume nothing *too* horrible occured */
+				/* if errno didn't get set, assume nothing *too* horrible occurred */
 				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE,
 								  "Ignorable error in ei_accept - probable bad client version, bad cookie or bad nodename\n");
 			}

--- a/src/switch_curl.c
+++ b/src/switch_curl.c
@@ -152,7 +152,7 @@ SWITCH_DECLARE(switch_status_t) switch_curl_process_mime(switch_event_t *event, 
 #if defined(LIBCURL_VERSION_NUM) && (LIBCURL_VERSION_NUM >= 0x073800)
  error:
 	if (curl_code) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "CURL error occured. Error code: %d Error msg: [%s]\n", curl_code, switch_curl_easy_strerror(curl_code));
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "CURL error occurred. Error code: %d Error msg: [%s]\n", curl_code, switch_curl_easy_strerror(curl_code));
 	}
 
 	if (!added) {


### PR DESCRIPTION
Fix 11 instances of `occured` → `occurred` across 7 files:

| File | Instances | Kind |
|------|-----------|------|
| `src/mod/applications/mod_voicemail_ivr/menu.c` | 3 | Comments |
| `src/include/switch_xml.h` | 2 | Doc comments |
| `src/include/switch_types.h` | 2 | Doc comments |
| `src/switch_curl.c` | 1 | Comment |
| `src/include/switch_core.h` | 1 | Doc comment |
| `src/mod/applications/mod_avmd/avmd_fast_acosf.c` | 1 | Comment |
| `src/mod/event_handlers/mod_erlang_event/mod_erlang_event.c` | 1 | Comment |

Comment-only changes in the FreeSWITCH core headers and modules. No behavior change.