### PR TITLE
apr: fix musl build

### DIFF
--- a/libs/apr/misc/unix/errorcodes.c
+++ b/libs/apr/misc/unix/errorcodes.c
@@ -25,6 +25,9 @@
 #ifdef HAVE_DLFCN_H
 #include <dlfcn.h>
 #endif
+#ifndef WIN32
+#include "../../../src/include/switch_private.h"
+#endif
 
 /*
  * stuffbuffer - like fspr_cpystrn() but returns the address of the
@@ -352,12 +355,20 @@ const char *strerror_r(fspr_status_t, char *, fspr_size_t);
 static char *native_strerror(fspr_status_t statcode, char *buf,
                              fspr_size_t bufsize)
 {
+#if defined(STRERROR_R_CHAR_P)
     const char *msg;
+#else
+    int msg;
+#endif
 
     buf[0] = '\0';
     msg = strerror_r(statcode, buf, bufsize);
     if (buf[0] == '\0') { /* libc didn't use our buffer */
+#if defined(STRERROR_R_CHAR_P)
         return stuffbuffer(buf, bufsize, msg);
+#else
+        return stuffbuffer(buf, bufsize, (const char*)msg);
+#endif
     }
     else {
         return buf;


### PR DESCRIPTION
## Description

strerror_r on musl always returns an int since its addition back in 2011 with
https://git.musl-libc.org/cgit/musl/commit/src/string/strerror_r.c?id=0b44a0315b47dd8eced9f3b7f31580cf14bbfc01

Add defines created by freeswitch configure to apr subproject to fix the build error:
```
misc/unix/errorcodes.c: In function ‘native_strerror’: misc/unix/errorcodes.c:358:9: error: assignment to ‘const char *’ from
 ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  358 |     msg = strerror_r(statcode, buf, bufsize);
```
## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
