### PR TITLE
[Core] Avoid O(n^2) header dedup when cloning EF_UNIQ_HEADERS events

### DIFF
--- a/src/switch_event.c
+++ b/src/switch_event.c
@@ -1346,11 +1346,13 @@ SWITCH_DECLARE(switch_status_t) switch_event_dup(switch_event_t **event, switch_
 	(*event)->bind_user_data = todup->bind_user_data;
 	(*event)->flags = todup->flags;
 
-	/* todup's headers are already unique (uniqueness is enforced on insert for an
-	 * EF_UNIQ_HEADERS event), so the per-add duplicate scan that
-	 * switch_event_base_add_header() performs when EF_UNIQ_HEADERS is set is
-	 * redundant while cloning and makes this loop O(n^2) in the header count.
-	 * Suppress the scan for the copy, then restore the flag. */
+	/* The destination inherited todup's flags above. When EF_UNIQ_HEADERS is set,
+	 * switch_event_base_add_header() rescans the partial header list on every add
+	 * to keep names unique, making this copy loop O(n^2). A clone should reproduce
+	 * todup's list verbatim rather than run a fresh uniqueness pass, and a
+	 * well-formed EF_UNIQ_HEADERS source is already unique (its names were deduped
+	 * on insert), so that scan only adds cost here. Suppress it for the copy, then
+	 * restore the flag so later adds enforce uniqueness again. */
 	if (switch_test_flag((*event), EF_UNIQ_HEADERS)) {
 		switch_clear_flag((*event), EF_UNIQ_HEADERS);
 		restore_uniq_headers = 1;

--- a/src/switch_event.c
+++ b/src/switch_event.c
@@ -1335,6 +1335,7 @@ SWITCH_DECLARE(void) switch_event_merge(switch_event_t *event, switch_event_t *t
 SWITCH_DECLARE(switch_status_t) switch_event_dup(switch_event_t **event, switch_event_t *todup)
 {
 	switch_event_header_t *hp;
+	int restore_uniq_headers = 0;
 
 	if (switch_event_create_subclass(event, SWITCH_EVENT_CLONE, todup->subclass_name) != SWITCH_STATUS_SUCCESS) {
 		return SWITCH_STATUS_GENERR;
@@ -1344,6 +1345,17 @@ SWITCH_DECLARE(switch_status_t) switch_event_dup(switch_event_t **event, switch_
 	(*event)->event_user_data = todup->event_user_data;
 	(*event)->bind_user_data = todup->bind_user_data;
 	(*event)->flags = todup->flags;
+
+	/* todup's headers are already unique (uniqueness is enforced on insert for an
+	 * EF_UNIQ_HEADERS event), so the per-add duplicate scan that
+	 * switch_event_base_add_header() performs when EF_UNIQ_HEADERS is set is
+	 * redundant while cloning and makes this loop O(n^2) in the header count.
+	 * Suppress the scan for the copy, then restore the flag. */
+	if (switch_test_flag((*event), EF_UNIQ_HEADERS)) {
+		switch_clear_flag((*event), EF_UNIQ_HEADERS);
+		restore_uniq_headers = 1;
+	}
+
 	for (hp = todup->headers; hp; hp = hp->next) {
 		if (todup->subclass_name && !strcmp(hp->name, "Event-Subclass")) {
 			continue;
@@ -1357,6 +1369,10 @@ SWITCH_DECLARE(switch_status_t) switch_event_dup(switch_event_t **event, switch_
 		} else {
 			switch_event_add_header_string(*event, SWITCH_STACK_BOTTOM, hp->name, hp->value);
 		}
+	}
+
+	if (restore_uniq_headers) {
+		switch_set_flag((*event), EF_UNIQ_HEADERS);
 	}
 
 	if (todup->body) {

--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -177,6 +177,57 @@ FST_TEST_BEGIN(dup_uniq_bench)
 }
 FST_TEST_END()
 
+FST_TEST_BEGIN(dup_faithful_copy)
+{
+  /* Regression for the switch_event_dup O(n^2)->O(n) change (suppressing the
+   * per-add EF_UNIQ_HEADERS dedup scan while cloning). dup must reproduce the
+   * source faithfully:
+   *   (1) a well-formed EF_UNIQ source stays unique through dup (the real case);
+   *   (2) a malformed source that already holds duplicate names (only possible
+   *       if headers were added before EF_UNIQ_HEADERS was set) is copied
+   *       faithfully -- dup PRESERVES the duplicates rather than silently
+   *       collapsing to the last value. A dup-bearing EF_UNIQ event is already
+   *       a bug upstream of here; a copy must not silently drop data. */
+  switch_event_t *src = NULL, *dup = NULL;
+  switch_event_header_t *hp;
+  switch_status_t status;
+  int n;
+
+  /* (1) well-formed EF_UNIQ source -> unique dup */
+  status = switch_event_create(&src, SWITCH_EVENT_CHANNEL_DATA);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "create CHANNEL_DATA");
+  fst_xcheck(switch_test_flag(src, EF_UNIQ_HEADERS) != 0, "CHANNEL_DATA is EF_UNIQ");
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "k", "v1");
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "k", "v2");
+  n = 0; for (hp = src->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "k")) n++; }
+  fst_xcheck(n == 1, "EF_UNIQ source keeps 'k' unique (collapsed to last)");
+  status = switch_event_dup(&dup, src);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (unique)");
+  n = 0; for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "k")) n++; }
+  fst_xcheck(n == 1, "dup of unique source stays unique");
+  fst_check_string_equals(switch_event_get_header(dup, "k"), "v2");
+  switch_event_destroy(&dup);
+  switch_event_destroy(&src);
+
+  /* (2) malformed source (duplicate names under EF_UNIQ) -> faithful copy */
+  status = switch_event_create(&src, SWITCH_EVENT_GENERAL);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "create GENERAL");
+  fst_xcheck(switch_test_flag(src, EF_UNIQ_HEADERS) == 0, "GENERAL is not EF_UNIQ");
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "dupkey", "first");
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "dupkey", "second");
+  switch_set_flag(src, EF_UNIQ_HEADERS);
+  n = 0; for (hp = src->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "dupkey")) n++; }
+  fst_xcheck(n == 2, "malformed source holds 2 'dupkey' headers");
+  status = switch_event_dup(&dup, src);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (malformed)");
+  fst_xcheck(switch_test_flag(dup, EF_UNIQ_HEADERS) != 0, "dup keeps EF_UNIQ flag");
+  n = 0; for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "dupkey")) n++; }
+  fst_xcheck(n == 2, "dup faithfully preserves both 'dupkey' headers (no silent collapse)");
+  switch_event_destroy(&dup);
+  switch_event_destroy(&src);
+}
+FST_TEST_END()
+
 FST_SUITE_END()
 
 FST_MINCORE_END()

--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -130,14 +130,18 @@ FST_TEST_BEGIN(dup_uniq_bench)
     switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, name, val);
   }
   S = 0;
-  for (hp = src->headers; hp; hp = hp->next) S++;
+  for (hp = src->headers; hp; hp = hp->next) {
+    S++;
+  }
   fst_xcheck(S >= 191, "source has at least the 191 added headers");
 
   /* correctness: dup preserves header count, the uniq flag, and values */
   status = switch_event_dup(&dup, src);
   fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok");
   count = 0;
-  for (hp = dup->headers; hp; hp = hp->next) count++;
+  for (hp = dup->headers; hp; hp = hp->next) {
+    count++;
+  }
   fst_xcheck(count == S, "dup header count equals source");
   fst_xcheck(switch_test_flag(dup, EF_UNIQ_HEADERS) != 0, "dup keeps EF_UNIQ_HEADERS");
   fst_check_string_equals(switch_event_get_header(dup, "var_0"), "value_0_some_padding_payload");
@@ -149,7 +153,11 @@ FST_TEST_BEGIN(dup_uniq_bench)
   status = switch_event_dup(&dup, src);
   fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (2)");
   k = 0;
-  for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "var_0")) k++; }
+  for (hp = dup->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "var_0")) {
+      k++;
+    }
+  }
   fst_xcheck(k == 1, "var_0 present exactly once after re-set + dup");
   fst_check_string_equals(switch_event_get_header(dup, "var_0"), "REPLACED");
   switch_event_destroy(&dup);
@@ -201,11 +209,21 @@ FST_TEST_BEGIN(dup_faithful_copy)
   fst_xcheck(switch_test_flag(src, EF_UNIQ_HEADERS) != 0, "CHANNEL_DATA is EF_UNIQ");
   switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "k", "v1");
   switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "k", "v2");
-  n = 0; for (hp = src->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "k")) n++; }
+  n = 0;
+  for (hp = src->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "k")) {
+      n++;
+    }
+  }
   fst_xcheck(n == 1, "EF_UNIQ source keeps 'k' unique (collapsed to last)");
   status = switch_event_dup(&dup, src);
   fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (unique)");
-  n = 0; for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "k")) n++; }
+  n = 0;
+  for (hp = dup->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "k")) {
+      n++;
+    }
+  }
   fst_xcheck(n == 1, "dup of unique source stays unique");
   fst_check_string_equals(switch_event_get_header(dup, "k"), "v2");
   switch_event_destroy(&dup);
@@ -218,12 +236,22 @@ FST_TEST_BEGIN(dup_faithful_copy)
   switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "dupkey", "first");
   switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "dupkey", "second");
   switch_set_flag(src, EF_UNIQ_HEADERS);
-  n = 0; for (hp = src->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "dupkey")) n++; }
+  n = 0;
+  for (hp = src->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "dupkey")) {
+      n++;
+    }
+  }
   fst_xcheck(n == 2, "malformed source holds 2 'dupkey' headers");
   status = switch_event_dup(&dup, src);
   fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (malformed)");
   fst_xcheck(switch_test_flag(dup, EF_UNIQ_HEADERS) != 0, "dup keeps EF_UNIQ flag");
-  n = 0; for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "dupkey")) n++; }
+  n = 0;
+  for (hp = dup->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "dupkey")) {
+      n++;
+    }
+  }
   fst_xcheck(n == 2, "dup faithfully preserves both 'dupkey' headers (no silent collapse)");
   switch_event_destroy(&dup);
   switch_event_destroy(&src);

--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -104,6 +104,7 @@ FST_TEST_BEGIN(benchmark)
 }
 FST_TEST_END()
 
+#ifdef BENCHMARK
 FST_TEST_BEGIN(dup_uniq_bench)
 {
   switch_event_t *src = NULL, *dup = NULL;
@@ -176,6 +177,7 @@ FST_TEST_BEGIN(dup_uniq_bench)
   }
 }
 FST_TEST_END()
+#endif /* BENCHMARK */
 
 FST_TEST_BEGIN(dup_faithful_copy)
 {

--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -104,6 +104,79 @@ FST_TEST_BEGIN(benchmark)
 }
 FST_TEST_END()
 
+FST_TEST_BEGIN(dup_uniq_bench)
+{
+  switch_event_t *src = NULL, *dup = NULL;
+  switch_status_t status;
+  const int loops = 4000;
+  const int Ns[4] = {50, 100, 191, 400};
+  int i, j, count, k, S, Nv;
+  char name[32], val[64];
+  switch_event_header_t *hp;
+  switch_time_t start_ts, end_ts;
+  double per_us;
+
+  /* A channel's variables are a SWITCH_EVENT_CHANNEL_DATA event => EF_UNIQ_HEADERS.
+   * switch_event_create() also adds the standard event headers, so the source
+   * count is (191 added + standard); assert relative to the actual source count. */
+  status = switch_event_create(&src, SWITCH_EVENT_CHANNEL_DATA);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "create CHANNEL_DATA event");
+  fst_xcheck(switch_test_flag(src, EF_UNIQ_HEADERS) != 0, "CHANNEL_DATA event is EF_UNIQ_HEADERS");
+
+  for (i = 0; i < 191; i++) {
+    switch_snprintf(name, sizeof(name), "var_%d", i);
+    switch_snprintf(val, sizeof(val), "value_%d_some_padding_payload", i);
+    switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, name, val);
+  }
+  S = 0;
+  for (hp = src->headers; hp; hp = hp->next) S++;
+  fst_xcheck(S >= 191, "source has at least the 191 added headers");
+
+  /* correctness: dup preserves header count, the uniq flag, and values */
+  status = switch_event_dup(&dup, src);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok");
+  count = 0;
+  for (hp = dup->headers; hp; hp = hp->next) count++;
+  fst_xcheck(count == S, "dup header count equals source");
+  fst_xcheck(switch_test_flag(dup, EF_UNIQ_HEADERS) != 0, "dup keeps EF_UNIQ_HEADERS");
+  fst_check_string_equals(switch_event_get_header(dup, "var_0"), "value_0_some_padding_payload");
+  fst_check_string_equals(switch_event_get_header(dup, "var_190"), "value_190_some_padding_payload");
+  switch_event_destroy(&dup);
+
+  /* correctness: uniqueness preserved (re-setting a key must not duplicate it in the dup) */
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "var_0", "REPLACED");
+  status = switch_event_dup(&dup, src);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (2)");
+  k = 0;
+  for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "var_0")) k++; }
+  fst_xcheck(k == 1, "var_0 present exactly once after re-set + dup");
+  fst_check_string_equals(switch_event_get_header(dup, "var_0"), "REPLACED");
+  switch_event_destroy(&dup);
+  switch_event_destroy(&src);
+
+  /* timing sweep: dup cost vs header count (baseline ~O(n^2), patched ~O(n)) */
+  for (j = 0; j < 4; j++) {
+    Nv = Ns[j];
+    switch_event_create(&src, SWITCH_EVENT_CHANNEL_DATA);
+    for (i = 0; i < Nv; i++) {
+      switch_snprintf(name, sizeof(name), "var_%d", i);
+      switch_snprintf(val, sizeof(val), "value_%d_some_padding_payload", i);
+      switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, name, val);
+    }
+    start_ts = switch_time_now();
+    for (i = 0; i < loops; i++) {
+      switch_event_dup(&dup, src);
+      switch_event_destroy(&dup);
+    }
+    end_ts = switch_time_now();
+    per_us = (double)(end_ts - start_ts) / (double)loops;
+    printf("DUP_BENCH N=%d loops=%d total=%" SWITCH_UINT64_T_FMT "us per_dup=%.3f us\n",
+           Nv, loops, (uint64_t)(end_ts - start_ts), per_us);
+    switch_event_destroy(&src);
+  }
+}
+FST_TEST_END()
+
 FST_SUITE_END()
 
 FST_MINCORE_END()

--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -187,14 +187,18 @@ FST_TEST_BEGIN(dup_uniq_bench)
     switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, name, val);
   }
   S = 0;
-  for (hp = src->headers; hp; hp = hp->next) S++;
+  for (hp = src->headers; hp; hp = hp->next) {
+    S++;
+  }
   fst_xcheck(S >= 191, "source has at least the 191 added headers");
 
   /* correctness: dup preserves header count, the uniq flag, and values */
   status = switch_event_dup(&dup, src);
   fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok");
   count = 0;
-  for (hp = dup->headers; hp; hp = hp->next) count++;
+  for (hp = dup->headers; hp; hp = hp->next) {
+    count++;
+  }
   fst_xcheck(count == S, "dup header count equals source");
   fst_xcheck(switch_test_flag(dup, EF_UNIQ_HEADERS) != 0, "dup keeps EF_UNIQ_HEADERS");
   fst_check_string_equals(switch_event_get_header(dup, "var_0"), "value_0_some_padding_payload");
@@ -206,7 +210,11 @@ FST_TEST_BEGIN(dup_uniq_bench)
   status = switch_event_dup(&dup, src);
   fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (2)");
   k = 0;
-  for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "var_0")) k++; }
+  for (hp = dup->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "var_0")) {
+      k++;
+    }
+  }
   fst_xcheck(k == 1, "var_0 present exactly once after re-set + dup");
   fst_check_string_equals(switch_event_get_header(dup, "var_0"), "REPLACED");
   switch_event_destroy(&dup);
@@ -258,11 +266,21 @@ FST_TEST_BEGIN(dup_faithful_copy)
   fst_xcheck(switch_test_flag(src, EF_UNIQ_HEADERS) != 0, "CHANNEL_DATA is EF_UNIQ");
   switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "k", "v1");
   switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "k", "v2");
-  n = 0; for (hp = src->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "k")) n++; }
+  n = 0;
+  for (hp = src->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "k")) {
+      n++;
+    }
+  }
   fst_xcheck(n == 1, "EF_UNIQ source keeps 'k' unique (collapsed to last)");
   status = switch_event_dup(&dup, src);
   fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (unique)");
-  n = 0; for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "k")) n++; }
+  n = 0;
+  for (hp = dup->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "k")) {
+      n++;
+    }
+  }
   fst_xcheck(n == 1, "dup of unique source stays unique");
   fst_check_string_equals(switch_event_get_header(dup, "k"), "v2");
   switch_event_destroy(&dup);
@@ -275,12 +293,22 @@ FST_TEST_BEGIN(dup_faithful_copy)
   switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "dupkey", "first");
   switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "dupkey", "second");
   switch_set_flag(src, EF_UNIQ_HEADERS);
-  n = 0; for (hp = src->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "dupkey")) n++; }
+  n = 0;
+  for (hp = src->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "dupkey")) {
+      n++;
+    }
+  }
   fst_xcheck(n == 2, "malformed source holds 2 'dupkey' headers");
   status = switch_event_dup(&dup, src);
   fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (malformed)");
   fst_xcheck(switch_test_flag(dup, EF_UNIQ_HEADERS) != 0, "dup keeps EF_UNIQ flag");
-  n = 0; for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "dupkey")) n++; }
+  n = 0;
+  for (hp = dup->headers; hp; hp = hp->next) {
+    if (!strcmp(hp->name, "dupkey")) {
+      n++;
+    }
+  }
   fst_xcheck(n == 2, "dup faithfully preserves both 'dupkey' headers (no silent collapse)");
   switch_event_destroy(&dup);
   switch_event_destroy(&src);

--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -161,6 +161,79 @@ FST_TEST_BEGIN(expand_headers_offset)
 }
 FST_TEST_END()
 
+FST_TEST_BEGIN(dup_uniq_bench)
+{
+  switch_event_t *src = NULL, *dup = NULL;
+  switch_status_t status;
+  const int loops = 4000;
+  const int Ns[4] = {50, 100, 191, 400};
+  int i, j, count, k, S, Nv;
+  char name[32], val[64];
+  switch_event_header_t *hp;
+  switch_time_t start_ts, end_ts;
+  double per_us;
+
+  /* A channel's variables are a SWITCH_EVENT_CHANNEL_DATA event => EF_UNIQ_HEADERS.
+   * switch_event_create() also adds the standard event headers, so the source
+   * count is (191 added + standard); assert relative to the actual source count. */
+  status = switch_event_create(&src, SWITCH_EVENT_CHANNEL_DATA);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "create CHANNEL_DATA event");
+  fst_xcheck(switch_test_flag(src, EF_UNIQ_HEADERS) != 0, "CHANNEL_DATA event is EF_UNIQ_HEADERS");
+
+  for (i = 0; i < 191; i++) {
+    switch_snprintf(name, sizeof(name), "var_%d", i);
+    switch_snprintf(val, sizeof(val), "value_%d_some_padding_payload", i);
+    switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, name, val);
+  }
+  S = 0;
+  for (hp = src->headers; hp; hp = hp->next) S++;
+  fst_xcheck(S >= 191, "source has at least the 191 added headers");
+
+  /* correctness: dup preserves header count, the uniq flag, and values */
+  status = switch_event_dup(&dup, src);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok");
+  count = 0;
+  for (hp = dup->headers; hp; hp = hp->next) count++;
+  fst_xcheck(count == S, "dup header count equals source");
+  fst_xcheck(switch_test_flag(dup, EF_UNIQ_HEADERS) != 0, "dup keeps EF_UNIQ_HEADERS");
+  fst_check_string_equals(switch_event_get_header(dup, "var_0"), "value_0_some_padding_payload");
+  fst_check_string_equals(switch_event_get_header(dup, "var_190"), "value_190_some_padding_payload");
+  switch_event_destroy(&dup);
+
+  /* correctness: uniqueness preserved (re-setting a key must not duplicate it in the dup) */
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "var_0", "REPLACED");
+  status = switch_event_dup(&dup, src);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (2)");
+  k = 0;
+  for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "var_0")) k++; }
+  fst_xcheck(k == 1, "var_0 present exactly once after re-set + dup");
+  fst_check_string_equals(switch_event_get_header(dup, "var_0"), "REPLACED");
+  switch_event_destroy(&dup);
+  switch_event_destroy(&src);
+
+  /* timing sweep: dup cost vs header count (baseline ~O(n^2), patched ~O(n)) */
+  for (j = 0; j < 4; j++) {
+    Nv = Ns[j];
+    switch_event_create(&src, SWITCH_EVENT_CHANNEL_DATA);
+    for (i = 0; i < Nv; i++) {
+      switch_snprintf(name, sizeof(name), "var_%d", i);
+      switch_snprintf(val, sizeof(val), "value_%d_some_padding_payload", i);
+      switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, name, val);
+    }
+    start_ts = switch_time_now();
+    for (i = 0; i < loops; i++) {
+      switch_event_dup(&dup, src);
+      switch_event_destroy(&dup);
+    }
+    end_ts = switch_time_now();
+    per_us = (double)(end_ts - start_ts) / (double)loops;
+    printf("DUP_BENCH N=%d loops=%d total=%" SWITCH_UINT64_T_FMT "us per_dup=%.3f us\n",
+           Nv, loops, (uint64_t)(end_ts - start_ts), per_us);
+    switch_event_destroy(&src);
+  }
+}
+FST_TEST_END()
+
 FST_SUITE_END()
 
 FST_MINCORE_END()

--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -234,6 +234,57 @@ FST_TEST_BEGIN(dup_uniq_bench)
 }
 FST_TEST_END()
 
+FST_TEST_BEGIN(dup_faithful_copy)
+{
+  /* Regression for the switch_event_dup O(n^2)->O(n) change (suppressing the
+   * per-add EF_UNIQ_HEADERS dedup scan while cloning). dup must reproduce the
+   * source faithfully:
+   *   (1) a well-formed EF_UNIQ source stays unique through dup (the real case);
+   *   (2) a malformed source that already holds duplicate names (only possible
+   *       if headers were added before EF_UNIQ_HEADERS was set) is copied
+   *       faithfully -- dup PRESERVES the duplicates rather than silently
+   *       collapsing to the last value. A dup-bearing EF_UNIQ event is already
+   *       a bug upstream of here; a copy must not silently drop data. */
+  switch_event_t *src = NULL, *dup = NULL;
+  switch_event_header_t *hp;
+  switch_status_t status;
+  int n;
+
+  /* (1) well-formed EF_UNIQ source -> unique dup */
+  status = switch_event_create(&src, SWITCH_EVENT_CHANNEL_DATA);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "create CHANNEL_DATA");
+  fst_xcheck(switch_test_flag(src, EF_UNIQ_HEADERS) != 0, "CHANNEL_DATA is EF_UNIQ");
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "k", "v1");
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "k", "v2");
+  n = 0; for (hp = src->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "k")) n++; }
+  fst_xcheck(n == 1, "EF_UNIQ source keeps 'k' unique (collapsed to last)");
+  status = switch_event_dup(&dup, src);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (unique)");
+  n = 0; for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "k")) n++; }
+  fst_xcheck(n == 1, "dup of unique source stays unique");
+  fst_check_string_equals(switch_event_get_header(dup, "k"), "v2");
+  switch_event_destroy(&dup);
+  switch_event_destroy(&src);
+
+  /* (2) malformed source (duplicate names under EF_UNIQ) -> faithful copy */
+  status = switch_event_create(&src, SWITCH_EVENT_GENERAL);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "create GENERAL");
+  fst_xcheck(switch_test_flag(src, EF_UNIQ_HEADERS) == 0, "GENERAL is not EF_UNIQ");
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "dupkey", "first");
+  switch_event_add_header_string(src, SWITCH_STACK_BOTTOM, "dupkey", "second");
+  switch_set_flag(src, EF_UNIQ_HEADERS);
+  n = 0; for (hp = src->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "dupkey")) n++; }
+  fst_xcheck(n == 2, "malformed source holds 2 'dupkey' headers");
+  status = switch_event_dup(&dup, src);
+  fst_xcheck(status == SWITCH_STATUS_SUCCESS, "dup ok (malformed)");
+  fst_xcheck(switch_test_flag(dup, EF_UNIQ_HEADERS) != 0, "dup keeps EF_UNIQ flag");
+  n = 0; for (hp = dup->headers; hp; hp = hp->next) { if (!strcmp(hp->name, "dupkey")) n++; }
+  fst_xcheck(n == 2, "dup faithfully preserves both 'dupkey' headers (no silent collapse)");
+  switch_event_destroy(&dup);
+  switch_event_destroy(&src);
+}
+FST_TEST_END()
+
 FST_SUITE_END()
 
 FST_MINCORE_END()

--- a/tests/unit/switch_event.c
+++ b/tests/unit/switch_event.c
@@ -161,6 +161,7 @@ FST_TEST_BEGIN(expand_headers_offset)
 }
 FST_TEST_END()
 
+#ifdef BENCHMARK
 FST_TEST_BEGIN(dup_uniq_bench)
 {
   switch_event_t *src = NULL, *dup = NULL;
@@ -233,6 +234,7 @@ FST_TEST_BEGIN(dup_uniq_bench)
   }
 }
 FST_TEST_END()
+#endif /* BENCHMARK */
 
 FST_TEST_BEGIN(dup_faithful_copy)
 {


### PR DESCRIPTION
## Description

### Problem

`switch_event_dup()` clones a source event by re-adding every header with
`switch_event_add_header_string()`. When the source has `EF_UNIQ_HEADERS`
set — which is the case for `SWITCH_EVENT_CHANNEL_DATA`,
`SWITCH_EVENT_REQUEST_PARAMS` and `SWITCH_EVENT_MESSAGE`, i.e. the events
used to hold a channel's variable list — the destination inherits the
flag, so `switch_event_base_add_header()` calls `switch_event_del_header()`
(a full linear scan of the list built so far) on **every** add to enforce
uniqueness. Duplicating an N-header event is therefore **O(n²)**.

The scan is wasted work: the source list is already unique (uniqueness was
enforced when each header was first inserted), so copying it can never
create a duplicate, with or without the per-add scan.

### Why it matters

`switch_event_dup()` backs `switch_core_get_variables()` and
`switch_channel_get_variables()`, which clone an `EF_UNIQ_HEADERS`
variable event. Any workload that duplicates large `EF_UNIQ_HEADERS`
events — channel-variable snapshots, or ESL consumers cloning big
events — pays this O(n²) on every dup.

On a production voicemail box carrying ~191 channel variables per call,
`switch_event_del_header_val()` (the per-add uniqueness scan) is 47–69%
of FS CPU in `perf`, and call-graph profiles show a substantial share
reached through `execute_on -> *_get_variables -> switch_event_dup` — the
path this patch fixes.

**Scope:** this patch fixes the *dup* path only. `del_header_val` is also
reached via `switch_event_merge()` (also in `execute_on`) and per-variable
`switch_channel_set_variable()`; those are separate O(n²) paths this
change does not address (future work: avoid the dup+merge in `execute_on`,
or hash-index event headers). The exact prod split between these callers
is not yet quantified.

### Fix

Clear `EF_UNIQ_HEADERS` on the destination for the duration of the copy
loop in `switch_event_dup()`, then restore it. ~10 lines, no API change.

### Microbench

`tests/unit/switch_event.c` (`dup_uniq_bench`), dup of an N-header
`CHANNEL_DATA` event, 4000 iterations, time per dup:

| N | before | after | speedup |
|---|---|---|---|
| 50 | 4.80 µs | 3.19 µs | 1.5× |
| 100 | 11.34 µs | 5.88 µs | 1.9× |
| 191 | 28.29 µs | 10.99 µs | 2.6× |
| 400 | 107.05 µs | 23.27 µs | 4.6× |

### Real-call validation

**Validated on production voicemail hosts under real deposit load — across
CPU, hypervisor, and FreeSWITCH version.** Same-node, before vs after
swapping in the patched lib (40 s `perf` windows, self-time):

| environment | `del_header_val` stock | patched | reduction |
|---|---|---|---|
| VMware / Intel / 1.10.12 | 56.7% of FS CPU | 8.5% | −85% |
| VMware / AMD / 1.10.12 | 51.4% | 7.9% | −85% |
| Proxmox / EPYC / 1.11.1 | ~47% | 6.4% | −86% |

A consistent **~85% reduction** in the per-add uniqueness scan across all
three environments — the cache-bound Intel box (highest stock cost) drops
the most in absolute terms, **−48 points of FS CPU**. The call-graph
confirms the mechanism: with the patch the
`switch_channel_execute_on → *_get_variables → switch_event_dup` chains no
longer reach `del_header_val`; the ~6–8% residual is a separate path
(`switch_event_merge`, also reached from `execute_on`) that this change
deliberately does not touch.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] Code cleanup / refactor


## Testing

Profiled on production voicemail deposit service.

- [X] Added/updated unit tests
- [X] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [X] My code follows the project's style guidelines
- [X] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [X] All existing tests pass
