### PR TITLE
[Core, mod_sofia] Make the rtp-autofix-timing codec check limit configurable

### DIFF
--- a/conf/vanilla/sip_profiles/internal.xml
+++ b/conf/vanilla/sip_profiles/internal.xml
@@ -373,6 +373,8 @@
     <!--<param name="outbound-use-uuid-as-callid" value="true"/>-->
     <!-- set to false disable this feature -->
     <!--<param name="rtp-autofix-timing" value="false"/>-->
+    <!-- how many initial frames rtp-autofix-timing inspects before stop, -1 to inspect for the whole call (default 50) -->
+    <!--<param name="rtp-autofix-max-codec-check-frames" value="-1"/>-->
 
     <!-- set this param to false if your gateway for some reason hates X- headers that it is supposed to ignore-->
     <!--<param name="pass-callee-id" value="false"/>-->

--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -41,6 +41,7 @@ SWITCH_BEGIN_EXTERN_C
 
 #define SWITCH_MAX_CAND_ACL 25
 #define SWITCH_NO_CRYPTO_TAG -1
+#define SWITCH_MAX_CODEC_CHECK_FRAMES 50
 
 typedef enum {
 	DTMF_AUTO,
@@ -101,6 +102,7 @@ typedef struct switch_core_media_params_s {
 	uint32_t rtp_hold_timeout_sec;
 	uint32_t dtmf_delay;
 	uint32_t codec_flags;
+	int32_t max_codec_check_frames;
 
 	switch_core_media_NDLB_t ndlb;
 	switch_rtp_bug_flag_t auto_rtp_bugs;

--- a/src/mod/endpoints/mod_rtc/mod_rtc.c
+++ b/src/mod/endpoints/mod_rtc/mod_rtc.c
@@ -331,6 +331,7 @@ void rtc_attach_private(switch_core_session_t *session, private_object_t *tech_p
 	switch_channel_set_cap(tech_pvt->channel, CC_JITTERBUFFER);
 	switch_channel_set_cap(tech_pvt->channel, CC_FS_RTP);
 	switch_channel_set_cap(tech_pvt->channel, CC_IO_OVERRIDE);
+	tech_pvt->mparams.max_codec_check_frames = SWITCH_MAX_CODEC_CHECK_FRAMES;
 	switch_media_handle_create(&tech_pvt->media_handle, session, &tech_pvt->mparams);
 	switch_core_session_set_private(session, tech_pvt);
 

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -59,7 +59,6 @@
 
 #define ROUTE_MAX_HEADERS 20
 #define ROUTE_ENCODED_HEADER_MAX_CHARS (1024 * 3)
-#define MAX_CODEC_CHECK_FRAMES 50
 #define MAX_MISMATCH_FRAMES 5
 #define MODNAME "mod_sofia"
 #define SOFIA_DEFAULT_CONTACT_USER MODNAME
@@ -697,6 +696,7 @@ struct sofia_profile {
 	unsigned int mflags;
 	unsigned int ndlb;
 	unsigned int mndlb;
+	int32_t max_codec_check_frames;
 	uint32_t max_calls;
 	uint32_t nonce_ttl;
 	uint32_t max_auth_validity;

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -4656,6 +4656,7 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 					sofia_set_pflag(profile, PFLAG_ENABLE_CHAT);
 					profile->auto_restart = 1;
 					sofia_set_media_flag(profile, SCMF_AUTOFIX_TIMING);
+					profile->max_codec_check_frames = SWITCH_MAX_CODEC_CHECK_FRAMES;
 					sofia_set_media_flag(profile, SCMF_RTP_AUTOFLUSH_DURING_BRIDGE);
 					profile->contact_user = SOFIA_DEFAULT_CONTACT_USER;
 					sofia_set_pflag(profile, PFLAG_PASS_CALLEE_ID);
@@ -5524,6 +5525,8 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 						} else {
 							sofia_clear_media_flag(profile, SCMF_AUTOFIX_TIMING);
 						}
+					} else if (!strcasecmp(var, "rtp-autofix-max-codec-check-frames")) {
+						profile->max_codec_check_frames = atoi(val);
 					} else if (!strcasecmp(var, "contact-user")) {
 						profile->contact_user = switch_core_strdup(profile->pool, val);
 					} else if (!strcasecmp(var, "nat-options-ping")) {

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -184,6 +184,7 @@ void sofia_glue_attach_private(switch_core_session_t *session, sofia_profile_t *
 	tech_pvt->mparams.cng_pt = tech_pvt->cng_pt;
 	tech_pvt->mparams.rtp_timeout_sec = profile->rtp_timeout_sec;
 	tech_pvt->mparams.rtp_hold_timeout_sec = profile->rtp_hold_timeout_sec;
+	tech_pvt->mparams.max_codec_check_frames = profile->max_codec_check_frames;
 
 	if (profile->rtp_digit_delay) {
 		tech_pvt->mparams.dtmf_delay = profile->rtp_digit_delay;

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -47,7 +47,6 @@ static void switch_core_media_set_r_sdp_codec_string(switch_core_session_t *sess
 static void gen_ice(switch_core_session_t *session, switch_media_type_t type, const char *ip, switch_port_t port);
 //#define GOOGLE_ICE
 #define RTCP_MUX
-#define MAX_CODEC_CHECK_FRAMES 50//x:mod_sofia.h
 #define MAX_MISMATCH_FRAMES 5//x:mod_sofia.h
 #define type2str(type) type == SWITCH_MEDIA_TYPE_VIDEO ? "video" : (type == SWITCH_MEDIA_TYPE_AUDIO ? "audio" : "text")
 #define VIDEO_REFRESH_FREQ 1000000
@@ -3041,12 +3040,13 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_read_frame(switch_core_session
 				/* check for timing issues */
 				if (smh->media_flags[SCMF_AUTOFIX_TIMING] && type == SWITCH_MEDIA_TYPE_AUDIO && engine->read_impl.samples_per_second) {
 					char is_vbr;
+					int32_t max_check_frames = smh->mparams->max_codec_check_frames;
 					is_vbr = engine->read_impl.encoded_bytes_per_packet?0:1;
 
 					engine->check_frames++;
 					/* CBR */
 					if ((smh->media_flags[SCMF_AUTOFIX_TIMING] && (engine->read_frame.datalen % 10) == 0)
-							&& (engine->check_frames < MAX_CODEC_CHECK_FRAMES) && !is_vbr) {
+							&& (max_check_frames < 0 || engine->check_frames < (uint32_t) max_check_frames) && !is_vbr) {
 						engine->check_frames++;
 
 						if (engine->last_ts && engine->read_frame.datalen != engine->read_impl.encoded_bytes_per_packet) {
@@ -3080,7 +3080,10 @@ SWITCH_DECLARE(switch_status_t) switch_core_media_read_frame(switch_core_session
 														  "[CBR]: Your phone is trying to send timestamps that suggest an increment of %dms per packet\n"
 														  "That seems hard to believe so I am going to go on ahead and um ignore that, mmkay?\n",
 														  (int) codec_ms);
-										engine->check_frames = MAX_CODEC_CHECK_FRAMES;
+										/* stop checking for the rest of the call, unless we were asked to check forever */
+										if (max_check_frames >= 0) {
+											engine->check_frames = (uint32_t) max_check_frames;
+										}
 										goto skip;
 									}
 


### PR DESCRIPTION
## Description
The CBR branch of the autofix-timing codec check stopped after a hardcoded 50 frames.

Add a sofia profile parameter, rtp-autofix-max-codec-check-frames:

  > 0   inspect that many frames (default 50, unchanged)
  < 0   inspect for the whole call

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] All existing tests pass

## Additional Notes

I need this change because I use FreeSWITCH (FS) with Trader turret systems. In some setupus, media is routed to a media server, and the packet rate can change dynamically between all participants (from the Turret phones, to their gateway, through the customer's SBC, and finally to our system).

When the Turret system changes the packet rate, it does not send a SIP re-INVITE or any other SIP signaling to notify the gateway or SBC. Because of this, there is no way to detect the rate change via SIP. Instead, it can only be detected and handled using the RTP timestamp and payload information.
FreeSWITCH already had a feature to handle this, but it previously only worked at the very beginning of the call. My change extends this functionality so FreeSWITCH by making configurable how many packets we want to check and, if its negative, check for entire call
