### PR TITLE
mod_sndfile: allow overriding the WAV write subtype via a file-string param

### DIFF
--- a/src/mod/formats/mod_sndfile/mod_sndfile.c
+++ b/src/mod/formats/mod_sndfile/mod_sndfile.c
@@ -235,6 +235,54 @@ static switch_status_t sndfile_file_open(switch_file_handle_t *handle, const cha
 		}
 	}
 
+	/* Allow the writer to override the encoding subtype via file-string params,
+	   e.g. record_session {subtype=ulaw}/tmp/foo.wav -> WAV container, u-law payload.
+	   Accepted values: ulaw, alaw, pcm16, pcm24, pcm32. Write mode only; reads
+	   always autodetect the subtype from the file header. An unrecognized value,
+	   or a subtype the container does not support (e.g. ulaw on a .flac target),
+	   is ignored with a warning and the container's default subtype is kept -- a
+	   bad param never fails the open. */
+	if ((mode & SFM_WRITE) && handle->params) {
+		const char *subtype = switch_event_get_header(handle->params, "subtype");
+
+		if (!zstr(subtype)) {
+			int sf_subtype = 0;
+
+			if (!strcasecmp(subtype, "ulaw")) {
+				sf_subtype = SF_FORMAT_ULAW;
+			} else if (!strcasecmp(subtype, "alaw")) {
+				sf_subtype = SF_FORMAT_ALAW;
+			} else if (!strcasecmp(subtype, "pcm16")) {
+				sf_subtype = SF_FORMAT_PCM_16;
+			} else if (!strcasecmp(subtype, "pcm24")) {
+				sf_subtype = SF_FORMAT_PCM_24;
+			} else if (!strcasecmp(subtype, "pcm32")) {
+				sf_subtype = SF_FORMAT_PCM_32;
+			} else {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+								  "Ignoring unsupported subtype param '%s' for %s (use ulaw|alaw|pcm16|pcm24|pcm32)\n", subtype, path);
+			}
+
+			if (sf_subtype) {
+				int orig_format = context->sfinfo.format;
+
+				context->sfinfo.format = (orig_format & ~SF_FORMAT_SUBMASK) | sf_subtype;
+
+				/* Keep the container implied by the extension; only apply the
+				   requested subtype if libsndfile accepts the combination. If it
+				   does not (e.g. subtype=ulaw on a .flac target), warn and fall
+				   back to the container's default subtype rather than failing the
+				   open on the sf_format_check() below. */
+				if (!sf_format_check(&context->sfinfo)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+									  "Ignoring subtype param '%s': not valid for the container implied by %s; using the default subtype\n",
+									  subtype, path);
+					context->sfinfo.format = orig_format;
+				}
+			}
+		}
+	}
+
 	if ((mode & SFM_WRITE) && sf_format_check(&context->sfinfo) == 0) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error : file format is invalid (0x%08X).\n", context->sfinfo.format);
 		return SWITCH_STATUS_GENERR;

--- a/tests/unit/switch_core_file.c
+++ b/tests/unit/switch_core_file.c
@@ -224,6 +224,165 @@ FST_CORE_BEGIN("./conf")
 		}
 		FST_TEST_END()
 
+		FST_TEST_BEGIN(test_switch_core_file_write_wav_subtype_ulaw)
+		{
+			switch_status_t status = SWITCH_STATUS_FALSE;
+			switch_file_handle_t fhw = { 0 };
+			switch_file_handle_t fhr = { 0 };
+			static char path[] = "{subtype=ulaw}/tmp/fs_write_unit_test_ulaw.wav";
+			static char filename[] = "/tmp/fs_write_unit_test_ulaw.wav";
+			int16_t *buf;
+			int16_t *rbuf;
+			int i;
+			switch_size_t len;
+			unsigned char hdr[36] = { 0 };
+			FILE *f = NULL;
+
+			len = 160;
+			switch_malloc(buf, len * sizeof(int16_t));
+			switch_malloc(rbuf, len * sizeof(int16_t));
+
+			/* a ramp spanning most of the 16-bit range */
+			for (i = 0; i < (int)len; i++) {
+				buf[i] = (int16_t)(-30000 + i * 375);
+			}
+
+			status = switch_core_file_open(&fhw, path, 1, 8000, SWITCH_FILE_FLAG_WRITE | SWITCH_FILE_DATA_SHORT, NULL);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_file_write(&fhw, buf, &len);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			status = switch_core_file_close(&fhw);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			/* RIFF/WAVE container with a u-law payload: fmt tag == 7, bits per sample == 8 */
+			f = fopen(filename, "rb");
+			fst_requires(f != NULL);
+			fst_check(fread(hdr, 1, sizeof(hdr), f) == sizeof(hdr));
+			fclose(f);
+
+			fst_check(!memcmp(hdr, "RIFF", 4));
+			fst_check(!memcmp(hdr + 8, "WAVE", 4));
+			fst_check(hdr[20] == 0x07 && hdr[21] == 0x00);
+			fst_check(hdr[34] == 8 && hdr[35] == 0);
+
+			/* it must read back through the core (the same path playback uses) and
+			   every decoded sample must sit within u-law quantization error of the
+			   original -- proves real companding, not just a successful open */
+			status = switch_core_file_open(&fhr, filename, 1, 8000, SWITCH_FILE_FLAG_READ | SWITCH_FILE_DATA_SHORT, NULL);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+			if (status == SWITCH_STATUS_SUCCESS) {
+				len = 160;
+				status = switch_core_file_read(&fhr, rbuf, &len);
+				fst_check(status == SWITCH_STATUS_SUCCESS);
+				fst_check(len == 160);
+
+				for (i = 0; i < (int)len; i++) {
+					int in = buf[i], out = rbuf[i];
+					int tolerance = abs(in) / 16 + 16; /* u-law segment step is < |x|/8 */
+					if (abs(out - in) > tolerance) {
+						fst_check(!"u-law round-trip sample outside quantization tolerance");
+						break;
+					}
+				}
+
+				status = switch_core_file_close(&fhr);
+				fst_check(status == SWITCH_STATUS_SUCCESS);
+			}
+
+			switch_safe_free(buf);
+			switch_safe_free(rbuf);
+			unlink(filename);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(test_switch_core_file_write_wav_subtype_unknown)
+		{
+			switch_status_t status = SWITCH_STATUS_FALSE;
+			switch_file_handle_t fhw = { 0 };
+			static char path[] = "{subtype=bogus}/tmp/fs_write_unit_test_subtype.wav";
+			static char filename[] = "/tmp/fs_write_unit_test_subtype.wav";
+			int16_t *buf;
+			int nr_frames = 3, i;
+			switch_size_t len;
+			unsigned char hdr[36] = { 0 };
+			FILE *f = NULL;
+
+			len = 160;
+			switch_malloc(buf, len * sizeof(int16_t));
+
+			/* an unrecognized subtype logs a warning and falls back to PCM_16 */
+			status = switch_core_file_open(&fhw, path, 1, 8000, SWITCH_FILE_FLAG_WRITE | SWITCH_FILE_DATA_SHORT, NULL);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			for (i = 0; i < nr_frames; i++) {
+				memset(buf, i, len * sizeof(int16_t));
+				status = switch_core_file_write(&fhw, buf, &len);
+				fst_requires(status == SWITCH_STATUS_SUCCESS);
+			}
+
+			status = switch_core_file_close(&fhw);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			f = fopen(filename, "rb");
+			fst_requires(f != NULL);
+			fst_check(fread(hdr, 1, sizeof(hdr), f) == sizeof(hdr));
+			fclose(f);
+
+			fst_check(!memcmp(hdr, "RIFF", 4));
+			fst_check(!memcmp(hdr + 8, "WAVE", 4));
+			fst_check(hdr[20] == 0x01 && hdr[21] == 0x00);
+			fst_check(hdr[34] == 16 && hdr[35] == 0);
+
+			switch_safe_free(buf);
+			unlink(filename);
+		}
+		FST_TEST_END()
+
+		FST_TEST_BEGIN(test_switch_core_file_write_subtype_container_mismatch)
+		{
+			switch_status_t status = SWITCH_STATUS_FALSE;
+			switch_file_handle_t fhw = { 0 };
+			static char path[] = "{subtype=ulaw}/tmp/fs_write_unit_test_mismatch.flac";
+			static char filename[] = "/tmp/fs_write_unit_test_mismatch.flac";
+			int16_t *buf;
+			int nr_frames = 3, i;
+			switch_size_t len;
+			unsigned char magic[4] = { 0 };
+			FILE *f = NULL;
+
+			len = 160;
+			switch_malloc(buf, len * sizeof(int16_t));
+
+			/* u-law is not a valid subtype for a FLAC container: the open must
+			   still succeed (warn + fall back to the container's default subtype),
+			   not fail with GENERR as it would without the fallback */
+			status = switch_core_file_open(&fhw, path, 1, 8000, SWITCH_FILE_FLAG_WRITE | SWITCH_FILE_DATA_SHORT, NULL);
+			fst_requires(status == SWITCH_STATUS_SUCCESS);
+
+			for (i = 0; i < nr_frames; i++) {
+				memset(buf, i, len * sizeof(int16_t));
+				status = switch_core_file_write(&fhw, buf, &len);
+				fst_requires(status == SWITCH_STATUS_SUCCESS);
+			}
+
+			status = switch_core_file_close(&fhw);
+			fst_check(status == SWITCH_STATUS_SUCCESS);
+
+			/* the file that lands is a real FLAC (fLaC magic): the container was
+			   preserved and only the unsupported subtype was dropped */
+			f = fopen(filename, "rb");
+			fst_requires(f != NULL);
+			fst_check(fread(magic, 1, sizeof(magic), f) == sizeof(magic));
+			fclose(f);
+			fst_check(!memcmp(magic, "fLaC", 4));
+
+			switch_safe_free(buf);
+			unlink(filename);
+		}
+		FST_TEST_END()
+
 	}
 	FST_SUITE_END()
 }


### PR DESCRIPTION
## Description

On write, `mod_sndfile` unconditionally OR-s `SF_FORMAT_PCM_16` into the format
for every standard sample rate, and no file extension maps a WAV container to a
companded (u-law/A-law) payload — `.ul`/`.ulaw` produce a headerless
`SF_FORMAT_RAW` file, not RIFF/WAVE. As a result there is no way to record, for
example, a G.711 call into a RIFF/WAVE file whose payload stays u-law: the
recording is always expanded to 16-bit PCM, doubling the size on disk and
losing the bit-exact relationship to what crossed the wire.

This adds an optional `subtype` parameter to the standard file-string prefix,
so the caller can choose the encoded subtype while the container stays implied
by the extension:

```lua
session:recordFile("{subtype=ulaw}/tmp/foo.wav")
```

Accepted values: `ulaw`, `alaw`, `pcm16`, `pcm24`, `pcm32`. Write mode only —
reads continue to autodetect the subtype from the header. If the requested
subtype is not valid for the container implied by the extension (for example
`ulaw` on a `.flac` target), `mod_sndfile` logs a warning and falls back to the
container's default subtype rather than failing the open; an unrecognized value
is likewise ignored with a warning. The change is therefore inert unless a
caller explicitly requests a supported subtype, and a bad param never costs the
recording.

Recording a G.711 call as u-law WAV is lossless with respect to the wire, half
the size of the PCM-16 file produced today, and trivially decodable by anything
that reads WAV.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues
No existing issue found for companded WAV write support; happy to open a
tracking issue if the maintainers prefer one.

## Testing

- [x] Added/updated unit tests
- [x] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

Unit tests were added to `tests/unit/switch_core_file.c`:
- `{subtype=ulaw}` on a `.wav` target produces a RIFF/WAVE file with format
  tag 7 (ITU G.711 u-law) and 8-bit samples that decodes back within u-law
  quantization tolerance.
- An unrecognized subtype falls back to `PCM_16` (format tag 1).
- An unsupported container/subtype pair (`{subtype=ulaw}` on a `.flac` target)
  still opens successfully and yields a valid FLAC file — proving the
  warn-and-fall-back path rather than a failed open.

Manual: recorded a live inbound G.711u call via `record_session` to a
`{subtype=ulaw}` `.wav` target, confirmed the container/subtype with `file(1)`
(RIFF/WAVE, format tag 7, 8-bit), then decoded and played the file back and
re-transcribed it successfully.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] All existing tests pass

## Additional Notes

**Why not just re-encode to a compressed format?**
For telephony audio that will be archived and later transcribed or analyzed,
re-encoding the recording to a low-bitrate lossy codec (e.g. MP3) is a poor
fit: lossy compression at telephony bitrates degrades the exact tokens that
downstream ASR/NLP extract — digit sequences and spelled names — even when
overall intelligibility is preserved. This is not hypothetical: internal A/B
testing that transcribed lossy-re-encoded copies against losslessly-stored
copies of the same calls showed a measurable, repeatable increase in misspelled
names and corrupted number sequences. Storing the native companded payload in a
WAV container sidesteps that entirely — lossless with respect to the wire, half
the size of PCM-16, and readable by any WAV consumer.

## Documentation
The parse site in `mod_sndfile.c` carries an inline comment
describing the parameter and its accepted values. The wiki/params entry below is
ready to drop into the mod_sndfile / file-string documentation so the parameter
is discoverable outside the source:

> ### `subtype` (write)
>
> Overrides the encoded sample format (subtype) that `mod_sndfile` writes,
> while the container is still selected by the file extension. Supplied as a
> file-string prefix param, e.g. via `record_session`, `recordFile`, or any
> API that opens a file through `mod_sndfile`:
>
> ```
> record_session {subtype=ulaw}/tmp/foo.wav      # RIFF/WAVE container, u-law payload
> uuid_record <uuid> start {subtype=alaw}/tmp/foo.wav
> session:recordFile("{subtype=pcm24}/tmp/foo.wav")
> ```
>
> | Value   | Encoded subtype        | Notes                              |
> |---------|------------------------|------------------------------------|
> | `ulaw`  | ITU G.711 µ-law, 8-bit | half the size of PCM-16, lossless vs. a G.711µ leg |
> | `alaw`  | ITU G.711 A-law, 8-bit | half the size of PCM-16, lossless vs. a G.711a leg |
> | `pcm16` | 16-bit signed PCM      | current default                    |
> | `pcm24` | 24-bit signed PCM      |                                    |
> | `pcm32` | 32-bit signed PCM      |                                    |
>
> - **Write only.** On read, `mod_sndfile` autodetects the subtype from the
>   file header; the param is ignored.
> - An **unrecognized value** is ignored (a warning is logged) and the
>   container's default subtype is kept.
> - A **subtype the container cannot hold** (for example `ulaw` on a `.flac`
>   target) is validated with libsndfile's `sf_format_check()`; if it fails,
>   `mod_sndfile` logs a warning and falls back to the container's default
>   subtype rather than failing the open. A bad `subtype` never costs the
>   recording — worst case you get the container's default encoding.