### PR TITLE
[mod_spandsp] Fix T.38 fax hangup after Phase E completion

### DIFF
--- a/src/mod/applications/mod_spandsp/mod_spandsp_fax.c
+++ b/src/mod/applications/mod_spandsp/mod_spandsp_fax.c
@@ -670,6 +670,7 @@ static void phase_e_handler(void *user_data, int result)
 	/* switch_channel_hangup(channel, SWITCH_CAUSE_NORMAL_CLEARING); */
 
 	pvt->done = 1;
+	switch_core_session_kill_channel(session, SWITCH_SIG_BREAK);
 
 	/* Fire event */
 
@@ -1486,6 +1487,7 @@ void mod_spandsp_fax_stop_fax(switch_core_session_t *session)
 	pvt_t *pvt = switch_channel_get_private(switch_core_session_get_channel(session), "_fax_pvt");
 	if (pvt) {
 		pvt->done = 1;
+		switch_core_session_kill_channel(session, SWITCH_SIG_BREAK);
 	}
 }
 


### PR DESCRIPTION
## Description

When a T.38 fax completes (Phase E), `phase_e_handler()` sets `pvt->done = 1` to signal the main loop in `mod_spandsp_fax_process_fax()` to exit. However, in T.38/UDPTL mode the peer stops sending packets after completion, causing `read_frame()` to block in `poll()`. The main loop never reaches the `pvt->done` check and the call hangs until the media inactivity timeout (up to 600 seconds).

This fix calls `switch_core_session_kill_channel(session, SWITCH_SIG_BREAK)` after setting `pvt->done = 1` to wake the blocked `read_frame()`.

The same `pvt->done = 1` pattern exists in `mod_spandsp_fax_stop_fax()`, which is also fixed to prevent the same hangup issue.

## Type of Change

- [x] Bug fix

## Related Issues

Closes #3044

## Testing

- The fix has been validated in a production environment for 3 weeks with no stalled T.38 fax calls observed (reported in #3044)
- Reverting the fix reproduced the 600-second stall issue