### PR TITLE
mod_shell_stream: fix file_open() blocking playback until child exits

### DIFF
--- a/src/mod/formats/mod_shell_stream/mod_shell_stream.c
+++ b/src/mod/formats/mod_shell_stream/mod_shell_stream.c
@@ -30,6 +30,7 @@
  */
 #include <switch.h>
 #include <sys/wait.h>
+#include <signal.h>
 
 #define MY_BUF_LEN 1024 * 32
 #define MY_BLOCK_SIZE MY_BUF_LEN
@@ -137,7 +138,13 @@ static switch_status_t shell_stream_file_open(switch_file_handle_t *handle, cons
 				switch_cond_next();
 			}
 
-			wait(&(context->pid));
+			/* NOTE: we intentionally do NOT wait() for the child here.
+			   Doing so blocks file_open() until the child process fully
+			   exits, which means FreeSWITCH can't start calling
+			   file_read() (i.e. can't start playing anything) until the
+			   ENTIRE external command has finished running - defeating
+			   the purpose of the background buffering thread above.
+			   The child is instead reaped in shell_stream_file_close(). */
 
 			goto end;
 		} else {				/*  child */
@@ -183,6 +190,31 @@ static switch_status_t shell_stream_file_close(switch_file_handle_t *handle)
 
 	switch_thread_rwlock_wrlock(context->rwlock);
 	switch_thread_rwlock_unlock(context->rwlock);
+
+	/* Reap the child process here instead of in file_open(). Closing
+	   fds[0] above closes the read end of the pipe, so if the child is
+	   still writing (e.g. playback was stopped mid-stream), its next
+	   write will fail (EPIPE/SIGPIPE) and it should exit on its own
+	   shortly. Give it a brief grace period, then force-kill as a
+	   safety net so we never block indefinitely or leak a process. */
+	if (context->pid > 0) {
+		int status = 0;
+		pid_t wp;
+		int tries = 0;
+
+		while ((wp = waitpid(context->pid, &status, WNOHANG)) == 0 && tries < 100) {
+			switch_yield(10000); /* 10ms; ~1s total grace period */
+			tries++;
+		}
+
+		if (wp == 0) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+							   "shell_stream child pid %d did not exit after stream close, killing it\n",
+							   (int) context->pid);
+			kill(context->pid, SIGKILL);
+			waitpid(context->pid, &status, 0);
+		}
+	}
 
 	return SWITCH_STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Description

Removes the blocking `wait()` call in `file_open()` that prevented FreeSWITCH from calling `file_read()` until the entire external command had exited, defeating the purpose of the background buffering thread. Child process reaping is moved to `file_close()` instead, with a bounded grace period + `SIGKILL` fallback so playback being cut short (e.g. caller hangs up mid-stream) can't leave a zombie or hung process.

**Before:** audio from a streaming shell command (e.g. a script that generates and writes audio progressively, such as a real-time TTS engine) is completely silent until the script fully exits, then plays back all at once.

**After:** audio starts playing as soon as the first frame's worth of data is available in the buffer, and streams in naturally as the child process produces more.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

Fixes #3089

## Testing

- [ ] Added/updated unit tests
- [x] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

Manually tested against a Python script streaming PCM16LE audio to stdout from a real-time TTS API over several seconds — confirmed playback now starts within the first buffered chunk instead of waiting for full completion. Also tested short-lived scripts (tone generator, static WAV file playback) to confirm unchanged behavior for that case, and tested closing the channel (hangup) while the child was still mid-stream to confirm clean process reaping via the grace-period/SIGKILL path.