### PR TITLE
fix(mod_conference): prime conference input buffers

### DIFF
--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -1815,6 +1815,7 @@ int conference_member_setup_media(conference_member_t *member, conference_obj_t 
 	if (!member->frame_size) {
 		member->frame_size = SWITCH_RECOMMENDED_BUFFER_SIZE;
 		member->frame = switch_core_alloc(member->pool, member->frame_size);
+		member->last_frame = switch_core_alloc(member->pool, member->frame_size);
 		member->mux_frame = switch_core_alloc(member->pool, member->frame_size);
 	}
 

--- a/src/mod/applications/mod_conference/conference_member.c
+++ b/src/mod/applications/mod_conference/conference_member.c
@@ -1815,7 +1815,6 @@ int conference_member_setup_media(conference_member_t *member, conference_obj_t 
 	if (!member->frame_size) {
 		member->frame_size = SWITCH_RECOMMENDED_BUFFER_SIZE;
 		member->frame = switch_core_alloc(member->pool, member->frame_size);
-		member->last_frame = switch_core_alloc(member->pool, member->frame_size);
 		member->mux_frame = switch_core_alloc(member->pool, member->frame_size);
 	}
 
@@ -1863,6 +1862,11 @@ int conference_member_setup_media(conference_member_t *member, conference_obj_t 
 		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(member->session), SWITCH_LOG_CRIT, "Memory Error Creating Audio Buffer!\n");
 		goto codec_done1;
 	}
+
+	switch_mutex_lock(member->audio_in_mutex);
+	switch_buffer_zero(member->audio_buffer);
+	member->audio_buffer_primed = SWITCH_FALSE;
+	switch_mutex_unlock(member->audio_in_mutex);
 
 	/* Setup an audio buffer for the outgoing audio */
 	if (!member->mux_buffer && switch_buffer_create_dynamic(&member->mux_buffer, CONF_DBLOCK_SIZE, CONF_DBUFFER_SIZE, CONF_DBUFFER_MAX) != SWITCH_STATUS_SUCCESS) {

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -219,6 +219,15 @@ static switch_bool_t conference_member_read_audio_frame(conference_member_t *mem
 	if (!member->audio_buffer_primed && inuse >= min_bytes) {
 		member->audio_buffer_primed = SWITCH_TRUE;
 	}
+	if (member->audio_buffer_primed && inuse < bytes) {
+		switch_mutex_unlock(member->audio_in_mutex);
+		switch_yield(CONF_AUDIO_BUFFER_RETRY_USEC);
+		switch_mutex_lock(member->audio_in_mutex);
+		inuse = switch_buffer_inuse(member->audio_buffer);
+		if (!member->audio_buffer_primed && inuse >= min_bytes) {
+			member->audio_buffer_primed = SWITCH_TRUE;
+		}
+	}
 
 	if (member->audio_buffer_primed && inuse >= bytes
 		&& (buf_read = (uint32_t) switch_buffer_read(member->audio_buffer, member->frame, bytes))) {

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -205,6 +205,8 @@ void conference_send_notify(conference_obj_t *conference, const char *status, co
 
 static switch_bool_t conference_member_read_audio_frame(conference_member_t *member, uint32_t bytes)
 {
+	switch_size_t inuse = 0;
+	switch_size_t min_bytes = bytes * CONF_AUDIO_BUFFER_MIN_FRAMES;
 	uint32_t buf_read = 0;
 	switch_bool_t have_audio = SWITCH_FALSE;
 
@@ -213,70 +215,28 @@ static switch_bool_t conference_member_read_audio_frame(conference_member_t *mem
 	}
 
 	switch_mutex_lock(member->audio_in_mutex);
-	if (switch_buffer_inuse(member->audio_buffer) >= bytes
+	inuse = switch_buffer_inuse(member->audio_buffer);
+	if (!member->audio_buffer_primed && inuse >= min_bytes) {
+		member->audio_buffer_primed = SWITCH_TRUE;
+	}
+
+	if (member->audio_buffer_primed && inuse >= bytes
 		&& (buf_read = (uint32_t) switch_buffer_read(member->audio_buffer, member->frame, bytes))) {
 		member->read = buf_read;
 
 		if (buf_read < bytes) {
 			memset(member->frame + buf_read, 0, bytes - buf_read);
-		}
-
-		if (member->last_frame && buf_read <= member->frame_size) {
-			memcpy(member->last_frame, member->frame, buf_read);
-			member->last_frame_read = buf_read;
-			member->audio_underflow_count = 0;
+			member->audio_buffer_primed = SWITCH_FALSE;
 		}
 
 		conference_utils_member_set_flag_locked(member, MFLAG_HAS_AUDIO);
 		have_audio = SWITCH_TRUE;
+	} else if (member->audio_buffer_primed && inuse < bytes) {
+		member->audio_buffer_primed = SWITCH_FALSE;
 	}
 	switch_mutex_unlock(member->audio_in_mutex);
 
 	return have_audio;
-}
-
-static switch_bool_t conference_member_should_replay_last_audio(conference_member_t *member, uint32_t bytes)
-{
-	if (!member->last_frame || member->last_frame_read != bytes || member->audio_underflow_count >= CONF_AUDIO_UNDERFLOW_REPLAY_FRAMES) {
-		return SWITCH_FALSE;
-	}
-
-	if (!conference_utils_member_test_flag(member, MFLAG_RUNNING) || !member->session || !member->channel ||
-		!switch_channel_ready(member->channel) || !switch_channel_test_flag(member->channel, CF_AUDIO)) {
-		return SWITCH_FALSE;
-	}
-
-	if (!conference_utils_member_test_flag(member, MFLAG_CAN_SPEAK) ||
-		conference_utils_member_test_flag(member, MFLAG_HOLD) ||
-		conference_utils_test_flag(member->conference, CFLAG_WAIT_MOD)) {
-		return SWITCH_FALSE;
-	}
-
-	if (!(conference_utils_member_test_flag(member, MFLAG_TALKING) || member->energy_level == 0 ||
-		  conference_utils_test_flag(member->conference, CFLAG_AUDIO_ALWAYS))) {
-		return SWITCH_FALSE;
-	}
-
-	if (!(member->conference->count > 1 ||
-		  (member->conference->record_count && member->conference->count >= member->conference->min_recording_participants))) {
-		return SWITCH_FALSE;
-	}
-
-	return SWITCH_TRUE;
-}
-
-static switch_bool_t conference_member_replay_last_audio_frame(conference_member_t *member, uint32_t bytes)
-{
-	if (!conference_member_should_replay_last_audio(member, bytes)) {
-		return SWITCH_FALSE;
-	}
-
-	memcpy(member->frame, member->last_frame, bytes);
-	member->read = bytes;
-	member->audio_underflow_count++;
-	conference_utils_member_set_flag_locked(member, MFLAG_HAS_AUDIO);
-
-	return SWITCH_TRUE;
 }
 
 /* Main monitor thread (1 per distinct conference room) */
@@ -639,32 +599,6 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 			}
 		}
 		switch_mutex_unlock(conference->file_mutex);
-
-		if (!ready && !has_file_data) {
-			switch_bool_t retry_audio = SWITCH_FALSE;
-
-			for (imember = conference->members; imember; imember = imember->next) {
-				if (conference_member_should_replay_last_audio(imember, bytes)) {
-					retry_audio = SWITCH_TRUE;
-					break;
-				}
-			}
-
-			if (retry_audio) {
-				switch_yield(1000);
-
-				for (imember = conference->members; imember; imember = imember->next) {
-					if (conference_utils_member_test_flag(imember, MFLAG_HAS_AUDIO)) {
-						continue;
-					}
-
-					if (conference_member_read_audio_frame(imember, bytes) ||
-						conference_member_replay_last_audio_frame(imember, bytes)) {
-						ready++;
-					}
-				}
-			}
-		}
 
 		if (ready || has_file_data) {
 			/* Use more bits in the main_frame to preserve the exact sum of the audio samples. */

--- a/src/mod/applications/mod_conference/mod_conference.c
+++ b/src/mod/applications/mod_conference/mod_conference.c
@@ -203,6 +203,81 @@ void conference_send_notify(conference_obj_t *conference, const char *status, co
 
 }
 
+static switch_bool_t conference_member_read_audio_frame(conference_member_t *member, uint32_t bytes)
+{
+	uint32_t buf_read = 0;
+	switch_bool_t have_audio = SWITCH_FALSE;
+
+	if (!member->audio_buffer || !member->frame) {
+		return SWITCH_FALSE;
+	}
+
+	switch_mutex_lock(member->audio_in_mutex);
+	if (switch_buffer_inuse(member->audio_buffer) >= bytes
+		&& (buf_read = (uint32_t) switch_buffer_read(member->audio_buffer, member->frame, bytes))) {
+		member->read = buf_read;
+
+		if (buf_read < bytes) {
+			memset(member->frame + buf_read, 0, bytes - buf_read);
+		}
+
+		if (member->last_frame && buf_read <= member->frame_size) {
+			memcpy(member->last_frame, member->frame, buf_read);
+			member->last_frame_read = buf_read;
+			member->audio_underflow_count = 0;
+		}
+
+		conference_utils_member_set_flag_locked(member, MFLAG_HAS_AUDIO);
+		have_audio = SWITCH_TRUE;
+	}
+	switch_mutex_unlock(member->audio_in_mutex);
+
+	return have_audio;
+}
+
+static switch_bool_t conference_member_should_replay_last_audio(conference_member_t *member, uint32_t bytes)
+{
+	if (!member->last_frame || member->last_frame_read != bytes || member->audio_underflow_count >= CONF_AUDIO_UNDERFLOW_REPLAY_FRAMES) {
+		return SWITCH_FALSE;
+	}
+
+	if (!conference_utils_member_test_flag(member, MFLAG_RUNNING) || !member->session || !member->channel ||
+		!switch_channel_ready(member->channel) || !switch_channel_test_flag(member->channel, CF_AUDIO)) {
+		return SWITCH_FALSE;
+	}
+
+	if (!conference_utils_member_test_flag(member, MFLAG_CAN_SPEAK) ||
+		conference_utils_member_test_flag(member, MFLAG_HOLD) ||
+		conference_utils_test_flag(member->conference, CFLAG_WAIT_MOD)) {
+		return SWITCH_FALSE;
+	}
+
+	if (!(conference_utils_member_test_flag(member, MFLAG_TALKING) || member->energy_level == 0 ||
+		  conference_utils_test_flag(member->conference, CFLAG_AUDIO_ALWAYS))) {
+		return SWITCH_FALSE;
+	}
+
+	if (!(member->conference->count > 1 ||
+		  (member->conference->record_count && member->conference->count >= member->conference->min_recording_participants))) {
+		return SWITCH_FALSE;
+	}
+
+	return SWITCH_TRUE;
+}
+
+static switch_bool_t conference_member_replay_last_audio_frame(conference_member_t *member, uint32_t bytes)
+{
+	if (!conference_member_should_replay_last_audio(member, bytes)) {
+		return SWITCH_FALSE;
+	}
+
+	memcpy(member->frame, member->last_frame, bytes);
+	member->read = bytes;
+	member->audio_underflow_count++;
+	conference_utils_member_set_flag_locked(member, MFLAG_HAS_AUDIO);
+
+	return SWITCH_TRUE;
+}
 
 /* Main monitor thread (1 per distinct conference room) */
 void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *obj)
@@ -306,7 +381,6 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 
 		/* Read one frame of audio from each member channel and save it for redistribution */
 		for (imember = conference->members; imember; imember = imember->next) {
-			uint32_t buf_read = 0;
 			total++;
 			imember->read = 0;
 
@@ -370,15 +444,9 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 			}
 
 			conference_utils_member_clear_flag_locked(imember, MFLAG_HAS_AUDIO);
-			switch_mutex_lock(imember->audio_in_mutex);
-
-			if (switch_buffer_inuse(imember->audio_buffer) >= bytes
-				&& (buf_read = (uint32_t) switch_buffer_read(imember->audio_buffer, imember->frame, bytes))) {
-				imember->read = buf_read;
-				conference_utils_member_set_flag_locked(imember, MFLAG_HAS_AUDIO);
+			if (conference_member_read_audio_frame(imember, bytes)) {
 				ready++;
 			}
-			switch_mutex_unlock(imember->audio_in_mutex);
 		}
 
 		conference->members_with_video = members_with_video;
@@ -571,6 +639,32 @@ void *SWITCH_THREAD_FUNC conference_thread_run(switch_thread_t *thread, void *ob
 			}
 		}
 		switch_mutex_unlock(conference->file_mutex);
+
+		if (!ready && !has_file_data) {
+			switch_bool_t retry_audio = SWITCH_FALSE;
+
+			for (imember = conference->members; imember; imember = imember->next) {
+				if (conference_member_should_replay_last_audio(imember, bytes)) {
+					retry_audio = SWITCH_TRUE;
+					break;
+				}
+			}
+
+			if (retry_audio) {
+				switch_yield(1000);
+
+				for (imember = conference->members; imember; imember = imember->next) {
+					if (conference_utils_member_test_flag(imember, MFLAG_HAS_AUDIO)) {
+						continue;
+					}
+
+					if (conference_member_read_audio_frame(imember, bytes) ||
+						conference_member_replay_last_audio_frame(imember, bytes)) {
+						ready++;
+					}
+				}
+			}
+		}
 
 		if (ready || has_file_data) {
 			/* Use more bits in the main_frame to preserve the exact sum of the audio samples. */

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -81,6 +81,8 @@
 #define SCORE_IIR_SPEAKING_MAX 300
 /* the threshold below which you cede the floor to someone loud (see above value). */
 #define SCORE_IIR_SPEAKING_MIN 100
+/* Short concealment window for conference input thread scheduling underflows. */
+#define CONF_AUDIO_UNDERFLOW_REPLAY_FRAMES 2
 /* the FPS of the conference canvas */
 #define FPS 30
 /* max supported layers in one mcu */
@@ -803,6 +805,8 @@ struct conference_member {
 	conference_record_t *rec;
 	uint8_t *frame;
 	uint8_t *last_frame;
+	uint32_t last_frame_read;
+	uint32_t audio_underflow_count;
 	uint32_t frame_size;
 	uint8_t *mux_frame;
 	uint32_t read;

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -83,6 +83,8 @@
 #define SCORE_IIR_SPEAKING_MIN 100
 /* Keep a small input cushion so the mixer is not phase-locked to the input thread. */
 #define CONF_AUDIO_BUFFER_MIN_FRAMES 2
+/* Give a primed input thread a short grace period to deliver the next real frame. */
+#define CONF_AUDIO_BUFFER_RETRY_USEC 1000
 /* the FPS of the conference canvas */
 #define FPS 30
 /* max supported layers in one mcu */

--- a/src/mod/applications/mod_conference/mod_conference.h
+++ b/src/mod/applications/mod_conference/mod_conference.h
@@ -81,8 +81,8 @@
 #define SCORE_IIR_SPEAKING_MAX 300
 /* the threshold below which you cede the floor to someone loud (see above value). */
 #define SCORE_IIR_SPEAKING_MIN 100
-/* Short concealment window for conference input thread scheduling underflows. */
-#define CONF_AUDIO_UNDERFLOW_REPLAY_FRAMES 2
+/* Keep a small input cushion so the mixer is not phase-locked to the input thread. */
+#define CONF_AUDIO_BUFFER_MIN_FRAMES 2
 /* the FPS of the conference canvas */
 #define FPS 30
 /* max supported layers in one mcu */
@@ -805,8 +805,7 @@ struct conference_member {
 	conference_record_t *rec;
 	uint8_t *frame;
 	uint8_t *last_frame;
-	uint32_t last_frame_read;
-	uint32_t audio_underflow_count;
+	switch_bool_t audio_buffer_primed;
 	uint32_t frame_size;
 	uint8_t *mux_frame;
 	uint32_t read;


### PR DESCRIPTION
Closes #3024.

## Summary
- replace the mixer-side last-frame replay/concealment workaround with input-buffer priming
- keep a small real-audio cushion in each member `audio_buffer` before the conference mixer starts consuming it
- when a primed input buffer briefly drains below one complete frame, wait 1 ms and retry a real read before marking it unprimed
- mark the buffer unprimed again if it still cannot provide a complete real frame, so it re-primes from the input thread instead of replaying synthetic audio
- clear and unprime the input buffer when member media is configured/reset

## Why
The issue is an input-thread underflow: the mixer can become phase-locked to a member input thread and sample the buffer just before the next real frame arrives. The previous approach concealed that by replaying the last frame, but that can corrupt FSK tones because it synthesizes audio. This version avoids replay and only mixes frames that came from the input thread.

## Testing
- `git diff --check`
- verified no remaining `audio_underflow` / replay helper references in `mod_conference`

Full compile/test was not available in my Windows workspace because `gcc`, `clang`, `cl`, `make`, and `cmake` were not present in PATH.