### PR TITLE
[mod_cdr_pg_csv] optionally honor force_process_cdr for B-leg CDRs

### DIFF
--- a/src/mod/event_handlers/mod_cdr_pg_csv/mod_cdr_pg_csv.c
+++ b/src/mod/event_handlers/mod_cdr_pg_csv/mod_cdr_pg_csv.c
@@ -88,6 +88,7 @@ static struct {
 	spool_format_t spool_format;
 	int rotate;
 	int debug;
+	int honor_force_process_cdr;
 } globals;
 
 static switch_xml_config_enum_item_t config_opt_cdr_leg_enum[] = {
@@ -122,6 +123,7 @@ static switch_xml_config_item_t config_settings[] = {
 	SWITCH_CONFIG_ITEM("spool-format", SWITCH_CONFIG_ENUM, CONFIG_RELOADABLE, &globals.spool_format, (void *) SPOOL_FORMAT_CSV, &config_opt_spool_format_enum, "csv|sql", "Disk spool format to use if SQL insert fails."),
 	SWITCH_CONFIG_ITEM("rotate-on-hup", SWITCH_CONFIG_BOOL, CONFIG_RELOADABLE, &globals.rotate, SWITCH_FALSE, NULL, NULL, NULL),
 	SWITCH_CONFIG_ITEM("debug", SWITCH_CONFIG_BOOL, CONFIG_RELOADABLE, &globals.debug, SWITCH_FALSE, NULL, NULL, NULL),
+	SWITCH_CONFIG_ITEM("honor-force-process-cdr", SWITCH_CONFIG_BOOL, CONFIG_RELOADABLE, &globals.honor_force_process_cdr, SWITCH_FALSE, NULL, NULL, NULL),
 
 	/* key, type, flags, ptr, defaultvalue, function, functiondata, syntax, helptext */
 	SWITCH_CONFIG_ITEM_CALLBACK("spool-dir", SWITCH_CONFIG_STRING, CONFIG_RELOADABLE, &globals.spool_dir, NULL, config_validate_spool_dir, NULL, NULL, NULL),
@@ -315,12 +317,19 @@ static switch_status_t my_on_reporting(switch_core_session_t *session)
 	const char *var = NULL;
 	cdr_field_t *cdr_field = NULL;
 	switch_size_t len, offset;
+	switch_bool_t forced_b_leg = SWITCH_FALSE;
 
 	if (globals.shutdown) {
 		return SWITCH_STATUS_SUCCESS;
 	}
 
-	if (!((globals.legs & CDR_LEG_A) && (globals.legs & CDR_LEG_B))) {
+	/* A b-leg flagged force_process_cdr bypasses the legs filter (opt-in), as in mod_json_cdr. */
+	if (globals.honor_force_process_cdr && switch_channel_get_originator_caller_profile(channel) &&
+		switch_true(switch_channel_get_variable(channel, SWITCH_FORCE_PROCESS_CDR_VARIABLE))) {
+		forced_b_leg = SWITCH_TRUE;
+	}
+
+	if (!forced_b_leg && !((globals.legs & CDR_LEG_A) && (globals.legs & CDR_LEG_B))) {
 		if ((globals.legs & CDR_LEG_A)) {
 			if (switch_channel_get_originator_caller_profile(channel)) {
 				return SWITCH_STATUS_SUCCESS;


### PR DESCRIPTION
## Description

`mod_cdr_pg_csv` chooses which legs to log solely from the global `legs` setting
(`a` | `b` | `ab`); there is no per-call override. With the default `legs=a`, the
B-leg of a bridged call (e.g. an outbound `bridge` / `<Dial>`) never produces a CDR
and cannot be billed from the pg_csv record, even when the application deliberately
wants it recorded.

`mod_json_cdr` and `mod_format_cdr` already handle this via the standard
`force_process_cdr` channel variable (`SWITCH_FORCE_PROCESS_CDR_VARIABLE`), reported
regardless of the leg filter. `mod_cdr_pg_csv` had no equivalent.

This adds an opt-in `honor-force-process-cdr` setting (default **off**). When
enabled, a B-leg whose `force_process_cdr` variable is set is logged even if the
`legs` filter would otherwise skip it. Enable in `cdr_pg_csv.conf.xml`:

    <param name="honor-force-process-cdr" value="true" />

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

None.

## Testing

Built against `master`. The same change (on a 1.10.12 base) is running in production:
with the setting on and a bridged B-leg exporting `force_process_cdr=true`, the dialed
leg now produces its own `cdr` row; with it off, output is identical to current behaviour.

- [ ] Added/updated unit tests
- [x] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass
