### PR TITLE
[switch_core_media.c] Renegotiate media on fsctl recovery

### DIFF
--- a/src/include/private/switch_core_pvt.h
+++ b/src/include/private/switch_core_pvt.h
@@ -288,6 +288,7 @@ struct switch_runtime {
 	uint32_t max_audio_channels;
 	switch_call_cause_t shutdown_cause;
 	uint32_t uuid_version;
+	switch_bool_t recovery_renegotiate_media;
 };
 
 extern struct switch_runtime runtime;

--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -2381,6 +2381,8 @@ static void switch_load_core_config(const char *file)
 					}
 				} else if (!strcasecmp(var, "max-audio-channels") && !zstr(val)) {
 					switch_core_max_audio_channels(atoi(val));
+				} else if (!strcasecmp(var, "recovery-renegotiate-media") && !zstr(val)) {
+					runtime.recovery_renegotiate_media = switch_true(val) ? SWITCH_TRUE : SWITCH_FALSE;
 				}
 			}
 		}

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -14098,13 +14098,17 @@ SWITCH_DECLARE (void) switch_core_media_recover_session(switch_core_session_t *s
 
 	switch_core_media_set_codec(session, 0, smh->mparams->codec_flags);
 
-	a_engine->adv_sdp_ip = smh->mparams->extrtpip = (char *) ip;
 	a_engine->adv_sdp_port = a_engine->local_sdp_port = (switch_port_t)atoi(port);
 	a_engine->codec_negotiated = 1;
 
-	if (!zstr(ip)) {
-		a_engine->local_sdp_ip = switch_core_session_strdup(session, ip);
-		smh->mparams->rtpip = a_engine->local_sdp_ip;
+	if (!runtime.recovery_renegotiate_media) {
+		a_engine->adv_sdp_ip = smh->mparams->extrtpip = (char *) ip;
+		if (!zstr(ip)) {
+			a_engine->local_sdp_ip = switch_core_session_strdup(session, ip);
+			smh->mparams->rtpip = a_engine->local_sdp_ip;
+		}
+	} else {
+		a_engine->adv_sdp_ip = (char *) ip;
 	}
 
 	if (!zstr(a_ip)) {
@@ -14114,6 +14118,10 @@ SWITCH_DECLARE (void) switch_core_media_recover_session(switch_core_session_t *s
 	if (r_ip && r_port) {
 		a_engine->cur_payload_map->remote_sdp_ip = (char *) r_ip;
 		a_engine->cur_payload_map->remote_sdp_port = (switch_port_t)atoi(r_port);
+	}
+
+	if (runtime.recovery_renegotiate_media) {
+		switch_core_media_choose_port(session, SWITCH_MEDIA_TYPE_AUDIO, 1);
 	}
 
 	if (switch_channel_test_flag(session->channel, CF_VIDEO)) {
@@ -14150,6 +14158,9 @@ SWITCH_DECLARE (void) switch_core_media_recover_session(switch_core_session_t *s
 		if (r_ip && r_port) {
 			v_engine->cur_payload_map->remote_sdp_ip = (char *) r_ip;
 			v_engine->cur_payload_map->remote_sdp_port = (switch_port_t)atoi(r_port);
+		}
+		if (runtime.recovery_renegotiate_media) {
+			switch_core_media_choose_port(session, SWITCH_MEDIA_TYPE_VIDEO, 1);
 		}
 	}
 


### PR DESCRIPTION
## Description

Currently, FreeSWITCH takes media information from the recovery.metadata table.
This works fine when using a single FreeSWITCH instance or when switching a single IP between two instances (active-passive setup).
However, in an active-active setup where each FreeSWITCH instance has its own IP address, session recovery does not work without modifying the metadata.

## Type of Change

- [+] New feature

## Related Issues

no issue 

## Testing

- [+] Tested manually
<img width="2329" height="834" alt="image" src="https://github.com/user-attachments/assets/fa4c37f5-0b26-41ba-9a28-8972f0787cd7" />


## Checklist

- [+] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [+] My code follows the project's style guidelines
- [+] I have added tests for my changes (if applicable)
- [+] I have updated documentation (if applicable)
- [+] All existing tests pass

## Additional Notes
