### PR TITLE
[mod_logfile] Add structured channel log tags

### DIFF
--- a/src/mod/applications/mod_dptools/mod_dptools.c
+++ b/src/mod/applications/mod_dptools/mod_dptools.c
@@ -1845,6 +1845,32 @@ SWITCH_STANDARD_APP(multiunset_function)
 }
 
 
+SWITCH_STANDARD_APP(set_log_tag_function)
+{
+	char *name;
+	char *value = NULL;
+	switch_channel_t *channel = switch_core_session_get_channel(session);
+
+	if (zstr(data)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "No log tag name specified.\n");
+		return;
+	}
+
+	name = switch_core_session_strdup(session, data);
+	if ((value = strchr(name, '='))) {
+		*value++ = '\0';
+	}
+
+	if (zstr(name)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Invalid empty log tag name.\n");
+		return;
+	}
+
+	if (switch_channel_set_log_tag(channel, name, value) != SWITCH_STATUS_SUCCESS) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Failed to update log tag [%s].\n", name);
+	}
+}
+
 SWITCH_STANDARD_APP(log_function)
 {
 	char *level, *log_str;
@@ -6688,6 +6714,10 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_dptools_load)
 	SWITCH_ADD_APP(app_interface, "bridge_export", "Export a channel variable across a bridge", EXPORT_LONG_DESC, bridge_export_function, "<varname>=<value>",
 				   SAF_SUPPORT_NOMEDIA | SAF_ROUTING_EXEC | SAF_ZOMBIE_EXEC);
 	SWITCH_ADD_APP(app_interface, "set", "Set a channel variable", SET_LONG_DESC, set_function, "<varname>=<value>",
+				   SAF_SUPPORT_NOMEDIA | SAF_ROUTING_EXEC | SAF_ZOMBIE_EXEC);
+	SWITCH_ADD_APP(app_interface, "set_log_tag", "Set or remove a channel log tag",
+				   "Set a tag with name=value; remove it with name= or name",
+				   set_log_tag_function, "<tagname>[=<value>]",
 				   SAF_SUPPORT_NOMEDIA | SAF_ROUTING_EXEC | SAF_ZOMBIE_EXEC);
 
 	SWITCH_ADD_APP(app_interface, "multiset", "Set many channel variables", SET_LONG_DESC, multiset_function, "[^^<delim>]<varname>=<value> <var2>=<val2>",

--- a/src/mod/loggers/mod_logfile/Makefile.am
+++ b/src/mod/loggers/mod_logfile/Makefile.am
@@ -2,7 +2,7 @@ include $(top_srcdir)/build/modmake.rulesam
 MODNAME=mod_logfile
 
 mod_LTLIBRARIES = mod_logfile.la
-mod_logfile_la_SOURCES  = mod_logfile.c
+mod_logfile_la_SOURCES  = mod_logfile.c mod_logfile_prefix.c
 mod_logfile_la_CFLAGS   = $(AM_CFLAGS)
 mod_logfile_la_LIBADD   = $(switch_builddir)/libfreeswitch.la
 mod_logfile_la_LDFLAGS  = -avoid-version -module -no-undefined -shared

--- a/src/mod/loggers/mod_logfile/README.md
+++ b/src/mod/loggers/mod_logfile/README.md
@@ -1,0 +1,73 @@
+# mod_logfile
+
+`mod_logfile` writes selected FreeSWITCH log records to a file. The default
+file is `freeswitch.log` in the FreeSWITCH log directory unless `logfile` is
+configured.
+
+## Structured prefixes
+
+`uuid`, `log-tags`, and `channel-vars` are emitted in that order and are
+prepended to every physical line. `log-tags` defaults to false and
+`channel-vars` defaults to empty. `uuid` retains the historical default of
+true; set it to false to omit the UUID.
+
+The UUID is emitted as a bare token. Log tags and channel variables are
+emitted as `name:value` tokens, with a space after each token. Only available
+values produce tokens. For example, an enabled profile can produce:
+
+```text
+550e8400-e29b-41d4-a716-446655440000 tenant:acme callid:abc123 message
+```
+
+Log tags are captured in the `switch_log_node_t` when the log record is
+created, so the captured values travel with a queued log node. The prefix is
+then applied to every physical line in that record. Existing message bytes
+and final-newline behavior are preserved; `mod_logfile` does not truncate the
+message.
+
+## set_log_tag
+
+Use `<action application="set_log_tag" data="tenant=acme"/>` to set or
+replace a tag. Use `tenant=` or `tenant` to remove it. Values may contain
+additional `=` characters: the input is split at the first `=` only.
+
+Tags are opt-in for the file logger with `log-tags="true"`:
+
+```xml
+<param name="log-tags" value="true"/>
+```
+
+## Channel variables
+
+`channel-vars="callid=sip_call_id,tenant"` maps `sip_call_id` to `callid`
+and uses `tenant` as both label and variable name. Values are read live while
+the session exists. Use log tags for stable fields that must survive session
+destruction or avoid per-log session lookup.
+
+## Safety limits
+
+Names are limited to 128 bytes and values to 512 bytes. Unsafe name bytes,
+whitespace/control bytes in values, and brackets are replaced with `_`.
+These limits apply to token names and values, not to the log message:
+messages are not limited to 2048 bytes and are not truncated by this module.
+
+## File rotation
+
+`rollover` sets the file-size threshold in bytes; `0` disables size-based
+rotation. When `maximum-rotate` is omitted, `max_rot` remains `0` and rotated
+files use a timestamp and an index (`logfile.YYYY-MM-DD-HH-MM-SS.N`). A nonzero
+`maximum-rotate` value of `N` keeps numbered files up to the configured count
+(`logfile.1` through `logfile.N`). If `maximum-rotate` is explicitly `0` (or
+parses as zero), it is normalized to `MAX_ROT` (`4096`), so numbered rotation
+is kept up to `4096` files.
+
+`rotate-on-hup` controls SIGHUP handling. When true, SIGHUP rotates each
+profile; when false, it closes and reopens each file. The sample configuration
+enables rotation on HUP and sets a 10 MiB rollover threshold.
+
+## Mappings
+
+Each `<map>` selects log levels for `all`, a source file, a function, or a
+`file:function` pair. Its `value` is a comma-separated list of `debug`,
+`info`, `notice`, `warning`, `err`, `crit`, `alert`, or `all`. The sample maps
+all listed levels for all sources.

--- a/src/mod/loggers/mod_logfile/conf/autoload_configs/logfile.conf.xml
+++ b/src/mod/loggers/mod_logfile/conf/autoload_configs/logfile.conf.xml
@@ -15,6 +15,10 @@
 		<!-- <param name="maximum-rotate" value="32"/> -->
         <!-- Prefix all log lines by the session's uuid  -->
         <param name="uuid" value="true" />
+        <!-- Include channel log tags captured by switch_log_node_t. -->
+        <!-- <param name="log-tags" value="true"/> -->
+        <!-- Add live channel variables as label:value tokens. -->
+        <!-- <param name="channel-vars" value="callid=sip_call_id,tenant"/> -->
       </settings>
       <mappings>
 	<!--

--- a/src/mod/loggers/mod_logfile/mod_logfile.2017.vcxproj
+++ b/src/mod/loggers/mod_logfile/mod_logfile.2017.vcxproj
@@ -126,6 +126,10 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="mod_logfile.c" />
+    <ClCompile Include="mod_logfile_prefix.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="mod_logfile_prefix.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\w32\Library\FreeSwitchCore.2017.vcxproj">

--- a/src/mod/loggers/mod_logfile/mod_logfile.c
+++ b/src/mod/loggers/mod_logfile/mod_logfile.c
@@ -32,6 +32,8 @@
 
 #include <switch.h>
 
+#include "mod_logfile_prefix.h"
+
 SWITCH_MODULE_LOAD_FUNCTION(mod_logfile_load);
 SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_logfile_shutdown);
 SWITCH_MODULE_DEFINITION(mod_logfile, mod_logfile_load, mod_logfile_shutdown, NULL);
@@ -59,7 +61,8 @@ struct logfile_profile {
 	switch_hash_t *log_hash;
 	uint32_t all_level;
 	uint32_t suffix;			/* suffix of the highest logfile name */
-	switch_bool_t log_uuid;
+	switch_bool_t reopening;
+	mod_logfile_prefix_config_t prefix;
 };
 
 typedef struct logfile_profile logfile_profile_t;
@@ -84,8 +87,10 @@ static void add_mapping(logfile_profile_t *profile, char *var, char *val)
 }
 
 static switch_status_t mod_logfile_rotate(logfile_profile_t *profile);
+static switch_status_t mod_logfile_reopen_profile(logfile_profile_t *profile, switch_bool_t check);
+static switch_status_t mod_logfile_reopen(void *context);
 
-static switch_status_t mod_logfile_openlogfile(logfile_profile_t *profile, switch_bool_t check)
+static switch_status_t mod_logfile_openlogfile(logfile_profile_t *profile, switch_bool_t check, switch_bool_t log_error)
 {
 	unsigned int flags = 0;
 	switch_file_t *afd;
@@ -98,7 +103,9 @@ static switch_status_t mod_logfile_openlogfile(logfile_profile_t *profile, switc
 
 	stat = switch_file_open(&afd, profile->logfile, flags, SWITCH_FPROT_OS_DEFAULT, module_pool);
 	if (stat != SWITCH_STATUS_SUCCESS) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "logfile %s open error, status=%d\n", profile->logfile, stat);
+		if (log_error) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "logfile %s open error, status=%d\n", profile->logfile, stat);
+		}
 
 		return SWITCH_STATUS_FALSE;
 	}
@@ -128,6 +135,10 @@ static switch_status_t mod_logfile_rotate(logfile_profile_t *profile)
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 
 	switch_mutex_lock(globals.mutex);
+	if (!profile->log_afd) {
+		status = SWITCH_STATUS_FALSE;
+		goto end;
+	}
 
 	switch_time_exp_lt(&tm, switch_micro_time_now());
 	switch_strftime_nocheck(date, &retsize, sizeof(date), "%Y-%m-%d-%H-%M-%S", &tm);
@@ -181,12 +192,13 @@ static switch_status_t mod_logfile_rotate(logfile_profile_t *profile)
 		}
 
 		switch_file_close(profile->log_afd);
+		profile->log_afd = NULL;
 		if ((status = switch_file_rename(profile->logfile, to_filename, pool)) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Error renaming log from %s to %s [%s]\n", profile->logfile, to_filename, strerror(errno));
 			goto end;
 		}
 
-		if ((status = mod_logfile_openlogfile(profile, SWITCH_FALSE)) != SWITCH_STATUS_SUCCESS) {
+		if ((status = mod_logfile_reopen(profile)) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Error reopening log %s\n", profile->logfile);
 		}
 		if (profile->suffix < profile->max_rot) {
@@ -206,8 +218,9 @@ static switch_status_t mod_logfile_rotate(logfile_profile_t *profile)
 		}
 
 		switch_file_close(profile->log_afd);
+		profile->log_afd = NULL;
 		switch_file_rename(profile->logfile, filename, pool);
-		if ((status = mod_logfile_openlogfile(profile, SWITCH_FALSE)) != SWITCH_STATUS_SUCCESS) {
+		if ((status = mod_logfile_reopen(profile)) != SWITCH_STATUS_SUCCESS) {
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Error Rotating Log!\n");
 			goto end;
 		}
@@ -228,34 +241,59 @@ static switch_status_t mod_logfile_rotate(logfile_profile_t *profile)
 }
 
 /* write to the actual logfile */
+static switch_status_t mod_logfile_file_write(void *context, const char *data, switch_size_t *length)
+{
+	logfile_profile_t *profile = context;
+	switch_size_t requested = *length;
+	switch_status_t status = switch_file_write(profile->log_afd, data, length);
+
+	if (*length > requested) *length = requested;
+	profile->log_size += *length;
+	return status;
+}
+
+static switch_status_t mod_logfile_reopen_profile(logfile_profile_t *profile, switch_bool_t check)
+{
+	switch_status_t status;
+
+	if (profile->reopening) return SWITCH_STATUS_FALSE;
+	profile->reopening = SWITCH_TRUE;
+
+	if (profile->log_afd) {
+		switch_file_close(profile->log_afd);
+		profile->log_afd = NULL;
+	}
+	status = mod_logfile_openlogfile(profile, check, SWITCH_FALSE);
+	profile->reopening = SWITCH_FALSE;
+	return status;
+}
+
+static switch_status_t mod_logfile_reopen(void *context)
+{
+	return mod_logfile_reopen_profile(context, SWITCH_FALSE);
+}
+
 static switch_status_t mod_logfile_raw_write(logfile_profile_t *profile, char *log_data)
 {
 	switch_size_t len;
-	switch_status_t status = SWITCH_STATUS_SUCCESS;
+	switch_size_t committed = 0;
+	switch_status_t status;
 	len = strlen(log_data);
 
-	if (len <= 0 || !profile->log_afd) {
+	if (len <= 0) {
 		return SWITCH_STATUS_FALSE;
 	}
 
 	switch_mutex_lock(globals.mutex);
-
-	if (switch_file_write(profile->log_afd, log_data, &len) != SWITCH_STATUS_SUCCESS) {
-		switch_file_close(profile->log_afd);
-		if ((status = mod_logfile_openlogfile(profile, SWITCH_TRUE)) == SWITCH_STATUS_SUCCESS) {
-			len = strlen(log_data);
-			switch_file_write(profile->log_afd, log_data, &len);
-		}
+	if (!profile->log_afd && (profile->reopening || mod_logfile_reopen(profile) != SWITCH_STATUS_SUCCESS)) {
+		status = SWITCH_STATUS_FALSE;
+	} else {
+		status = mod_logfile_complete_write(profile, log_data, len, mod_logfile_file_write, mod_logfile_reopen, &committed);
 	}
-
 	switch_mutex_unlock(globals.mutex);
 
-	if (status == SWITCH_STATUS_SUCCESS) {
-		profile->log_size += len;
-
-		if (profile->roll_size && profile->log_size >= profile->roll_size) {
-			mod_logfile_rotate(profile);
-		}
+	if (status == SWITCH_STATUS_SUCCESS && profile->roll_size && profile->log_size >= profile->roll_size) {
+		mod_logfile_rotate(profile);
 	}
 
 	return status;
@@ -295,25 +333,17 @@ static switch_status_t process_node(const switch_log_node_t *node, switch_log_le
 		}
 
 		if (ok) {
-			if (profile->log_uuid && !zstr(node->userdata)) {
-				char buf[2048];
-				char *dup = strdup(node->data);
-				char *lines[100];
-				int argc, i;
+			char *prefix = mod_logfile_prefix_build(&profile->prefix, node);
+			char *formatted = prefix ? mod_logfile_prefix_lines(prefix, node->data) : NULL;
+			char *output = formatted ? formatted : node->data;
 
-				argc = switch_split(dup, '\n', lines);
-				for (i = 0; i < argc; i++) {
-					switch_snprintf(buf, sizeof(buf), "%s %s\n", node->userdata, lines[i]);
-					mod_logfile_raw_write(profile, buf);
-				}
-
-				free(dup);
-
-			} else {
-				mod_logfile_raw_write(profile, node->data);
+			if (!zstr(output)) {
+				mod_logfile_raw_write(profile, output);
 			}
-		}
 
+			switch_safe_free(formatted);
+			switch_safe_free(prefix);
+		}
 	}
 
 	return SWITCH_STATUS_SUCCESS;
@@ -329,9 +359,13 @@ static void cleanup_profile(void *ptr)
 	logfile_profile_t *profile = (logfile_profile_t *) ptr;
 
 	switch_core_hash_destroy(&profile->log_hash);
-	switch_file_close(profile->log_afd);
+	if (profile->log_afd) {
+		switch_file_close(profile->log_afd);
+		profile->log_afd = NULL;
+	}
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "Closing %s\n", profile->logfile);
 	switch_safe_free(profile->logfile);
+	mod_logfile_prefix_config_destroy(&profile->prefix);
 
 }
 
@@ -343,11 +377,12 @@ static switch_status_t load_profile(switch_xml_t xml)
 
 	new_profile = switch_core_alloc(module_pool, sizeof(*new_profile));
 	memset(new_profile, 0, sizeof(*new_profile));
+	mod_logfile_prefix_config_init(&new_profile->prefix);
 	switch_core_hash_init(&(new_profile->log_hash));
 	new_profile->name = switch_core_strdup(module_pool, switch_str_nil(name));
 
 	new_profile->suffix = 1;
-	new_profile->log_uuid = SWITCH_TRUE;
+	new_profile->prefix.log_uuid = SWITCH_TRUE;
 
 	if ((settings = switch_xml_child(xml, "settings"))) {
 		for (param = switch_xml_child(settings, "param"); param; param = param->next) {
@@ -363,7 +398,15 @@ static switch_status_t load_profile(switch_xml_t xml)
 					new_profile->max_rot = MAX_ROT;
 				}
 			} else if (!strcmp(var, "uuid")) {
-				new_profile->log_uuid = switch_true(val);
+				new_profile->prefix.log_uuid = switch_true(val);
+			} else if (!strcmp(var, "log-tags")) {
+				new_profile->prefix.log_tags = switch_true(val);
+			} else if (!strcmp(var, "channel-vars")) {
+				if (mod_logfile_prefix_add_channel_vars(&new_profile->prefix, val) != SWITCH_STATUS_SUCCESS) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+								  "Ignoring invalid channel-vars for logfile profile [%s]: [%s]\n",
+								  switch_str_nil(new_profile->name), switch_str_nil(val));
+				}
 			}
 		}
 	}
@@ -383,7 +426,8 @@ static switch_status_t load_profile(switch_xml_t xml)
 		new_profile->logfile = strdup(logfile);
 	}
 
-	if (mod_logfile_openlogfile(new_profile, SWITCH_TRUE) != SWITCH_STATUS_SUCCESS) {
+	if (mod_logfile_openlogfile(new_profile, SWITCH_TRUE, SWITCH_TRUE) != SWITCH_STATUS_SUCCESS) {
+		mod_logfile_prefix_config_destroy(&new_profile->prefix);
 		return SWITCH_STATUS_GENERR;
 	}
 
@@ -412,8 +456,7 @@ static void event_handler(switch_event_t *event)
 			for (hi = switch_core_hash_first(profile_hash); hi; hi = switch_core_hash_next(&hi)) {
 				switch_core_hash_this(hi, &var, NULL, &val);
 				profile = val;
-				switch_file_close(profile->log_afd);
-				if (mod_logfile_openlogfile(profile, SWITCH_TRUE) != SWITCH_STATUS_SUCCESS) {
+				if (mod_logfile_reopen_profile(profile, SWITCH_TRUE) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Error Re-opening Log!\n");
 				}
 			}

--- a/src/mod/loggers/mod_logfile/mod_logfile_prefix.c
+++ b/src/mod/loggers/mod_logfile/mod_logfile_prefix.c
@@ -1,0 +1,377 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * The Initial Developer of the Original Code is
+ * Anthony Minessale II <anthm@freeswitch.org>
+ * Portions created by the Initial Developer are Copyright (C)
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ *
+ * mod_logfile_prefix.c -- Structured logfile prefix formatting
+ *
+ */
+
+#include "mod_logfile_prefix.h"
+
+#define LOGFILE_TOKEN_NAME_MAX 128
+#define LOGFILE_TOKEN_VALUE_MAX 512
+#define LOGFILE_CHANNEL_VAR_MAX 128
+#define LOGFILE_BUFFER_INITIAL_SIZE 64
+
+typedef struct {
+	char *data;
+	switch_size_t length;
+	switch_size_t capacity;
+} logfile_buffer_t;
+
+#ifdef MOD_LOGFILE_PREFIX_TEST
+static int test_allocation_fail_after = -1;
+static int test_allocation_count = 0;
+
+void mod_logfile_prefix_test_fail_allocation_after(int successful_allocations)
+{
+	test_allocation_fail_after = successful_allocations;
+	test_allocation_count = 0;
+}
+
+void mod_logfile_prefix_test_reset_failures(void)
+{
+	test_allocation_fail_after = -1;
+	test_allocation_count = 0;
+}
+#endif
+
+static void *logfile_buffer_realloc(void *data, switch_size_t size)
+{
+#ifdef MOD_LOGFILE_PREFIX_TEST
+	if (test_allocation_fail_after >= 0 && test_allocation_count >= test_allocation_fail_after) {
+		return NULL;
+	}
+	test_allocation_count++;
+#endif
+	return realloc(data, size);
+}
+
+static switch_status_t logfile_buffer_reserve(logfile_buffer_t *buffer, switch_size_t additional)
+{
+	char *data;
+	switch_size_t capacity;
+	switch_size_t required;
+
+	if (!buffer || additional > (switch_size_t) -1 - buffer->length - 1) return SWITCH_STATUS_MEMERR;
+	required = buffer->length + additional + 1;
+	if (required <= buffer->capacity) return SWITCH_STATUS_SUCCESS;
+
+	capacity = buffer->capacity ? buffer->capacity : LOGFILE_BUFFER_INITIAL_SIZE;
+	while (capacity < required) {
+		if (capacity > (switch_size_t) -1 / 2) {
+			capacity = required;
+			break;
+		}
+		capacity *= 2;
+	}
+
+	data = logfile_buffer_realloc(buffer->data, capacity);
+	if (!data) return SWITCH_STATUS_MEMERR;
+	buffer->data = data;
+	buffer->capacity = capacity;
+	return SWITCH_STATUS_SUCCESS;
+}
+
+static switch_status_t logfile_buffer_append(logfile_buffer_t *buffer, const char *data, switch_size_t length)
+{
+	if (!length) return SWITCH_STATUS_SUCCESS;
+	if (!buffer || !data || logfile_buffer_reserve(buffer, length) != SWITCH_STATUS_SUCCESS) return SWITCH_STATUS_MEMERR;
+	memcpy(buffer->data + buffer->length, data, length);
+	buffer->length += length;
+	buffer->data[buffer->length] = '\0';
+	return SWITCH_STATUS_SUCCESS;
+}
+
+static switch_status_t logfile_buffer_append_string(logfile_buffer_t *buffer, const char *data)
+{
+	return logfile_buffer_append(buffer, data, data ? strlen(data) : 0);
+}
+
+static void logfile_buffer_destroy(logfile_buffer_t *buffer)
+{
+	if (!buffer) return;
+	switch_safe_free(buffer->data);
+	buffer->length = 0;
+	buffer->capacity = 0;
+}
+
+static void sanitize_name(char *dst, switch_size_t size, const char *src)
+{
+	switch_size_t i = 0;
+
+	if (!dst || !size) return;
+	for (; src && *src && i + 1 < size; src++) {
+		unsigned char c = (unsigned char) *src;
+		switch_bool_t safe = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '_' || c == '.' || c == '-';
+		dst[i++] = (char) (safe ? c : '_');
+	}
+	dst[i] = '\0';
+}
+
+static switch_size_t utf8_sequence_length(const unsigned char *src)
+{
+	unsigned char first;
+
+	if (!src) return 0;
+	first = src[0];
+	if (first >= 0xc2 && first <= 0xdf) {
+		return src[1] && src[1] >= 0x80 && src[1] <= 0xbf ? 2 : 0;
+	}
+	if (first == 0xe0) {
+		return src[1] >= 0xa0 && src[1] <= 0xbf && src[2] &&
+			src[2] >= 0x80 && src[2] <= 0xbf ? 3 : 0;
+	}
+	if ((first >= 0xe1 && first <= 0xec) || (first >= 0xee && first <= 0xef)) {
+		return src[1] >= 0x80 && src[1] <= 0xbf && src[2] &&
+			src[2] >= 0x80 && src[2] <= 0xbf ? 3 : 0;
+	}
+	if (first == 0xed) {
+		return src[1] >= 0x80 && src[1] <= 0x9f && src[2] &&
+			src[2] >= 0x80 && src[2] <= 0xbf ? 3 : 0;
+	}
+	if (first == 0xf0) {
+		return src[1] >= 0x90 && src[1] <= 0xbf && src[2] && src[3] &&
+			src[2] >= 0x80 && src[2] <= 0xbf && src[3] >= 0x80 && src[3] <= 0xbf ? 4 : 0;
+	}
+	if (first >= 0xf1 && first <= 0xf3) {
+		return src[1] >= 0x80 && src[1] <= 0xbf && src[2] && src[3] &&
+			src[2] >= 0x80 && src[2] <= 0xbf && src[3] >= 0x80 && src[3] <= 0xbf ? 4 : 0;
+	}
+	if (first == 0xf4) {
+		return src[1] >= 0x80 && src[1] <= 0x8f && src[2] && src[3] &&
+			src[2] >= 0x80 && src[2] <= 0xbf && src[3] >= 0x80 && src[3] <= 0xbf ? 4 : 0;
+	}
+
+	return 0;
+}
+
+static void sanitize_value(char *dst, switch_size_t size, const char *src)
+{
+	switch_size_t i = 0;
+	const unsigned char *cursor = (const unsigned char *) src;
+
+	if (!dst || !size) return;
+	while (cursor && *cursor && i + 1 < size) {
+		unsigned char c = *cursor;
+		switch_size_t length = utf8_sequence_length(cursor);
+
+		if (length) {
+			if (length == 2 && cursor[0] == 0xc2 && cursor[1] >= 0x80 && cursor[1] <= 0x9f) {
+				dst[i++] = '_';
+			} else if (i + length < size) {
+				memcpy(dst + i, cursor, length);
+				i += length;
+			} else {
+				break;
+			}
+			cursor += length;
+		} else {
+			dst[i++] = (char) (c <= 32 || c == 127 || c == '[' || c == ']' || switch_iscntrl(c) ? '_' : c);
+			cursor++;
+		}
+	}
+	dst[i] = '\0';
+}
+
+static switch_status_t append_pair(logfile_buffer_t *buffer, const char *name, const char *value)
+{
+	char safe_name[LOGFILE_TOKEN_NAME_MAX + 1] = "";
+	char safe_value[LOGFILE_TOKEN_VALUE_MAX + 1] = "";
+
+	if (!buffer) return SWITCH_STATUS_FALSE;
+	sanitize_name(safe_name, sizeof(safe_name), name);
+	sanitize_value(safe_value, sizeof(safe_value), value);
+	if (!zstr(safe_name) && !zstr(safe_value)) {
+		if (logfile_buffer_append_string(buffer, safe_name) != SWITCH_STATUS_SUCCESS ||
+			logfile_buffer_append(buffer, ":", 1) != SWITCH_STATUS_SUCCESS ||
+			logfile_buffer_append_string(buffer, safe_value) != SWITCH_STATUS_SUCCESS ||
+			logfile_buffer_append(buffer, " ", 1) != SWITCH_STATUS_SUCCESS) {
+			return SWITCH_STATUS_MEMERR;
+		}
+	}
+	return SWITCH_STATUS_SUCCESS;
+}
+
+void mod_logfile_prefix_config_init(mod_logfile_prefix_config_t *config)
+{
+	if (!config) return;
+	memset(config, 0, sizeof(*config));
+}
+
+void mod_logfile_prefix_config_destroy(mod_logfile_prefix_config_t *config)
+{
+	if (config && config->channel_vars) {
+		switch_event_destroy(&config->channel_vars);
+	}
+}
+
+switch_status_t mod_logfile_prefix_add_channel_vars(mod_logfile_prefix_config_t *config, const char *data)
+{
+	char *argv[LOGFILE_CHANNEL_VAR_MAX] = { 0 };
+	char *dup;
+	int argc;
+	int i;
+	int added = 0;
+
+	if (!config || zstr(data)) return SWITCH_STATUS_FALSE;
+	dup = strdup(data);
+	if (!dup) return SWITCH_STATUS_MEMERR;
+	argc = switch_separate_string(dup, ',', argv, LOGFILE_CHANNEL_VAR_MAX);
+
+	if (!config->channel_vars &&
+		switch_event_create_plain(&config->channel_vars, SWITCH_EVENT_CHANNEL_DATA) != SWITCH_STATUS_SUCCESS) {
+		free(dup);
+		return SWITCH_STATUS_MEMERR;
+	}
+
+	for (i = 0; i < argc; i++) {
+		char *item = switch_strip_spaces(argv[i], SWITCH_FALSE);
+		char *name = item;
+		char *variable = strchr(item, '=');
+
+		if (variable) {
+			*variable++ = '\0';
+			name = switch_strip_spaces(name, SWITCH_FALSE);
+			variable = switch_strip_spaces(variable, SWITCH_FALSE);
+		} else {
+			variable = name;
+		}
+
+		if (!zstr(name) && !zstr(variable)) {
+			switch_event_del_header(config->channel_vars, name);
+			switch_event_add_header_string(config->channel_vars, SWITCH_STACK_BOTTOM, name, variable);
+			added++;
+		}
+	}
+
+	free(dup);
+	return added ? SWITCH_STATUS_SUCCESS : SWITCH_STATUS_FALSE;
+}
+
+char *mod_logfile_prefix_build(const mod_logfile_prefix_config_t *config, const switch_log_node_t *node)
+{
+	logfile_buffer_t buffer = { 0 };
+	switch_event_header_t *header;
+	switch_core_session_t *session = NULL;
+
+	if (!config || !node) return NULL;
+
+	if (config->log_uuid && !zstr(node->userdata)) {
+		char uuid[LOGFILE_TOKEN_VALUE_MAX + 1] = "";
+		sanitize_value(uuid, sizeof(uuid), node->userdata);
+		if (!zstr(uuid) && (logfile_buffer_append_string(&buffer, uuid) != SWITCH_STATUS_SUCCESS ||
+			logfile_buffer_append(&buffer, " ", 1) != SWITCH_STATUS_SUCCESS)) {
+			goto fail;
+		}
+	}
+
+	if (config->log_tags && node->tags) {
+		for (header = node->tags->headers; header; header = header->next) {
+			if (append_pair(&buffer, header->name, header->value) != SWITCH_STATUS_SUCCESS) goto fail;
+		}
+	}
+
+	if (!zstr(node->userdata) && config->channel_vars && config->channel_vars->headers &&
+		(session = switch_core_session_locate(node->userdata))) {
+		switch_channel_t *channel = switch_core_session_get_channel(session);
+		for (header = config->channel_vars->headers; header; header = header->next) {
+			const char *value = switch_channel_get_variable(channel, header->value);
+			if (append_pair(&buffer, header->name, value) != SWITCH_STATUS_SUCCESS) {
+				switch_core_session_rwunlock(session);
+				session = NULL;
+				goto fail;
+			}
+		}
+		switch_core_session_rwunlock(session);
+		session = NULL;
+	}
+
+	if (!buffer.length) logfile_buffer_destroy(&buffer);
+	return buffer.data;
+
+  fail:
+	if (session) switch_core_session_rwunlock(session);
+	logfile_buffer_destroy(&buffer);
+	return NULL;
+}
+
+char *mod_logfile_prefix_lines(const char *prefix, const char *data)
+{
+	logfile_buffer_t buffer = { 0 };
+	const char *cursor;
+	switch_size_t prefix_length;
+
+	if (zstr(data)) return NULL;
+	if (zstr(prefix)) return strdup(data);
+
+	prefix_length = strlen(prefix);
+	cursor = data;
+	while (*cursor) {
+		const char *newline = strchr(cursor, '\n');
+		switch_size_t length = newline ? (switch_size_t) (newline - cursor) : strlen(cursor);
+
+		if (logfile_buffer_append(&buffer, prefix, prefix_length) != SWITCH_STATUS_SUCCESS ||
+			(length && logfile_buffer_append(&buffer, cursor, length) != SWITCH_STATUS_SUCCESS)) goto fail;
+		if (!newline) break;
+		if (logfile_buffer_append(&buffer, "\n", 1) != SWITCH_STATUS_SUCCESS) goto fail;
+		cursor = newline + 1;
+	}
+
+	return buffer.data;
+
+  fail:
+	logfile_buffer_destroy(&buffer);
+	return NULL;
+}
+
+switch_status_t mod_logfile_complete_write(void *context, const char *data, switch_size_t length,
+	mod_logfile_write_callback_t write_callback, mod_logfile_reopen_callback_t reopen_callback,
+	switch_size_t *committed)
+{
+	switch_size_t offset = 0;
+	switch_bool_t recovered = SWITCH_FALSE;
+
+	if (committed) *committed = 0;
+	if (!data || !length || !write_callback) return SWITCH_STATUS_FALSE;
+
+	while (offset < length) {
+		switch_size_t written = length - offset;
+		switch_status_t status = write_callback(context, data + offset, &written);
+
+		if (written > length - offset) written = length - offset;
+		offset += written;
+		if (committed) *committed = offset;
+		if (offset == length) return SWITCH_STATUS_SUCCESS;
+		if (status == SWITCH_STATUS_SUCCESS && written) continue;
+
+		if (recovered || !reopen_callback || reopen_callback(context) != SWITCH_STATUS_SUCCESS) {
+			return SWITCH_STATUS_FALSE;
+		}
+		recovered = SWITCH_TRUE;
+	}
+
+	return SWITCH_STATUS_SUCCESS;
+}

--- a/src/mod/loggers/mod_logfile/mod_logfile_prefix.h
+++ b/src/mod/loggers/mod_logfile/mod_logfile_prefix.h
@@ -1,0 +1,58 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * The Initial Developer of the Original Code is
+ * Anthony Minessale II <anthm@freeswitch.org>
+ * Portions created by the Initial Developer are Copyright (C)
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ *
+ * mod_logfile_prefix.h -- Structured logfile prefix formatting
+ *
+ */
+
+#ifndef MOD_LOGFILE_PREFIX_H
+#define MOD_LOGFILE_PREFIX_H
+
+#include <switch.h>
+
+typedef struct mod_logfile_prefix_config_s {
+	switch_bool_t log_uuid;
+	switch_bool_t log_tags;
+	switch_event_t *channel_vars;
+} mod_logfile_prefix_config_t;
+
+typedef switch_status_t (*mod_logfile_write_callback_t)(void *context, const char *data, switch_size_t *length);
+typedef switch_status_t (*mod_logfile_reopen_callback_t)(void *context);
+
+void mod_logfile_prefix_config_init(mod_logfile_prefix_config_t *config);
+void mod_logfile_prefix_config_destroy(mod_logfile_prefix_config_t *config);
+switch_status_t mod_logfile_prefix_add_channel_vars(mod_logfile_prefix_config_t *config, const char *data);
+char *mod_logfile_prefix_build(const mod_logfile_prefix_config_t *config, const switch_log_node_t *node);
+char *mod_logfile_prefix_lines(const char *prefix, const char *data);
+switch_status_t mod_logfile_complete_write(void *context, const char *data, switch_size_t length,
+	mod_logfile_write_callback_t write_callback, mod_logfile_reopen_callback_t reopen_callback,
+	switch_size_t *committed);
+
+#ifdef MOD_LOGFILE_PREFIX_TEST
+void mod_logfile_prefix_test_fail_allocation_after(int successful_allocations);
+void mod_logfile_prefix_test_reset_failures(void);
+#endif
+
+#endif

--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -1454,20 +1454,29 @@ SWITCH_DECLARE(void) switch_channel_set_presence_data_vals(switch_channel_t *cha
 SWITCH_DECLARE(switch_status_t) switch_channel_set_log_tag(switch_channel_t *channel, const char *tagname, const char *tagvalue)
 {
 	switch_status_t status = SWITCH_STATUS_FALSE;
+
 	switch_assert(channel != NULL);
+
+	if (zstr(tagname)) {
+		return status;
+	}
+
 	switch_mutex_lock(channel->profile_mutex);
-	if (!zstr(tagname)) {
-		if (!channel->log_tags) {
-			switch_event_create_plain(&channel->log_tags, SWITCH_EVENT_CHANNEL_DATA);
-		}
-		if (zstr(tagvalue)) {
-			switch_event_del_header(channel->log_tags, tagname);
-		} else {
+
+	if (!channel->log_tags && !zstr(tagvalue)) {
+		switch_event_create_plain(&channel->log_tags, SWITCH_EVENT_CHANNEL_DATA);
+	}
+
+	if (channel->log_tags) {
+		switch_event_del_header(channel->log_tags, tagname);
+		if (!zstr(tagvalue)) {
 			switch_event_add_header_string(channel->log_tags, SWITCH_STACK_BOTTOM, tagname, tagvalue);
 		}
-		status = SWITCH_STATUS_SUCCESS;
 	}
+
+	status = SWITCH_STATUS_SUCCESS;
 	switch_mutex_unlock(channel->profile_mutex);
+
 	return status;
 }
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -5,8 +5,33 @@ noinst_PROGRAMS = switch_event switch_hash switch_ivr_originate switch_utils swi
 noinst_PROGRAMS += switch_core_video switch_core_db switch_vad switch_packetizer switch_core_session test_sofia switch_ivr_async switch_core_asr switch_log
 noinst_PROGRAMS += switch_stun
 noinst_PROGRAMS += test_tts_format
+noinst_PROGRAMS += test_mod_logfile_prefix
+noinst_PROGRAMS += test_mod_logfile
 noinst_PROGRAMS+= switch_hold switch_sip
 noinst_PROGRAMS += test_mod_verto
+
+test_mod_logfile_prefix_SOURCES = test_mod_logfile_prefix.c
+test_mod_logfile_prefix_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/mod/loggers/mod_logfile -DMOD_LOGFILE_PREFIX_TEST
+nodist_test_mod_logfile_prefix_SOURCES = mod_logfile_prefix_test.c
+BUILT_SOURCES = mod_logfile_prefix_test.c
+CLEANFILES = mod_logfile_prefix_test.c
+
+test_mod_logfile_SOURCES = test_mod_logfile.c
+test_mod_logfile_DEPENDENCIES = \
+	$(top_builddir)/src/mod/applications/mod_dptools/mod_dptools.la \
+	$(top_builddir)/src/mod/loggers/mod_logfile/mod_logfile.la
+
+.PHONY: mod_logfile_test_force
+mod_logfile_test_force:
+
+$(top_builddir)/src/mod/applications/mod_dptools/mod_dptools.la: mod_logfile_test_force
+	$(MAKE) $(AM_MAKEFLAGS) -C $(top_builddir)/src/mod/applications/mod_dptools mod_dptools.la
+
+$(top_builddir)/src/mod/loggers/mod_logfile/mod_logfile.la: mod_logfile_test_force
+	$(MAKE) $(AM_MAKEFLAGS) -C $(top_builddir)/src/mod/loggers/mod_logfile mod_logfile.la
+
+mod_logfile_prefix_test.c: $(top_srcdir)/src/mod/loggers/mod_logfile/mod_logfile_prefix.c
+	$(AM_V_GEN)cp $< $@
 
 if HAVE_PCAP
 noinst_PROGRAMS += switch_rtp_pcap

--- a/tests/unit/conf_logfile/freeswitch.xml
+++ b/tests/unit/conf_logfile/freeswitch.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<document type="freeswitch/xml">
+  <section name="configuration">
+    <configuration name="modules.conf" description="Modules">
+      <modules>
+        <load module="mod_console"/>
+        <load module="mod_loopback"/>
+        <load module="mod_sndfile"/>
+        <load module="mod_dptools" path="../../src/mod/applications/mod_dptools/.libs"/>
+        <load module="mod_logfile" path="../../src/mod/loggers/mod_logfile/.libs"/>
+      </modules>
+    </configuration>
+    <configuration name="switch.conf" description="Core">
+      <settings>
+        <param name="colorize-console" value="false"/>
+        <param name="loglevel" value="debug"/>
+      </settings>
+    </configuration>
+    <configuration name="console.conf" description="Console Logger">
+      <mappings>
+        <map name="all" value="debug,info,notice,warning,err,crit,alert"/>
+      </mappings>
+    </configuration>
+    <configuration name="logfile.conf" description="File Logger">
+      <settings>
+        <param name="rotate-on-hup" value="false"/>
+      </settings>
+      <profiles>
+        <profile name="default">
+          <settings>
+            <param name="rollover" value="0"/>
+            <param name="uuid" value="true"/>
+            <param name="log-tags" value="true"/>
+            <param name="channel-vars" value="callid=sip_call_id"/>
+          </settings>
+          <mappings>
+            <map name="all" value="debug,info,notice,warning,err,crit,alert"/>
+          </mappings>
+        </profile>
+      </profiles>
+    </configuration>
+  </section>
+  <section name="dialplan">
+    <context name="default"/>
+  </section>
+</document>

--- a/tests/unit/switch_log.c
+++ b/tests/unit/switch_log.c
@@ -107,6 +107,120 @@ FST_CORE_BEGIN("./conf")
 		}
 		FST_TEARDOWN_END()
 
+		FST_SESSION_BEGIN(switch_channel_log_tag_remove_without_allocation)
+		{
+			switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+			switch_event_t *tags = NULL;
+
+			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", NULL), SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_FALSE);
+			fst_check(tags == NULL);
+			if (tags) {
+				switch_event_destroy(&tags);
+			}
+
+			tags = NULL;
+			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", ""), SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_FALSE);
+			fst_check(tags == NULL);
+			if (tags) {
+				switch_event_destroy(&tags);
+			}
+		}
+		FST_SESSION_END()
+
+		FST_SESSION_BEGIN(switch_channel_log_tag_replace)
+		{
+			switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+			switch_event_t *tags = NULL;
+
+			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", "acme"), SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", "acme-west"), SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(tags != NULL);
+			if (tags) {
+				fst_check_string_equals(switch_event_get_header(tags, "tenant"), "acme-west");
+				fst_check(tags->headers != NULL && tags->headers->next == NULL);
+				switch_event_destroy(&tags);
+			}
+
+			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", NULL), SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(tags != NULL);
+			if (tags) {
+				fst_check(switch_event_get_header(tags, "tenant") == NULL);
+				switch_event_destroy(&tags);
+			}
+
+			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", "acme"), SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", ""), SWITCH_STATUS_SUCCESS);
+			tags = NULL;
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(tags != NULL);
+			if (tags) {
+				fst_check(switch_event_get_header(tags, "tenant") == NULL);
+				switch_event_destroy(&tags);
+			}
+		}
+		FST_SESSION_END()
+
+		FST_SESSION_BEGIN(set_log_tag_application)
+		{
+			switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+			switch_event_t *tags = NULL;
+
+			fst_requires_module("mod_dptools");
+
+			switch_core_session_execute_application(fst_session, "set_log_tag", "tenant=acme=west");
+			tags = NULL;
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(tags != NULL);
+			if (tags) {
+				fst_check_string_equals(switch_event_get_header(tags, "tenant"), "acme=west");
+				switch_event_destroy(&tags);
+			}
+
+			switch_core_session_execute_application(fst_session, "set_log_tag", "tenant=acme-east");
+			tags = NULL;
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(tags != NULL);
+			if (tags) {
+				fst_check_string_equals(switch_event_get_header(tags, "tenant"), "acme-east");
+				switch_event_destroy(&tags);
+			}
+
+			switch_core_session_execute_application(fst_session, "set_log_tag", "tenant=");
+			tags = NULL;
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(tags != NULL);
+			if (tags) {
+				fst_check(switch_event_get_header(tags, "tenant") == NULL);
+				switch_event_destroy(&tags);
+			}
+
+			switch_core_session_execute_application(fst_session, "set_log_tag", "region=us-west");
+			switch_core_session_execute_application(fst_session, "set_log_tag", "region");
+			tags = NULL;
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(tags != NULL);
+			if (tags) {
+				fst_check(switch_event_get_header(tags, "region") == NULL);
+				switch_event_destroy(&tags);
+			}
+
+			switch_core_session_execute_application(fst_session, "set_log_tag", "stable=keep");
+			switch_core_session_execute_application(fst_session, "set_log_tag", "=invalid");
+			tags = NULL;
+			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(tags != NULL);
+			if (tags) {
+				fst_check_string_equals(switch_event_get_header(tags, "stable"), "keep");
+				fst_check(switch_event_get_header(tags, "") == NULL);
+				switch_event_destroy(&tags);
+			}
+		}
+		FST_SESSION_END()
+
 		FST_SESSION_BEGIN(switch_log_meta_printf)
 		{
 			cJSON *item = NULL;

--- a/tests/unit/switch_log.c
+++ b/tests/unit/switch_log.c
@@ -112,16 +112,16 @@ FST_CORE_BEGIN("./conf")
 			switch_channel_t *channel = switch_core_session_get_channel(fst_session);
 			switch_event_t *tags = NULL;
 
-			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", NULL), SWITCH_STATUS_SUCCESS);
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_FALSE);
+			fst_check(switch_channel_set_log_tag(channel, "tenant", NULL) == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_FALSE);
 			fst_check(tags == NULL);
 			if (tags) {
 				switch_event_destroy(&tags);
 			}
 
 			tags = NULL;
-			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", ""), SWITCH_STATUS_SUCCESS);
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_FALSE);
+			fst_check(switch_channel_set_log_tag(channel, "tenant", "") == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_FALSE);
 			fst_check(tags == NULL);
 			if (tags) {
 				switch_event_destroy(&tags);
@@ -134,9 +134,9 @@ FST_CORE_BEGIN("./conf")
 			switch_channel_t *channel = switch_core_session_get_channel(fst_session);
 			switch_event_t *tags = NULL;
 
-			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", "acme"), SWITCH_STATUS_SUCCESS);
-			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", "acme-west"), SWITCH_STATUS_SUCCESS);
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_set_log_tag(channel, "tenant", "acme") == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_set_log_tag(channel, "tenant", "acme-west") == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_SUCCESS);
 			fst_check(tags != NULL);
 			if (tags) {
 				fst_check_string_equals(switch_event_get_header(tags, "tenant"), "acme-west");
@@ -144,18 +144,18 @@ FST_CORE_BEGIN("./conf")
 				switch_event_destroy(&tags);
 			}
 
-			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", NULL), SWITCH_STATUS_SUCCESS);
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_set_log_tag(channel, "tenant", NULL) == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_SUCCESS);
 			fst_check(tags != NULL);
 			if (tags) {
 				fst_check(switch_event_get_header(tags, "tenant") == NULL);
 				switch_event_destroy(&tags);
 			}
 
-			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", "acme"), SWITCH_STATUS_SUCCESS);
-			fst_check_int_equals(switch_channel_set_log_tag(channel, "tenant", ""), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_set_log_tag(channel, "tenant", "acme") == SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_set_log_tag(channel, "tenant", "") == SWITCH_STATUS_SUCCESS);
 			tags = NULL;
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_SUCCESS);
 			fst_check(tags != NULL);
 			if (tags) {
 				fst_check(switch_event_get_header(tags, "tenant") == NULL);
@@ -173,7 +173,7 @@ FST_CORE_BEGIN("./conf")
 
 			switch_core_session_execute_application(fst_session, "set_log_tag", "tenant=acme=west");
 			tags = NULL;
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_SUCCESS);
 			fst_check(tags != NULL);
 			if (tags) {
 				fst_check_string_equals(switch_event_get_header(tags, "tenant"), "acme=west");
@@ -182,7 +182,7 @@ FST_CORE_BEGIN("./conf")
 
 			switch_core_session_execute_application(fst_session, "set_log_tag", "tenant=acme-east");
 			tags = NULL;
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_SUCCESS);
 			fst_check(tags != NULL);
 			if (tags) {
 				fst_check_string_equals(switch_event_get_header(tags, "tenant"), "acme-east");
@@ -191,7 +191,7 @@ FST_CORE_BEGIN("./conf")
 
 			switch_core_session_execute_application(fst_session, "set_log_tag", "tenant=");
 			tags = NULL;
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_SUCCESS);
 			fst_check(tags != NULL);
 			if (tags) {
 				fst_check(switch_event_get_header(tags, "tenant") == NULL);
@@ -201,7 +201,7 @@ FST_CORE_BEGIN("./conf")
 			switch_core_session_execute_application(fst_session, "set_log_tag", "region=us-west");
 			switch_core_session_execute_application(fst_session, "set_log_tag", "region");
 			tags = NULL;
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_SUCCESS);
 			fst_check(tags != NULL);
 			if (tags) {
 				fst_check(switch_event_get_header(tags, "region") == NULL);
@@ -211,7 +211,7 @@ FST_CORE_BEGIN("./conf")
 			switch_core_session_execute_application(fst_session, "set_log_tag", "stable=keep");
 			switch_core_session_execute_application(fst_session, "set_log_tag", "=invalid");
 			tags = NULL;
-			fst_check_int_equals(switch_channel_get_log_tags(channel, &tags), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_channel_get_log_tags(channel, &tags) == SWITCH_STATUS_SUCCESS);
 			fst_check(tags != NULL);
 			if (tags) {
 				fst_check_string_equals(switch_event_get_header(tags, "stable"), "keep");

--- a/tests/unit/test_mod_logfile.c
+++ b/tests/unit/test_mod_logfile.c
@@ -1,0 +1,231 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * The Initial Developer of the Original Code is
+ * Anthony Minessale II <anthm@freeswitch.org>
+ * Portions created by the Initial Developer are Copyright (C)
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ *
+ * test_mod_logfile.c -- End-to-end tests for structured logfile prefixes
+ *
+ */
+
+#include <switch.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <test/switch_test.h>
+
+static char *read_test_log(void)
+{
+	char *path;
+	FILE *file;
+	char *data = NULL;
+	long length;
+
+	path = switch_mprintf("%s%sfreeswitch.log", SWITCH_GLOBAL_dirs.log_dir, SWITCH_PATH_SEPARATOR);
+	if (!path) return NULL;
+	file = fopen(path, "rb");
+	free(path);
+	if (!file) return NULL;
+	if (fseek(file, 0, SEEK_END) != 0 || (length = ftell(file)) < 0 || fseek(file, 0, SEEK_SET) != 0) {
+		fclose(file);
+		return NULL;
+	}
+
+	data = malloc((size_t) length + 1);
+	if (!data) {
+		fclose(file);
+		return NULL;
+	}
+	if (length && fread(data, 1, (size_t) length, file) != (size_t) length) {
+		free(data);
+		fclose(file);
+		return NULL;
+	}
+	data[length] = '\0';
+	fclose(file);
+	return data;
+}
+
+static char *wait_for_test_log(const char *marker)
+{
+	int attempt;
+
+	for (attempt = 0; attempt < 100; attempt++) {
+		char *data = read_test_log();
+		if (data && strstr(data, marker)) return data;
+		switch_safe_free(data);
+		switch_yield(10000);
+	}
+	return NULL;
+}
+
+FST_CORE_BEGIN("./conf_logfile")
+{
+	FST_SUITE_BEGIN(mod_logfile)
+	{
+		FST_SETUP_BEGIN()
+		{
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+		}
+		FST_TEARDOWN_END()
+
+		FST_SESSION_BEGIN(writes_structured_prefixes)
+		{
+			const char *uuid = switch_core_session_get_uuid(fst_session);
+			char *expected = NULL;
+			char *marker = NULL;
+			char *long_payload = NULL;
+			char *contents = NULL;
+			char *marker_position = NULL;
+			char *first_line = NULL;
+			char *second_line = NULL;
+			switch_size_t marker_length = 0;
+			switch_size_t expected_length = 0;
+
+			fst_check(uuid != NULL);
+			if (uuid) {
+				expected = switch_mprintf("%s tenant:acme callid:call-42 ", uuid);
+				marker = switch_mprintf("mod_logfile integration marker %s", uuid);
+				if (expected && marker) {
+					marker_length = strlen(marker);
+					expected_length = strlen(expected);
+					long_payload = malloc(6001);
+					if (long_payload && marker_length <= 6000) {
+						memcpy(long_payload, marker, marker_length);
+						memset(long_payload + marker_length, 'x', 6000 - marker_length);
+						long_payload[6000] = '\0';
+					}
+				}
+			}
+			fst_check(expected != NULL);
+			fst_check(marker != NULL);
+			fst_check(long_payload != NULL);
+			if (expected && marker && long_payload) {
+				fst_requires_module("mod_dptools");
+				fst_requires_module("mod_logfile");
+				switch_core_session_execute_application(fst_session, "set_log_tag", "tenant=acme");
+				switch_channel_set_variable(fst_channel, "sip_call_id", "call-42");
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(fst_session), SWITCH_LOG_INFO,
+							  "%s\nsecond physical line\n", long_payload);
+
+				contents = wait_for_test_log(marker);
+				fst_check(contents != NULL);
+				if (contents) {
+					switch_size_t available;
+					switch_size_t required;
+
+					marker_position = strstr(contents, marker);
+					fst_check(marker_position != NULL);
+					if (marker_position) {
+						first_line = marker_position;
+						while (first_line > contents && first_line[-1] != '\n') first_line--;
+						available = strlen(marker_position);
+						required = 6001 + expected_length + 21;
+						fst_check(strlen(first_line) >= expected_length);
+						fst_check(available >= required);
+						if (strlen(first_line) >= expected_length && available >= required) {
+							fst_check(!strncmp(first_line, expected, expected_length));
+							fst_check(!strncmp(marker_position, long_payload, 6000));
+							fst_check(marker_position[6000] == '\n');
+							second_line = marker_position + 6001;
+							fst_check(!strncmp(second_line, expected, expected_length));
+							fst_check(!strncmp(second_line + expected_length, "second physical line\n", 21));
+						}
+					}
+				}
+			}
+
+			switch_safe_free(contents);
+			free(long_payload);
+			free(marker);
+			free(expected);
+		}
+		FST_SESSION_END()
+
+		FST_SESSION_BEGIN(recovers_after_transient_reopen_failure)
+		{
+			switch_memory_pool_t *pool = switch_core_session_get_pool(fst_session);
+			const char *uuid = switch_core_session_get_uuid(fst_session);
+			switch_event_t *event = NULL;
+			char *log_path = switch_mprintf("%s%sfreeswitch.log", SWITCH_GLOBAL_dirs.log_dir, SWITCH_PATH_SEPARATOR);
+			char *backup_path = switch_mprintf("%s.reopen-test", switch_str_nil(log_path));
+			char *marker = switch_mprintf("mod_logfile reopen recovery marker %s", switch_str_nil(uuid));
+			char *contents = NULL;
+			switch_bool_t renamed = SWITCH_FALSE;
+			switch_bool_t directory_created = SWITCH_FALSE;
+
+			fst_check(pool != NULL);
+			fst_check(uuid != NULL);
+			fst_check(log_path != NULL);
+			fst_check(backup_path != NULL);
+			fst_check(marker != NULL);
+			if (pool && uuid && log_path && backup_path && marker) {
+				fst_check(switch_file_rename(log_path, backup_path, pool) == SWITCH_STATUS_SUCCESS);
+				renamed = switch_file_exists(backup_path, pool) == SWITCH_STATUS_SUCCESS;
+				if (renamed) {
+					fst_check(switch_dir_make(log_path, SWITCH_FPROT_OS_DEFAULT, pool) == SWITCH_STATUS_SUCCESS);
+					directory_created = switch_file_exists(log_path, pool) == SWITCH_STATUS_SUCCESS;
+				}
+
+				if (directory_created) {
+					fst_check(switch_event_create(&event, SWITCH_EVENT_TRAP) == SWITCH_STATUS_SUCCESS);
+					if (event) {
+						switch_event_add_header_string(event, SWITCH_STACK_BOTTOM, "Trapped-Signal", "HUP");
+						switch_event_deliver(&event);
+					}
+					if (remove(log_path) == 0) {
+						directory_created = SWITCH_FALSE;
+					} else {
+						fst_check(0);
+					}
+					if (!directory_created) {
+						if (switch_file_rename(backup_path, log_path, pool) == SWITCH_STATUS_SUCCESS) {
+							renamed = SWITCH_FALSE;
+						} else {
+							fst_check(0);
+						}
+					}
+
+					if (!renamed) {
+						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(fst_session), SWITCH_LOG_INFO, "%s\n", marker);
+						contents = wait_for_test_log(marker);
+						fst_check(contents != NULL);
+					}
+				}
+			}
+
+			if (event) switch_event_destroy(&event);
+			if (directory_created && log_path) remove(log_path);
+			if (renamed && pool && log_path && backup_path) switch_file_rename(backup_path, log_path, pool);
+			switch_safe_free(contents);
+			free(marker);
+			free(backup_path);
+			free(log_path);
+		}
+		FST_SESSION_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()

--- a/tests/unit/test_mod_logfile_prefix.c
+++ b/tests/unit/test_mod_logfile_prefix.c
@@ -208,7 +208,7 @@ FST_CORE_BEGIN("./conf")
 			config.log_uuid = SWITCH_TRUE;
 			config.log_tags = SWITCH_TRUE;
 			node.userdata = "uuid-123";
-			fst_check_int_equals(switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA) == SWITCH_STATUS_SUCCESS);
 			if (node.tags) {
 				switch_event_add_header_string(node.tags, SWITCH_STACK_BOTTOM, "tenant", long_value);
 			}
@@ -246,9 +246,9 @@ FST_CORE_BEGIN("./conf")
 			mod_logfile_prefix_config_t config;
 
 			mod_logfile_prefix_config_init(&config);
-			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config,
-				" shorthand , tenant = account_id , =missing, empty= , duplicate = first "), SWITCH_STATUS_SUCCESS);
-			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config, " duplicate = second "), SWITCH_STATUS_SUCCESS);
+			fst_check(mod_logfile_prefix_add_channel_vars(&config,
+				" shorthand , tenant = account_id , =missing, empty= , duplicate = first ") == SWITCH_STATUS_SUCCESS);
+			fst_check(mod_logfile_prefix_add_channel_vars(&config, " duplicate = second ") == SWITCH_STATUS_SUCCESS);
 			fst_check(config.channel_vars != NULL);
 			if (config.channel_vars) {
 				fst_check_string_equals_safe(switch_event_get_header(config.channel_vars, "shorthand"), "shorthand");
@@ -257,7 +257,7 @@ FST_CORE_BEGIN("./conf")
 				fst_check(switch_event_get_header(config.channel_vars, "empty") == NULL);
 				fst_check_int_equals(event_header_count(config.channel_vars), 3);
 			}
-			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config, " =missing, empty= "), SWITCH_STATUS_FALSE);
+			fst_check(mod_logfile_prefix_add_channel_vars(&config, " =missing, empty= ") == SWITCH_STATUS_FALSE);
 
 			mod_logfile_prefix_config_destroy(&config);
 		}
@@ -315,9 +315,9 @@ FST_CORE_BEGIN("./conf")
 			config.log_uuid = SWITCH_TRUE;
 			config.log_tags = SWITCH_TRUE;
 			node.userdata = (char *) switch_core_session_get_uuid(fst_session);
-			fst_check_int_equals(switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA), SWITCH_STATUS_SUCCESS);
-			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config,
-				" call = sip_call_id , origin = source_var "), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA) == SWITCH_STATUS_SUCCESS);
+			fst_check(mod_logfile_prefix_add_channel_vars(&config,
+				" call = sip_call_id , origin = source_var ") == SWITCH_STATUS_SUCCESS);
 			fst_check(channel != NULL);
 			fst_check(node.userdata != NULL);
 			if (node.tags) {
@@ -409,7 +409,7 @@ FST_CORE_BEGIN("./conf")
 			char *prefix;
 
 			mod_logfile_prefix_config_init(&config);
-			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config, "callid=sip_call_id"), SWITCH_STATUS_SUCCESS);
+			fst_check(mod_logfile_prefix_add_channel_vars(&config, "callid=sip_call_id") == SWITCH_STATUS_SUCCESS);
 			node.userdata = (char *) switch_core_session_get_uuid(fst_session);
 			fst_check(channel != NULL);
 			fst_check(node.userdata != NULL);
@@ -441,11 +441,11 @@ FST_CORE_BEGIN("./conf")
 
 			mod_logfile_prefix_config_init(&config);
 			config.log_tags = SWITCH_TRUE;
-			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config, "live=live_c1"), SWITCH_STATUS_SUCCESS);
+			fst_check(mod_logfile_prefix_add_channel_vars(&config, "live=live_c1") == SWITCH_STATUS_SUCCESS);
 			node.userdata = (char *) switch_core_session_get_uuid(fst_session);
 			fst_check(channel != NULL);
 			fst_check(node.userdata != NULL);
-			fst_check_int_equals(switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA), SWITCH_STATUS_SUCCESS);
+			fst_check(switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA) == SWITCH_STATUS_SUCCESS);
 
 			if (node.tags) {
 				switch_event_add_header_string(node.tags, SWITCH_STACK_BOTTOM, "captured", captured_value);

--- a/tests/unit/test_mod_logfile_prefix.c
+++ b/tests/unit/test_mod_logfile_prefix.c
@@ -1,0 +1,468 @@
+/*
+ * FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * Version: MPL 1.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is FreeSWITCH Modular Media Switching Software Library / Soft-Switch Application
+ *
+ * The Initial Developer of the Original Code is
+ * Anthony Minessale II <anthm@freeswitch.org>
+ * Portions created by the Initial Developer are Copyright (C)
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ *
+ * test_mod_logfile_prefix.c -- Tests for structured logfile prefix formatting
+ *
+ */
+
+#include <switch.h>
+#include <stdlib.h>
+#include <test/switch_test.h>
+
+#include "../../src/mod/loggers/mod_logfile/mod_logfile_prefix.h"
+
+#define fst_check_string_equals_safe(actual, expected) do { \
+	const char *fst_actual__ = (actual); \
+	const char *fst_expected__ = (expected); \
+	fst_check(fst_actual__ != NULL); \
+	fst_check(fst_expected__ != NULL); \
+	if (fst_actual__ && fst_expected__) { \
+		fst_check_string_equals(fst_actual__, fst_expected__); \
+	} \
+} while (0)
+
+static int event_header_count(const switch_event_t *event)
+{
+	const switch_event_header_t *header;
+	int count = 0;
+
+	for (header = event ? event->headers : NULL; header; header = header->next) {
+		count++;
+	}
+
+	return count;
+}
+
+typedef struct {
+	switch_status_t status;
+	switch_size_t bytes;
+} write_step_t;
+
+typedef struct {
+	write_step_t steps[4];
+	int step_count;
+	int write_calls;
+	int reopen_calls;
+	switch_status_t reopen_status;
+	char sink[64];
+	switch_size_t sink_length;
+} write_script_t;
+
+static switch_status_t scripted_write(void *context, const char *data, switch_size_t *length)
+{
+	write_script_t *script = context;
+	write_step_t step;
+	switch_size_t bytes;
+
+	if (script->write_calls >= script->step_count) {
+		*length = 0;
+		return SWITCH_STATUS_FALSE;
+	}
+
+	step = script->steps[script->write_calls++];
+	bytes = step.bytes < *length ? step.bytes : *length;
+	memcpy(script->sink + script->sink_length, data, bytes);
+	script->sink_length += bytes;
+	script->sink[script->sink_length] = '\0';
+	*length = bytes;
+	return step.status;
+}
+
+static switch_status_t scripted_reopen(void *context)
+{
+	write_script_t *script = context;
+
+	script->reopen_calls++;
+	return script->reopen_status;
+}
+
+FST_CORE_BEGIN("./conf")
+{
+	FST_SUITE_BEGIN(mod_logfile_prefix)
+	{
+		FST_SETUP_BEGIN()
+		{
+		}
+		FST_SETUP_END()
+
+		FST_TEARDOWN_BEGIN()
+		{
+			mod_logfile_prefix_test_reset_failures();
+		}
+		FST_TEARDOWN_END()
+
+		FST_TEST_BEGIN(complete_write_finishes_successful_short_writes)
+		{
+			write_script_t script = { { { SWITCH_STATUS_SUCCESS, 2 }, { SWITCH_STATUS_SUCCESS, 3 } }, 2, 0, 0,
+				SWITCH_STATUS_SUCCESS, "", 0 };
+			switch_size_t committed = 0;
+			switch_status_t status;
+
+			status = mod_logfile_complete_write(&script, "abcde", 5, scripted_write, scripted_reopen, &committed);
+			fst_check_int_equals(status, SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(script.write_calls, 2);
+			fst_check_int_equals(script.reopen_calls, 0);
+			fst_check_int_equals((int) committed, 5);
+			fst_check_string_equals(script.sink, "abcde");
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(complete_write_recovers_partial_error_without_duplication)
+		{
+			write_script_t script = { { { SWITCH_STATUS_FALSE, 2 }, { SWITCH_STATUS_SUCCESS, 3 } }, 2, 0, 0,
+				SWITCH_STATUS_SUCCESS, "", 0 };
+			switch_size_t committed = 0;
+			switch_status_t status;
+
+			status = mod_logfile_complete_write(&script, "abcde", 5, scripted_write, scripted_reopen, &committed);
+			fst_check_int_equals(status, SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(script.write_calls, 2);
+			fst_check_int_equals(script.reopen_calls, 1);
+			fst_check_int_equals((int) committed, 5);
+			fst_check_string_equals(script.sink, "abcde");
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(complete_write_stops_when_recovery_fails)
+		{
+			write_script_t script = { { { SWITCH_STATUS_SUCCESS, 0 } }, 1, 0, 0, SWITCH_STATUS_FALSE, "", 0 };
+			switch_size_t committed = 99;
+			switch_status_t status;
+
+			status = mod_logfile_complete_write(&script, "abc", 3, scripted_write, scripted_reopen, &committed);
+			fst_check_int_equals(status, SWITCH_STATUS_FALSE);
+			fst_check_int_equals(script.write_calls, 1);
+			fst_check_int_equals(script.reopen_calls, 1);
+			fst_check_int_equals((int) committed, 0);
+			fst_check_string_equals(script.sink, "");
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(complete_write_stops_after_second_zero_progress)
+		{
+			write_script_t script = { { { SWITCH_STATUS_SUCCESS, 0 }, { SWITCH_STATUS_SUCCESS, 0 } }, 2, 0, 0,
+				SWITCH_STATUS_SUCCESS, "", 0 };
+			switch_size_t committed = 99;
+			switch_status_t status;
+
+			status = mod_logfile_complete_write(&script, "abc", 3, scripted_write, scripted_reopen, &committed);
+			fst_check_int_equals(status, SWITCH_STATUS_FALSE);
+			fst_check_int_equals(script.write_calls, 2);
+			fst_check_int_equals(script.reopen_calls, 1);
+			fst_check_int_equals((int) committed, 0);
+			fst_check_string_equals(script.sink, "");
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(prefix_initial_allocation_failure_returns_null)
+		{
+			mod_logfile_prefix_config_t config;
+			switch_log_node_t node = { 0 };
+			char *prefix;
+
+			mod_logfile_prefix_config_init(&config);
+			config.log_uuid = SWITCH_TRUE;
+			node.userdata = "uuid-123";
+			mod_logfile_prefix_test_fail_allocation_after(0);
+			prefix = mod_logfile_prefix_build(&config, &node);
+			mod_logfile_prefix_test_reset_failures();
+
+			fst_check(prefix == NULL);
+			switch_safe_free(prefix);
+			mod_logfile_prefix_config_destroy(&config);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(prefix_mid_growth_failure_discards_fragment)
+		{
+			mod_logfile_prefix_config_t config;
+			switch_log_node_t node = { 0 };
+			char long_value[201];
+			char *prefix;
+
+			memset(long_value, 'v', sizeof(long_value) - 1);
+			long_value[sizeof(long_value) - 1] = '\0';
+			mod_logfile_prefix_config_init(&config);
+			config.log_uuid = SWITCH_TRUE;
+			config.log_tags = SWITCH_TRUE;
+			node.userdata = "uuid-123";
+			fst_check_int_equals(switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA), SWITCH_STATUS_SUCCESS);
+			if (node.tags) {
+				switch_event_add_header_string(node.tags, SWITCH_STACK_BOTTOM, "tenant", long_value);
+			}
+			mod_logfile_prefix_test_fail_allocation_after(1);
+			prefix = mod_logfile_prefix_build(&config, &node);
+			mod_logfile_prefix_test_reset_failures();
+
+			fst_check(prefix == NULL);
+			switch_safe_free(prefix);
+			switch_event_destroy(&node.tags);
+			mod_logfile_prefix_config_destroy(&config);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(multiline_mid_growth_failure_discards_fragment)
+		{
+			char data[260];
+			char *formatted;
+
+			memset(data, 'a', 60);
+			data[60] = '\n';
+			memset(data + 61, 'b', sizeof(data) - 62);
+			data[sizeof(data) - 1] = '\0';
+			mod_logfile_prefix_test_fail_allocation_after(1);
+			formatted = mod_logfile_prefix_lines("tag:value ", data);
+			mod_logfile_prefix_test_reset_failures();
+
+			fst_check(formatted == NULL);
+			switch_safe_free(formatted);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(channel_var_parser_supports_shorthand_aliases_and_replacement)
+		{
+			mod_logfile_prefix_config_t config;
+
+			mod_logfile_prefix_config_init(&config);
+			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config,
+				" shorthand , tenant = account_id , =missing, empty= , duplicate = first "), SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config, " duplicate = second "), SWITCH_STATUS_SUCCESS);
+			fst_check(config.channel_vars != NULL);
+			if (config.channel_vars) {
+				fst_check_string_equals_safe(switch_event_get_header(config.channel_vars, "shorthand"), "shorthand");
+				fst_check_string_equals_safe(switch_event_get_header(config.channel_vars, "tenant"), "account_id");
+				fst_check_string_equals_safe(switch_event_get_header(config.channel_vars, "duplicate"), "second");
+				fst_check(switch_event_get_header(config.channel_vars, "empty") == NULL);
+				fst_check_int_equals(event_header_count(config.channel_vars), 3);
+			}
+			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config, " =missing, empty= "), SWITCH_STATUS_FALSE);
+
+			mod_logfile_prefix_config_destroy(&config);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(tags_are_ordered_and_sanitized)
+		{
+			mod_logfile_prefix_config_t config;
+			switch_log_node_t node = { 0 };
+			char *prefix;
+
+			mod_logfile_prefix_config_init(&config);
+			config.log_uuid = SWITCH_TRUE;
+			config.log_tags = SWITCH_TRUE;
+			node.userdata = "uuid-123";
+			switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA);
+			switch_event_add_header_string(node.tags, SWITCH_STACK_BOTTOM, "tenant name", "acme]\nwest");
+
+			prefix = mod_logfile_prefix_build(&config, &node);
+			fst_check_string_equals_safe(prefix, "uuid-123 tenant_name:acme__west ");
+
+			switch_safe_free(prefix);
+			switch_event_destroy(&node.tags);
+			mod_logfile_prefix_config_destroy(&config);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(unsafe_uuid_is_sanitized)
+		{
+			mod_logfile_prefix_config_t config;
+			switch_log_node_t node = { 0 };
+			char *prefix;
+
+			mod_logfile_prefix_config_init(&config);
+			config.log_uuid = SWITCH_TRUE;
+			node.userdata = "unsafe uuid]\nvalue";
+
+			prefix = mod_logfile_prefix_build(&config, &node);
+			fst_check_string_equals_safe(prefix, "unsafe_uuid__value ");
+
+			switch_safe_free(prefix);
+			mod_logfile_prefix_config_destroy(&config);
+		}
+		FST_TEST_END()
+
+		FST_SESSION_BEGIN(combined_prefix_orders_uuid_tags_and_live_vars)
+		{
+			mod_logfile_prefix_config_t config;
+			switch_log_node_t node = { 0 };
+			switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+			char *expected = NULL;
+			char *prefix = NULL;
+
+			mod_logfile_prefix_config_init(&config);
+			config.log_uuid = SWITCH_TRUE;
+			config.log_tags = SWITCH_TRUE;
+			node.userdata = (char *) switch_core_session_get_uuid(fst_session);
+			fst_check_int_equals(switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA), SWITCH_STATUS_SUCCESS);
+			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config,
+				" call = sip_call_id , origin = source_var "), SWITCH_STATUS_SUCCESS);
+			fst_check(channel != NULL);
+			fst_check(node.userdata != NULL);
+			if (node.tags) {
+				switch_event_add_header_string(node.tags, SWITCH_STACK_BOTTOM, "tenant name", "acme]\nwest");
+				switch_event_add_header_string(node.tags, SWITCH_STACK_BOTTOM, "trace.id", "trace value");
+			}
+			if (channel && node.userdata) {
+				switch_channel_set_variable(channel, "sip_call_id", "call id]\nwest");
+				switch_channel_set_variable(channel, "source_var", "live[ value");
+				expected = switch_mprintf("%s tenant_name:acme__west trace.id:trace_value call:call_id__west origin:live__value ",
+					node.userdata);
+				prefix = mod_logfile_prefix_build(&config, &node);
+				fst_check_string_equals_safe(prefix, expected);
+			}
+
+			switch_safe_free(expected);
+			switch_safe_free(prefix);
+			switch_event_destroy(&node.tags);
+			mod_logfile_prefix_config_destroy(&config);
+		}
+		FST_SESSION_END()
+
+		FST_TEST_BEGIN(prefix_is_applied_without_truncation)
+		{
+			char *long_line = malloc(5002);
+			char *formatted;
+
+			fst_check(long_line != NULL);
+			if (long_line) {
+				memset(long_line, 'x', 5000);
+				long_line[5000] = '\n';
+				long_line[5001] = '\0';
+				formatted = mod_logfile_prefix_lines("tenant:acme ", long_line);
+
+				fst_check(formatted != NULL);
+				if (formatted) {
+					fst_check_int_equals((int) strlen(formatted), 5013);
+					fst_check_string_starts_with(formatted, "tenant:acme ");
+					fst_check_string_ends_with(formatted, "x\n");
+				}
+
+				switch_safe_free(formatted);
+			}
+			free(long_line);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(prefix_preserves_final_newline_shape)
+		{
+			char *formatted = mod_logfile_prefix_lines("tag:v ", "one\ntwo\n");
+
+			fst_check_string_equals_safe(formatted, "tag:v one\ntag:v two\n");
+			switch_safe_free(formatted);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(prefix_handles_single_blank_line)
+		{
+			char *formatted = mod_logfile_prefix_lines("tag:v ", "\n");
+
+			fst_check_string_equals_safe(formatted, "tag:v \n");
+			switch_safe_free(formatted);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(prefix_preserves_intermediate_blank_lines)
+		{
+			char *formatted = mod_logfile_prefix_lines("tag:v ", "a\n\nb");
+
+			fst_check_string_equals_safe(formatted, "tag:v a\ntag:v \ntag:v b");
+			switch_safe_free(formatted);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(prefix_handles_multiline_data_without_final_newline)
+		{
+			char *formatted = mod_logfile_prefix_lines("tag:v ", "one\ntwo");
+
+			fst_check_string_equals_safe(formatted, "tag:v one\ntag:v two");
+			switch_safe_free(formatted);
+		}
+		FST_TEST_END()
+
+		FST_SESSION_BEGIN(channel_vars_are_live)
+		{
+			mod_logfile_prefix_config_t config;
+			switch_log_node_t node = { 0 };
+			switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+			char *prefix;
+
+			mod_logfile_prefix_config_init(&config);
+			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config, "callid=sip_call_id"), SWITCH_STATUS_SUCCESS);
+			node.userdata = (char *) switch_core_session_get_uuid(fst_session);
+			fst_check(channel != NULL);
+			fst_check(node.userdata != NULL);
+
+			if (channel && node.userdata) {
+				switch_channel_set_variable(channel, "sip_call_id", "first");
+				prefix = mod_logfile_prefix_build(&config, &node);
+				fst_check_string_equals_safe(prefix, "callid:first ");
+				switch_safe_free(prefix);
+
+				switch_channel_set_variable(channel, "sip_call_id", "second");
+				prefix = mod_logfile_prefix_build(&config, &node);
+				fst_check_string_equals_safe(prefix, "callid:second ");
+				switch_safe_free(prefix);
+			}
+
+			mod_logfile_prefix_config_destroy(&config);
+		}
+		FST_SESSION_END()
+
+		FST_SESSION_BEGIN(c1_controls_are_sanitized_without_corrupting_utf8)
+		{
+			static const char captured_value[] = "raw" "\x85" "\x9b" "utf8" "\xc2\x85" "\xc2\x9b" "han" "\xe4\xb8\x80";
+			static const char live_value[] = "raw" "\x85" "\x9b" "utf8" "\xc2\x85" "\xc2\x9b" "han" "\xe4\xb8\x80";
+			mod_logfile_prefix_config_t config;
+			switch_log_node_t node = { 0 };
+			switch_channel_t *channel = switch_core_session_get_channel(fst_session);
+			char *prefix = NULL;
+
+			mod_logfile_prefix_config_init(&config);
+			config.log_tags = SWITCH_TRUE;
+			fst_check_int_equals(mod_logfile_prefix_add_channel_vars(&config, "live=live_c1"), SWITCH_STATUS_SUCCESS);
+			node.userdata = (char *) switch_core_session_get_uuid(fst_session);
+			fst_check(channel != NULL);
+			fst_check(node.userdata != NULL);
+			fst_check_int_equals(switch_event_create_plain(&node.tags, SWITCH_EVENT_CHANNEL_DATA), SWITCH_STATUS_SUCCESS);
+
+			if (node.tags) {
+				switch_event_add_header_string(node.tags, SWITCH_STACK_BOTTOM, "captured", captured_value);
+			}
+			if (channel && node.userdata && node.tags) {
+				switch_channel_set_variable(channel, "live_c1", live_value);
+				prefix = mod_logfile_prefix_build(&config, &node);
+				fst_check_string_equals_safe(prefix,
+					"captured:raw__utf8__han" "\xe4\xb8\x80" " live:raw__utf8__han" "\xe4\xb8\x80" " ");
+			}
+
+			switch_safe_free(prefix);
+			switch_event_destroy(&node.tags);
+			mod_logfile_prefix_config_destroy(&config);
+		}
+		FST_SESSION_END()
+	}
+	FST_SUITE_END()
+}
+FST_CORE_END()


### PR DESCRIPTION
## Description

Adds structured per-channel context to `mod_logfile` output and a `set_log_tag` dialplan application.

`set_log_tag name=value` sets or replaces a channel log tag. `set_log_tag name=` and `set_log_tag name` remove it. `mod_logfile` can include captured tags and configured live channel variables in the prefix of each physical log line.

The implementation also handles APR short writes, partial-error writes, transient reopen failures, HUP/rotation cleanup, allocation failures with raw fallback, and UTF-8-safe value sanitation.

Existing UUID behavior remains enabled by default. `log-tags` and `channel-vars` are opt-in.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

None.

## Testing

Validated in a Linux amd64 ASAN container:

- `make -j10`
- `switch_log`: 4/4
- `test_mod_logfile_prefix`: 18/18
- `test_mod_logfile`: 2/2
- XML parsing and `git diff --check`

- [x] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

Example profile settings:

```xml
<param name="uuid" value="true"/>
<param name="log-tags" value="true"/>
<param name="channel-vars" value="sip_call_id=callid,caller_id_number"/>
```
