### PR TITLE
[core/media] Opus: multi-rate transcoding negotiation + RFC 7587 RTP timestamp (#2226)

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5526,6 +5526,10 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					uint32_t bit_rate = imp->bits_per_second;
 					uint32_t codec_rate = imp->samples_per_second;
 
+					if (!strcasecmp(map->rm_encoding, "opus")) {
+						codec_rate = imp->actual_samples_per_second;
+					}
+
 					if (imp->codec_type != SWITCH_CODEC_TYPE_AUDIO) {
 						continue;
 					}

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -3710,11 +3710,22 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_set_codec(switch_core_session_
 	switch_core_session_set_write_impl(session, a_engine->write_codec.implementation);
 
 	if (switch_rtp_ready(a_engine->rtp_session)) {
+		uint32_t samples_per_interval = a_engine->read_impl.samples_per_packet;
+
 		switch_assert(a_engine->read_codec.implementation);
+
+		/* RFC 7587: Opus advances its RTP timestamp at a fixed 48 kHz clock regardless of the
+		   negotiated payload rate, so the interval must come from samples_per_second, not
+		   samples_per_packet. switch_rtp_new() applies this at init; mirror it here so the
+		   post-negotiation change does not reset the Opus clock to the payload rate. */
+		if (!strcasecmp("opus", a_engine->read_impl.iananame)) {
+			samples_per_interval = a_engine->read_impl.samples_per_second *
+				(a_engine->read_impl.microseconds_per_packet / 1000) / 1000;
+		}
 
 		if (switch_rtp_change_interval(a_engine->rtp_session,
 									   a_engine->read_impl.microseconds_per_packet,
-									   a_engine->read_impl.samples_per_packet) != SWITCH_STATUS_SUCCESS) {
+									   samples_per_interval) != SWITCH_STATUS_SUCCESS) {
 			switch_channel_hangup(session->channel, SWITCH_CAUSE_DESTINATION_OUT_OF_ORDER);
 			switch_goto_status(SWITCH_STATUS_FALSE, end);
 		}
@@ -16212,7 +16223,14 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 				session->enc_write_frame.codec = session->write_codec;
 				session->enc_write_frame.samples = enc_frame->datalen / sizeof(int16_t) / session->write_impl.number_of_channels;
 				session->enc_write_frame.channels = session->write_impl.number_of_channels;
-				if (frame->codec->implementation->samples_per_packet != session->write_impl.samples_per_packet) {
+				if (frame->codec->implementation->samples_per_packet != session->write_impl.samples_per_packet ||
+					frame->codec->implementation->samples_per_second != session->write_impl.samples_per_second) {
+					/* RFC 7587: a clock-rate change (e.g. AMR-WB/16000 -> Opus, whose RTP clock is
+					   48 kHz) must regenerate the RTP timestamp at the write codec's clock instead of
+					   passing the source timestamp through. samples_per_packet alone misses this for
+					   a same-rate transcode (AMR-WB 16k and Opus 16k both pack 320 samples/20ms), so
+					   the Opus timestamp would advance at 16 kHz. samples_per_interval carries the
+					   correct 48 kHz Opus clock (see switch_core_media_set_codec). */
 					session->enc_write_frame.timestamp = 0;
 				} else {
 					session->enc_write_frame.timestamp = frame->timestamp;

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5521,6 +5521,9 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					}
 				}
 
+				if (fmtp_remote_codec_rate) {
+					remote_codec_rate = fmtp_remote_codec_rate;
+				}
 				for (i = 0; i < smh->mparams->num_codecs && i < total_codecs; i++) {
 					const switch_codec_implementation_t *imp = codec_array[i];
 					uint32_t bit_rate = imp->bits_per_second;
@@ -5542,10 +5545,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					} else {
 						match = (!strcasecmp(rm_encoding, imp->iananame) &&
 								 ((map->rm_pt < 96 && imp->ianacode < 96) || (map->rm_pt > 95 && imp->ianacode > 95)) &&
-								 (remote_codec_rate == codec_rate || fmtp_remote_codec_rate == imp->actual_samples_per_second)) ? 1 : 0;
-						if (fmtp_remote_codec_rate) {
-							remote_codec_rate = fmtp_remote_codec_rate;
-						}
+								 (remote_codec_rate == codec_rate || remote_codec_rate == imp->actual_samples_per_second)) ? 1 : 0;
 					}
 
 					if (match && bit_rate && map_bit_rate && map_bit_rate != bit_rate && strcasecmp(map->rm_encoding, "ilbc") &&

--- a/tests/unit/switch_core_codec.c
+++ b/tests/unit/switch_core_codec.c
@@ -153,6 +153,45 @@ FST_CORE_BEGIN("./conf")
 		}
 		FST_TEST_END()
 
+		FST_TEST_BEGIN(test_opus_samples_per_packet)
+		{
+			/* RFC 7587: the Opus RTP timestamp advances at a fixed 48 kHz clock
+			   (samples_per_second == 48000) regardless of the audio rate
+			   (actual_samples_per_second). samples_per_packet must stay the TRUE
+			   decoded PCM frame count (rate * ptime), because media bugs,
+			   record_session and playback read it to size PCM frames -- inflating
+			   it to the 48 kHz value corrupts them. Guard that invariant for the
+			   8k/16k/48k Opus implementations at 20 ms. */
+			switch_codec_settings_t codec_settings = {{ 0 }};
+			int i;
+			struct { uint32_t rate; uint32_t samples_per_packet; } cases[] = {
+				{  8000, 160 },
+				{ 16000, 320 },
+				{ 48000, 960 },
+			};
+
+			for (i = 0; i < 3; i++) {
+				switch_codec_t codec = { 0 };
+				switch_status_t status = switch_core_codec_init(&codec,
+					"OPUS",
+					"mod_opus",
+					NULL,
+					cases[i].rate,
+					20,
+					1, SWITCH_CODEC_FLAG_ENCODE | SWITCH_CODEC_FLAG_DECODE,
+					&codec_settings, fst_pool);
+				fst_check(status == SWITCH_STATUS_SUCCESS);
+				if (status == SWITCH_STATUS_SUCCESS) {
+					fst_check_int_equals(codec.implementation->actual_samples_per_second, cases[i].rate);
+					fst_check_int_equals(codec.implementation->samples_per_second, 48000);
+					fst_check_int_equals(codec.implementation->microseconds_per_packet, 20000);
+					fst_check_int_equals(codec.implementation->samples_per_packet, cases[i].samples_per_packet);
+					switch_core_codec_destroy(&codec);
+				}
+			}
+		}
+		FST_TEST_END()
+
 	}
 	FST_SUITE_END()
 }


### PR DESCRIPTION
## Description

### Problem

Two related defects break Opus at a non-48 kHz payload rate (issue #2226):

1. **Negotiation.** When a leg offers `opus/48000` constrained to 16 kHz
   (`maxplaybackrate=16000` / `sprop-maxcapturerate=16000`), the codec-match loop
   compares the constrained rate (16000) against Opus's registered 48 kHz rate;
   because they differ it never records Opus@16k as a match, so Opus is dropped
   from the candidate set. What the caller gets then depends entirely on the rest
   of the offer:
     - **another codec also offered** (the usual case — carriers list e.g. PCMU
       alongside): negotiation falls through to it, so the call connects but on
       that codec (narrowband) even though both ends support Opus@16k;
     - **Opus offered alone:** nothing matches and the INVITE is rejected with
       `488 Not Acceptable Here`.

   So PCMU is only the incidental fallback that happened to be in the offer, not
   the defect — the defect is that Opus@16k is never matched. Regressed in 1.10.10.

2. **RFC 7587 RTP timestamp.** RFC 7587 §4.1 requires the Opus RTP timestamp to
   advance at a fixed 48 kHz clock regardless of the payload rate. For a
   **same-rate transcode** (e.g. `AMR-WB/16000` ↔ `Opus`, as some carriers offer),
   FreeSWITCH advanced the Opus timestamp at the 16 kHz payload rate (320/20 ms)
   instead of 48 kHz (960/20 ms), producing wrong-clock RTP that breaks audio on
   RFC-7587-conformant endpoints. Resampled paths (e.g. PCMU 8k→Opus) were already
   correct, so the bug is specific to same-rate Opus transcodes.

### Fix

Commits 1–2 fix negotiation (Opus-scoped rate comparison + updating the remote
rate before the comparison loop). Commit 3 fixes the timestamp in two coupled spots:

- `switch_core_media_set_codec()`: after negotiation `switch_rtp_change_interval()`
  reset the RTP interval to `samples_per_packet` and omitted the Opus 48 kHz clock
  that `switch_rtp_new()` already applies at init — mirror it.
- `switch_core_session_write_frame()`: it only regenerated the RTP timestamp (vs
  passing the source timestamp through) when `samples_per_packet` changed. A
  same-rate transcode keeps the same `samples_per_packet` (AMR-WB 16k and Opus 16k
  both pack 320 samples/20 ms), so also regenerate when `samples_per_second` (the
  RTP clock rate) differs.

**Recording-safe by construction.** This reuses FreeSWITCH's existing
timestamp-regeneration path and leaves `samples_per_packet` at the true PCM frame
count (160/80), so nothing that consumes the codec's per-frame sample count
changes. An earlier approach hard-coded `samples = 480` in `mod_opus.c`; that also
fixes the on-wire timestamp but mislabels the per-frame sample count that media
bugs, captures and playback rely on — @ticpu reported it causing broken
playback/captures and one-way audio on #2832, which is why that approach was
abandoned. This PR does **not** touch `mod_opus.c`. (Note: `record_session`
specifically recomputes its frame length from the byte count, so it is robust to
the `samples=480` mislabel — verified — but the clean approach here avoids the
dual-purpose field for all consumers.)

### Failure modes covered

Every symptom across the referenced issues/PRs maps to a fix here — or is
explicitly avoided/out of scope:

- **#2226 — Opus@16k offered but PCMU selected** (the 16 kHz offer scored only a
  "near-match" against Opus@48k). → commit 1 (Opus-scoped rate comparison, the
  #2623 form). *Validated: Opus@16k now selected.*
- **#2833 — the fmtp rate (`sprop-maxcapturerate=16000`) was applied only
  mid-loop**, so Opus@16k didn't compare cleanly. → commit 2 (hoist
  `remote_codec_rate` before the match loop). *Validated: selected at the true
  16 kHz rate.*
- **#2582 — its all-codecs form caused `488` on mismatched non-Opus legs.** Not
  reintroduced: the rate override is guarded by `rm_encoding=="opus"` and
  `fmtp_remote_codec_rate` is only set for Opus offers, so the non-Opus
  negotiation path is byte-identical to stock. *Verified in the diff.*
- **#2832 / #2226 — wrong-clock Opus RTP timestamp on same-rate transcodes →
  playback glitches and one-way audio.** → commit 3 (48 kHz RTP clock, RFC 7587).
  *Validated: B-leg ts delta 320→960.*
- **#2832 — the `samples=480` approach broke recording, playback and captures.**
  Avoided by construction: `mod_opus.c` and `samples_per_packet` stay stock; the
  fix lives entirely in `switch_core_media.c`. *Validated: `record_session` WAV
  intact.*

Out of scope (untouched, not regressed): non-Opus codec negotiation and G.722's
8 kHz-clock / 16 kHz-audio handling — the negotiation change is Opus-scoped.

### Validation

Built and driven through a SIP transcoding harness (real AMR-WB media replayed
into FreeSWITCH, bridged to an Opus@16k UAS, RTP timestamps measured on the wire):

| check | stock | this PR |
|---|---|---|
| Negotiation: AMR-WB/16000 leg bridged to an Opus@16k client | Opus@16k not matched → PCMU fallback (or `488` if Opus offered alone) | Opus@16k selected + AMR-WB↔Opus transcode ✓ |
| AMR-WB(16k)→Opus(16k) same-rate transcode, B-leg Opus RTP ts delta | 320 (bug) | **960 (RFC 7587)** ✓ |
| PCMU(8k)→Opus(16k) transcode ts | 960 | 960 (unchanged) |
| inbound Opus@16k recorded via `record_session` | intact ~6.5s/16 kHz WAV | intact ~6.5s/16 kHz WAV (mod_opus.c untouched) |

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

### Credit / relationship to prior PRs

This consolidates and supersedes the stalled negotiation PRs, with credit to the
original authors (their commits are cherry-picked here, authorship preserved):

- #2582 — @magiclin99 — original root-cause + first fix (applied to all codecs;
  caused SIP 488 on mismatched non-Opus legs, so scoped to Opus below)
- #2623 — @shaunjstokes — scoped the fix to Opus (branch deleted, auto-closed)
- #2833 — @nltd101 (Dat Nguyen) — update `remote_codec_rate` before comparison
- #2832 — @ticpu — consolidated the above (draft); diagnosed that the `samples=480`
  timestamp approach breaks recording/playback/captures, and tested the
  negotiation commits
- #2226 — reported by @admin-toneca

The RFC 7587 timestamp fix (commit 3) is the piece none of the above landed:
#2832 sidestepped the timestamp by forcing a transcode but left the clock wrong;
this PR fixes the clock itself, recording-safe.


## Testing

Profiled on production PSTN to Opus VoIP app.

- [X] Added/updated unit tests
- [X] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [X] My code follows the project's style guidelines
- [X] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [X] All existing tests pass

