### PR TITLE
set dlg_req_swap_direction based on call direction

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -1713,6 +1713,8 @@ static void our_sofia_event_callback(nua_event_t event,
 
 				if (switch_channel_direction(channel) == SWITCH_CALL_DIRECTION_OUTBOUND) {
 					switch_channel_set_variable(channel, "dlg_req_swap_direction", "true");
+				} else {
+					switch_channel_set_variable(channel, "dlg_req_swap_direction", "false");
 				}
 
 				extract_header_vars(profile, sip, session, nh);
@@ -7229,6 +7231,8 @@ static void sofia_handle_sip_r_invite(switch_core_session_t *session, int status
 
 			if (switch_channel_direction(channel) == SWITCH_CALL_DIRECTION_INBOUND) {
 				 switch_channel_set_variable(channel, "dlg_req_swap_direction", "true");
+			} else {
+				switch_channel_set_variable(channel, "dlg_req_swap_direction", "false");
 			}
 
 			extract_header_vars(profile, sip, session, nh);


### PR DESCRIPTION
## Description

This PR fixes a call recovery issue during FreeSWITCH failover.

### Background

FreeSWITCH uses the channel variable `dlg_req_swap_direction` to determine whether the `From` and `To` headers should be swapped when sending a re-INVITE for call recovery.

The variable is set to `true` when:

- an outbound channel receives a `nua_i_ack` event, or

- an inbound channel receives a `nua_r_invite` event.

### Problem

Once `dlg_req_swap_direction` is set to `true`, there is no clear logic to reset or update it. As a result, subsequent SIP events may leave the variable in an incorrect state, eg: an outbound channel receives a `nua_r_invite` event later, causing invalid `From`/`To` header handling during call recovery after a FreeSWITCH failover.

### Solution

This PR updates the handling of `dlg_req_swap_direction` so that its value correctly reflects the current SIP dialog state during call recovery.
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [x] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
