### PR TITLE
[Core] Add fc00::/7 (ULA) to builtin private/WAN ACL lists

### DIFF
--- a/src/switch_core.c
+++ b/src/switch_core.c
@@ -1490,6 +1490,8 @@ SWITCH_DECLARE(void) switch_load_network_lists(switch_bool_t reload)
 	switch_network_list_add_cidr(rfc_list, "172.16.0.0/12", SWITCH_TRUE);
 	switch_network_list_add_cidr(rfc_list, "192.168.0.0/16", SWITCH_TRUE);
 	switch_network_list_add_cidr(rfc_list, "fe80::/10", SWITCH_TRUE);
+	/* Unique Local Addresses (ULA) — RFC 4193 */
+	switch_network_list_add_cidr(rfc_list, "fc00::/7", SWITCH_TRUE);
 	switch_core_hash_insert(IP_LIST.hash, tmp_name, rfc_list);
 
 	tmp_name = "wan.auto";
@@ -1502,6 +1504,8 @@ SWITCH_DECLARE(void) switch_load_network_lists(switch_bool_t reload)
 	switch_network_list_add_cidr(rfc_list, "169.254.0.0/16", SWITCH_FALSE);
 	switch_network_list_add_cidr(rfc_list, "100.64.0.0/10", SWITCH_FALSE);
 	switch_network_list_add_cidr(rfc_list, "fe80::/10", SWITCH_FALSE);
+	/* Unique Local Addresses (ULA) — RFC 4193 */
+	switch_network_list_add_cidr(rfc_list, "fc00::/7", SWITCH_FALSE);
 	switch_core_hash_insert(IP_LIST.hash, tmp_name, rfc_list);
 
 	tmp_name = "wan_v6.auto";
@@ -1509,6 +1513,8 @@ SWITCH_DECLARE(void) switch_load_network_lists(switch_bool_t reload)
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "Created ip list %s default (allow)\n", tmp_name);
 	switch_network_list_add_cidr(rfc_list, "0.0.0.0/0", SWITCH_FALSE);
 	switch_network_list_add_cidr(rfc_list, "fe80::/10", SWITCH_FALSE);
+	/* Unique Local Addresses (ULA) — RFC 4193 */
+	switch_network_list_add_cidr(rfc_list, "fc00::/7", SWITCH_FALSE);
 	switch_core_hash_insert(IP_LIST.hash, tmp_name, rfc_list);
 
 

--- a/tests/unit/switch_core.c
+++ b/tests/unit/switch_core.c
@@ -173,6 +173,14 @@ FST_CORE_BEGIN("./conf")
 			fst_check_int_equals(mask.v6.s6_addr[1], 0xc0);
 			fst_check_int_equals(mask.v6.s6_addr[2], 0);
 
+			/* Unique Local Addresses (ULA) — RFC 4193 / fc00::/7 */
+			fst_check(!switch_parse_cidr("fc00::/7", &ip, &mask, &bits));
+			fst_check_int_equals(bits, 7);
+			fst_check_int_equals(ip.v6.s6_addr[0], 0xfc);
+			fst_check_int_equals(ip.v6.s6_addr[1], 0);
+			fst_check_int_equals(mask.v6.s6_addr[0], 0xfe);
+			fst_check_int_equals(mask.v6.s6_addr[1], 0);
+
 			fst_check(!switch_parse_cidr("::/0", &ip, &mask, &bits));
 			fst_check_int_equals(bits, 0);
 			fst_check_int_equals(ip.v6.s6_addr[0], 0);
@@ -216,6 +224,25 @@ FST_CORE_BEGIN("./conf")
 			fst_check_int_equals(mask.v6.s6_addr[13], 0xff);
 			fst_check_int_equals(mask.v6.s6_addr[14], 0xff);
 			fst_check_int_equals(mask.v6.s6_addr[15], 0xff);
+		}
+		FST_TEST_END()
+
+		/* Issue #2703: ULA fc00::/7 must be treated as private / non-WAN */
+		FST_TEST_BEGIN(test_ula_fc00_in_builtin_acls)
+		{
+			/* rfc1918.auto is default-deny; private ranges are allow-listed */
+			fst_check(switch_check_network_list_ip("fc00::1", "rfc1918.auto"));
+			fst_check(switch_check_network_list_ip("fd12:3456:789a::1", "rfc1918.auto"));
+			fst_check(!switch_check_network_list_ip("2001:db8::1", "rfc1918.auto"));
+
+			/* wan.auto / wan_v6.auto are default-allow; private ranges are deny-listed */
+			fst_check(!switch_check_network_list_ip("fc00::1", "wan.auto"));
+			fst_check(!switch_check_network_list_ip("fd12:3456:789a::1", "wan.auto"));
+			fst_check(switch_check_network_list_ip("2001:db8::1", "wan.auto"));
+
+			fst_check(!switch_check_network_list_ip("fc00::1", "wan_v6.auto"));
+			fst_check(!switch_check_network_list_ip("fd12:3456:789a::1", "wan_v6.auto"));
+			fst_check(switch_check_network_list_ip("2001:db8::1", "wan_v6.auto"));
 		}
 		FST_TEST_END()
 


### PR DESCRIPTION
Unique Local Addresses (RFC 4193) are not globally routable and should be treated like other private ranges for ICE candidate ACL purposes.

Add fc00::/7 to rfc1918.auto (allow), wan.auto and wan_v6.auto (deny), matching how fe80::/10 link-local is already handled. Include unit tests for CIDR parsing and builtin ACL matching.

Fixes #2703

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
