### PR TITLE
[mod_sofia] use-after-free crash - ensure that sofia_private is cleared in all cases where the nh handle is destroyed (since it is allocated out of nh's memory pool).

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -679,7 +679,7 @@ switch_status_t sofia_on_hangup(switch_core_session_t *session)
 
 	sofia_clear_flag(tech_pvt, TFLAG_IO);
 
-	if (tech_pvt->sofia_private) {
+	if (tech_pvt->nh && tech_pvt->sofia_private) {
 		/* set to NULL so that switch_core_session_locate no longer succeeds, but don't lose the UUID in uuid_str so we
 		 * can fire events with session UUID */
 		tech_pvt->sofia_private->uuid = NULL;

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -2161,6 +2161,8 @@ static void our_sofia_event_callback(nua_event_t event,
 
 			if (tech_pvt && (tech_pvt->nh == nh)) {
 				tech_pvt->nh = NULL;
+				/* Sofia private is allocated from nh's pool.  If it will be destroyed, we need to clear it */
+				tech_pvt->sofia_private = NULL;
 			}
 
 			nua_handle_destroy(nh);


### PR DESCRIPTION
This particular bug was found when running load testing under very adverse calling circumstances.  Bug originally manifested as a heap metadata corruption issue causing random crashes in memory allocation and free functions.

After running the test using ASAN, it was found that the corrupting write was during a call to sofia_on_hangup().  At this callsite, tech_pvt->nh had already been set to NULL somewhere else, but tech_pvt->sofia_private was still set to a non-NULL pointer.  This is problematic as this likely meant that the nua_handle had been destroyed and any child allocations on the same memory pool (such as tech_pvt->sofia_private) were likely free'd and shouldn't be touched.

After auditing the event callback code path, a case was found where tech_pvt->nh was destroyed without clearing sofia_private, prompting this fix.  After re-running the load test, this patch resolved our issue - no more crashes.
