### PR TITLE
[Core] Silence GCC 15 false positives from vendored stb_image

### DIFF
--- a/src/switch_core_video.c
+++ b/src/switch_core_video.c
@@ -41,11 +41,23 @@
 #include <gd.h>
 #endif
 
+/* stb_image triggers false-positive -Wstringop-overflow / -Wmaybe-uninitialized
+ * under GCC 15+ (e.g. tc[3] write when img_n can be 4). Treat as system headers. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 #define STB_IMAGE_IMPLEMENTATION
 #include "../libs/stb/stb_image.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "../libs/stb/stb_image_write.h"
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef SWITCH_HAVE_YUV
 static inline void switch_img_get_yuv_pixel(switch_image_t *img, switch_yuv_color_t *yuv, int x, int y);


### PR DESCRIPTION
GCC 15 treats -Wstringop-overflow / -Wmaybe-uninitialized as errors when building with -Werror, and flags false positives inside the vendored stb_image / stb_image_write headers (e.g. tc[3] vs img_n). Wrap the includes with diagnostic push/pop so switch_core_video.c builds cleanly.

Fixes #3040

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
