### PR TITLE
[core] Fix use-after-free in session thread pool worker.

### DIFF
--- a/src/switch_core_session.c
+++ b/src/switch_core_session.c
@@ -1932,7 +1932,8 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_thread_pool_launch(switch_co
 	} else {
 		switch_set_flag(session, SSF_THREAD_RUNNING);
 		switch_set_flag(session, SSF_THREAD_STARTED);
-		td = switch_core_session_alloc(session, sizeof(*td));
+		switch_zmalloc(td, sizeof(*td));
+		td->alloc = 1;
 		td->obj = session;
 		td->func = switch_core_session_thread;
 		status = switch_queue_push(session_manager.thread_queue, td);


### PR DESCRIPTION
`switch_core_session_thread_pool_launch()` allocated the thread data (`td`) from the session pool. However, `switch_core_session_thread()` destroys the session pool before returning, leaving td as a dangling pointer. The worker then accesses `td->running` and `td->pool` — a use-after-free that crashes under memory pressure when the freed pool is reused.

Allocate `td` with `switch_zmalloc()` and set `td->alloc = 1` so the worker frees it after the task completes. This ensures `td` outlives the session pool destruction.
