### PR TITLE
[core] Add RTP_BUG_DONT_REPORT_FLUSHED_AS_LOST to exclude flushed packets from RTCP loss

### DIFF
--- a/src/include/switch_types.h
+++ b/src/include/switch_types.h
@@ -739,6 +739,7 @@ typedef struct {
 	uint32_t last_rpt_ext_seq;    /* Packet loss calculation, extended sequence number at the begining of this RTCP report interval */
 	uint16_t last_rpt_cycle;      /* Packet loss calculation, sequence number cycle at the begining of the current RTCP report interval */
 	uint16_t period_pkt_count;    /* Packet loss calculation, packet count received during this RTCP report interval */
+	switch_size_t last_rpt_flush_count; /* inbound.flush_packet_count at the start of this RTCP report interval (RTP_BUG_DONT_REPORT_FLUSHED_AS_LOST) */
 	uint16_t pkt_count;           /* Packet loss calculation, packet count received during this session */
 	uint16_t sent_pkt_count;
 	uint32_t rtcp_rtp_count;      /* RTCP report generated count */
@@ -975,11 +976,19 @@ typedef enum {
 	*/
 
 
-	RTP_BUG_ALWAYS_AUTO_ADJUST = (1 << 12)
+	RTP_BUG_ALWAYS_AUTO_ADJUST = (1 << 12),
 
 	/*
 	  Leave the auto-adjust behavior enableed permenantly rather than only at appropriate times.  (IMPLICITLY sets RTP_BUG_ACCEPT_ANY_PACKETS)
 
+	 */
+
+	RTP_BUG_DONT_REPORT_FLUSHED_AS_LOST = (1 << 13)
+
+	/*
+	  Do not count packets FreeSWITCH itself flushed (do_flush) as lost in the RTCP
+	  receiver report. They arrived over the network; discarding them locally is not
+	  transport loss. Genuine network loss (packets that never arrived) is still reported.
 	 */
 
 } switch_rtp_bug_flag_t;

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -1018,6 +1018,14 @@ SWITCH_DECLARE(void) switch_core_media_parse_rtp_bugs(switch_rtp_bug_flag_t *fla
 		*flag_pole &= ~RTP_BUG_FLUSH_JB_ON_DTMF;
 	}
 
+	if (switch_stristr("DONT_REPORT_FLUSHED_AS_LOST", str)) {
+		*flag_pole |= RTP_BUG_DONT_REPORT_FLUSHED_AS_LOST;
+	}
+
+	if (switch_stristr("~DONT_REPORT_FLUSHED_AS_LOST", str)) {
+		*flag_pole &= ~RTP_BUG_DONT_REPORT_FLUSHED_AS_LOST;
+	}
+
 	if (switch_stristr("ALWAYS_AUTO_ADJUST", str)) {
 		*flag_pole |= (RTP_BUG_ALWAYS_AUTO_ADJUST | RTP_BUG_ACCEPT_ANY_PACKETS);
 	}

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -1854,6 +1854,14 @@ static void rtcp_generate_report_block(switch_rtp_t *rtp_session, struct switch_
 	}
 
 	pkt_lost = expected_pkt - stats->period_pkt_count;
+
+	if (rtp_session->rtp_bugs & RTP_BUG_DONT_REPORT_FLUSHED_AS_LOST) {
+		switch_size_t fc = rtp_session->stats.inbound.flush_packet_count;
+		if (fc > stats->last_rpt_flush_count) {
+			pkt_lost -= (int32_t)(fc - stats->last_rpt_flush_count); /* flushed by FS = arrived, not transport loss */
+		}
+	}
+
 	if (pkt_lost < 0) pkt_lost = 0;
 
 	stats->cum_lost=stats->cum_lost+pkt_lost;
@@ -1920,6 +1928,7 @@ static void rtcp_stats_init(switch_rtp_t *rtp_session)
 	stats->bad_seq = (1<<16) + 1; /* Make sure we wont missmatch 2 consecutive packets, so seq == bad_seq is false */
 	stats->cum_lost = 0;
 	stats->period_pkt_count = 0;
+	stats->last_rpt_flush_count = rtp_session->stats.inbound.flush_packet_count;
 	stats->sent_pkt_count = 0;
 	stats->pkt_count = 0;
 	stats->rtcp_rtp_count = 0;
@@ -2468,6 +2477,7 @@ static int check_rtcp_and_ice(switch_rtp_t *rtp_session)
 			stats->last_rpt_ext_seq = stats->high_ext_seq_recv;
 			stats->last_rpt_ts = rtp_session->write_timer.samplecount;
 			stats->period_pkt_count = 0;
+			stats->last_rpt_flush_count = rtp_session->stats.inbound.flush_packet_count;
 		}
 
 


### PR DESCRIPTION
## Summary

Adds an opt-in RTP bug flag `RTP_BUG_DONT_REPORT_FLUSHED_AS_LOST` (default **off**) that stops packets FreeSWITCH deliberately flushed from being reported as lost in the outbound RTCP receiver report.

Resolves #3070.

## Problem

On DTMF-heavy systems with no jitter buffer, a sending endpoint (including FreeSWITCH itself) sets the RTP marker bit on the first voice packet after a DTMF event (talkspurt onset). This triggers `do_flush()`, which drains queued RTP from the socket and discards it. Those packets arrived over the network — FreeSWITCH just chose not to play them — but the resulting sequence gap is then reported as **lost** in RTCP. On calls with frequent DTMF the phantom loss accumulates and drags the MOS reported by upstream monitors below 4.0, hiding genuine quality problems behind spurious low-MOS calls.

Existing workarounds are unsatisfying:
- `IGNORE_MARK_BIT` disables *all* marker-driven flushing — too blunt, breaks legitimate marker uses (hold, etc.).
- Running a jitter buffer bypasses the flush, but adds delay on bridged calls for what is really a reporting problem.

## Change

`rtcp_generate_report_block()` subtracts the number of packets flushed during the current RTCP interval from `pkt_lost` when the flag is set. A per-interval baseline (`last_rpt_flush_count`, added to `switch_rtcp_numbers_t`) is captured in `rtcp_stats_init()` and at each report reset. Genuine network loss (packets that never arrived, hence never counted as flushed) is unaffected — only deliberately-flushed, already-received packets are excluded.

Enable per channel: `rtp_manual_rtp_bugs=DONT_REPORT_FLUSHED_AS_LOST`.

## Validation

Reproduced and A/B-tested on FreeSWITCH 1.11.1 behind rtpengine, DTMF-heavy bridged calls, no jitter buffer, matched measurement windows:

| metric | flag OFF | flag ON |
|---|---|---|
| packets flushed by FS | ~500 | ~500 (unchanged) |
| max RTCP loss reported / call | 30 | 1 |
| calls with MOS < 4.0 | 1 (MOS 3.5) | 0 (all MOS 4.3) |

Flushing is identical in both arms; with the flag on the phantom loss disappears and MOS stays clean, while genuine loss would still be reported.

## Notes

- **Default off** — no behavior change for existing deployments.
- 3 files, +31/-4.
