### PR TITLE
[mod_sofia] Use invite failure phrase in NOTIFY sipfrag

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -1477,7 +1477,7 @@ static switch_status_t sofia_receive_message(switch_core_session_t *session, swi
 					if (other_session) {
 						switch_channel_t *other_channel = switch_core_session_get_channel(other_session);
 						const char *invite_failure_status = switch_channel_get_variable(other_channel, "sip_invite_failure_status");
-						const char *invite_failure_str = switch_channel_get_variable(other_channel, "sip_invite_failure_status");
+						const char *invite_failure_str = switch_channel_get_variable(other_channel, "sip_invite_failure_phrase");
 						if (!zstr(invite_failure_status) && !zstr(invite_failure_str)) {
 							snprintf(payload_str, sizeof(payload_str), "SIP/2.0 %s %s\r\n", invite_failure_status, invite_failure_str);
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,


### PR DESCRIPTION
## Description

With the existing code, FreeSWITCH may generate a payload like:

```
SIP/2.0 486 486
```

instead of:

```
SIP/2.0 486 Busy Here
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

## Testing

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] All existing tests pass

## Additional Notes
