### PR TITLE
[Core] EJB: revised elastic jitter buffer — reduces per-call max delay ~2× in canary A/B

### DIFF
--- a/src/include/private/switch_core_pvt.h
+++ b/src/include/private/switch_core_pvt.h
@@ -170,6 +170,8 @@ struct switch_core_session {
 	switch_buffer_t *text_line_buffer;
 	switch_mutex_t *text_mutex;
 	const char *external_id;
+
+	packet_stats_t stats;
 };
 
 struct switch_media_bug {

--- a/src/include/switch_core.h
+++ b/src/include/switch_core.h
@@ -90,6 +90,31 @@ typedef struct device_uuid_node_s {
 	struct device_uuid_node_s *next;
 } switch_device_node_t;
 
+typedef struct packet_stats_io_info {
+	const char* in_callid;
+	char* in_codec;
+	uint32_t in_ssrc;
+	switch_sockaddr_t *in_remote_addr;
+	switch_sockaddr_t *in_local_addr;
+	const char* out_callid;
+	char* out_codec;
+	uint32_t out_ssrc;
+	switch_sockaddr_t *out_remote_addr;
+	switch_sockaddr_t *out_local_addr;
+	uint32_t count; // count of packets going out
+} packet_stats_io_info_t;
+
+typedef struct packet_stats {
+	int max;
+	float average;
+	uint32_t in_count;
+	uint32_t in_plc;
+	uint32_t in_rx;     /* Packets received via RTP and about to enter the JB. */
+	uint32_t count;
+	packet_stats_io_info_t io_info;
+	switch_bool_t reported;
+} packet_stats_t;
+
 typedef struct switch_device_stats_s {
 	uint32_t total;
 	uint32_t total_in;
@@ -268,6 +293,11 @@ static inline void *switch_must_realloc(void *_b, size_t _z)
 ///\{
 
 
+SWITCH_DECLARE(void) switch_core_session_increment_read(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_session_increment_plc(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_session_increment_rx(switch_core_session_t *session);
+SWITCH_DECLARE(void) packet_stats_print(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_session_set_io_stats(switch_core_session_t *session, packet_stats_io_info_t *packet_stats_io_info);
 SWITCH_DECLARE(void) switch_core_screen_size(int *x, int *y);
 SWITCH_DECLARE(void) switch_core_session_sched_heartbeat(switch_core_session_t *session, uint32_t seconds);
 SWITCH_DECLARE(void) switch_core_session_unsched_heartbeat(switch_core_session_t *session);

--- a/src/include/switch_core.h
+++ b/src/include/switch_core.h
@@ -101,16 +101,15 @@ typedef struct packet_stats_io_info {
 	uint32_t out_ssrc;
 	switch_sockaddr_t *out_remote_addr;
 	switch_sockaddr_t *out_local_addr;
-	uint32_t count; // count of packets going out
 } packet_stats_io_info_t;
 
 typedef struct packet_stats {
 	int max;
 	float average;
-	uint32_t in_count;
-	uint32_t in_plc;
-	uint32_t in_rx;     /* Packets received via RTP and about to enter the JB. */
-	uint32_t count;
+	uint32_t rx_ingress;      /* RTP packets off the socket (pre-JB). */
+	uint32_t rx_egress;       /* Real audio frames the bridge read (post-JB, excluding PLC). */
+	uint32_t rx_egress_plc;   /* PLC fill frames the bridge read (concealment, not real audio). */
+	uint32_t tx_egress;       /* Frames written toward the peer. */
 	packet_stats_io_info_t io_info;
 	switch_bool_t reported;
 } packet_stats_t;
@@ -293,9 +292,9 @@ static inline void *switch_must_realloc(void *_b, size_t _z)
 ///\{
 
 
-SWITCH_DECLARE(void) switch_core_session_increment_read(switch_core_session_t *session);
-SWITCH_DECLARE(void) switch_core_session_increment_plc(switch_core_session_t *session);
-SWITCH_DECLARE(void) switch_core_session_increment_rx(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_session_increment_rx_ingress(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_session_increment_rx_egress(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_session_increment_rx_egress_plc(switch_core_session_t *session);
 SWITCH_DECLARE(void) packet_stats_print(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_session_set_io_stats(switch_core_session_t *session, packet_stats_io_info_t *packet_stats_io_info);
 SWITCH_DECLARE(void) switch_core_screen_size(int *x, int *y);

--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -292,6 +292,7 @@ SWITCH_DECLARE(void) switch_core_media_resume(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_media_init(void);
 SWITCH_DECLARE(void) switch_core_media_deinit(void);
 SWITCH_DECLARE(void) switch_core_media_set_stats(switch_core_session_t *session);
+SWITCH_DECLARE(void) switch_core_media_export_jb_stats(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_media_sync_stats(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_session_wake_video_thread(switch_core_session_t *session);
 SWITCH_DECLARE(void) switch_core_session_clear_crypto(switch_core_session_t *session);

--- a/src/include/switch_frame.h
+++ b/src/include/switch_frame.h
@@ -87,6 +87,7 @@ typedef struct switch_frame_geometry {
 	payload_map_t *pmap;
 	switch_image_t *img;
 	struct switch_frame_geometry geometry;
+	switch_time_t received_ts;
 };
 
 SWITCH_END_EXTERN_C

--- a/src/include/switch_jitterbuffer.h
+++ b/src/include/switch_jitterbuffer.h
@@ -67,6 +67,8 @@ SWITCH_DECLARE(void) switch_jb_set_flag(switch_jb_t *jb, switch_jb_flag_t flag);
 SWITCH_DECLARE(void) switch_jb_clear_flag(switch_jb_t *jb, switch_jb_flag_t flag);
 SWITCH_DECLARE(uint32_t) switch_jb_get_nack_success(switch_jb_t *jb);
 SWITCH_DECLARE(uint32_t) switch_jb_get_packets_per_frame(switch_jb_t *jb);
+SWITCH_DECLARE(switch_bool_t) switch_jb_is_elastic(switch_jb_t *jb);
+SWITCH_DECLARE(void) switch_jb_export_stats(switch_jb_t *jb);
 
 SWITCH_END_EXTERN_C
 #endif

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -57,6 +57,7 @@ typedef struct {
 	char body[SWITCH_RTP_MAX_BUF_LEN+4+sizeof(char *)];
 	switch_rtp_hdr_ext_t *ext;
 	char *ebody;
+	switch_time_t received_ts;
 } switch_rtp_packet_t;
 
 typedef enum {
@@ -360,6 +361,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_debug_jitter_buffer(switch_rtp_t *rtp
 SWITCH_DECLARE(switch_status_t) switch_rtp_deactivate_jitter_buffer(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(switch_status_t) switch_rtp_pause_jitter_buffer(switch_rtp_t *rtp_session, switch_bool_t pause);
 SWITCH_DECLARE(switch_jb_t *) switch_rtp_get_jitter_buffer(switch_rtp_t *rtp_session);
+SWITCH_DECLARE(switch_jb_t *) switch_rtp_get_jitter_buffer_for_stats(switch_rtp_t *rtp_session);
 
 
 

--- a/src/mod/codecs/mod_opus/mod_opus.c
+++ b/src/mod/codecs/mod_opus/mod_opus.c
@@ -109,6 +109,20 @@ struct dec_stats {
 	uint32_t fec_counter;
 	uint32_t plc_counter;
 	uint32_t frame_counter;
+	/* PLC run-length classification. ≤3 PLC frames in a run (≤60ms) are
+	 * essentially inaudible — opus spectrally interpolates from the prior
+	 * packet. Beyond 3 the output degenerates into comfort noise.
+	 *
+	 * A "run" is gap-tolerant: as long as a new PLC arrives within
+	 * PLC_GAP_TOLERANCE frames (200ms) of the prior PLC, it continues the
+	 * same run. This catches alternating glitchy patterns like
+	 * PLC-real-PLC-real-PLC where each PLC is "isolated" but the listener
+	 * hears a sustained audible artifact. */
+	uint32_t plc_run_len;       /* current run length (gap-tolerant) */
+	uint32_t plc_gap_since;     /* frames since last PLC (caps at gap tolerance) */
+	uint32_t plc_short;         /* PLC frames in runs ≤3 — soft */
+	uint32_t plc_long;          /* PLC frames in runs >3 — audible */
+	uint32_t plc_long_starts;   /* count of runs that crossed the >3 threshold */
 };
 typedef struct dec_stats dec_stats_t;
 
@@ -732,8 +746,19 @@ static switch_status_t switch_opus_destroy(switch_codec_t *codec)
 		if (context->decoder_object) {
 			switch_core_session_t *session = codec->session;
 			if (session) {
+				switch_channel_t *channel = switch_core_session_get_channel(session);
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,"Opus decoder stats: Frames[%d] PLC[%d] FEC[%d]\n",
 										context->decoder_stats.frame_counter, context->decoder_stats.plc_counter-context->decoder_stats.fec_counter, context->decoder_stats.fec_counter);
+				if (channel) {
+					switch_channel_set_variable_printf(channel, "opus_decoder_frames", "%u", context->decoder_stats.frame_counter);
+					switch_channel_set_variable_printf(channel, "opus_decoder_plc", "%u",
+						context->decoder_stats.plc_counter > context->decoder_stats.fec_counter
+							? context->decoder_stats.plc_counter - context->decoder_stats.fec_counter : 0);
+					switch_channel_set_variable_printf(channel, "opus_decoder_fec", "%u", context->decoder_stats.fec_counter);
+					switch_channel_set_variable_printf(channel, "opus_decoder_plc_short", "%u", context->decoder_stats.plc_short);
+					switch_channel_set_variable_printf(channel, "opus_decoder_plc_long",  "%u", context->decoder_stats.plc_long);
+					switch_channel_set_variable_printf(channel, "opus_decoder_plc_long_starts", "%u", context->decoder_stats.plc_long_starts);
+				}
 			}
 			opus_decoder_destroy(context->decoder_object);
 			context->decoder_object = NULL;
@@ -916,14 +941,52 @@ static switch_status_t switch_opus_decode(switch_codec_t *codec,
 						 !encoded_data ? "PLC correction" : fec ?  "FEC correction" : "decode");
 	}
 
+	/* Gap-tolerant PLC run accounting. PLC_GAP_TOLERANCE is in frames at
+	 * 20ms ptime. If a new PLC fires within this gap of the previous one,
+	 * treat it as continuing the same audible event. Otherwise start fresh. */
+	#define PLC_GAP_TOLERANCE 10  /* 10 frames * 20ms = 200ms */
 	if (plc) {
 		context->decoder_stats.plc_counter++;
+		if (context->decoder_stats.plc_gap_since <= PLC_GAP_TOLERANCE) {
+			context->decoder_stats.plc_run_len++;
+		} else {
+			context->decoder_stats.plc_run_len = 1;
+		}
+		context->decoder_stats.plc_gap_since = 0;
+		if (context->decoder_stats.plc_run_len <= 3) {
+			context->decoder_stats.plc_short++;
+		} else {
+			if (context->decoder_stats.plc_run_len == 4) {
+				context->decoder_stats.plc_long_starts++;
+			}
+			context->decoder_stats.plc_long++;
+		}
+	} else {
+		if (context->decoder_stats.plc_gap_since <= PLC_GAP_TOLERANCE) {
+			context->decoder_stats.plc_gap_since++;
+		}
 	}
 	if (fec) {
 		context->decoder_stats.fec_counter++;
 	}
 	/* a frame for which we decode FEC will be counted twice */
 	context->decoder_stats.frame_counter++;
+
+	/* Keep channel variables fresh on each PLC/FEC event so the hangup hook
+	 * (api_hangup_hook fires in CS_HANGUP, before CS_DESTROY runs codec destroy)
+	 * sees current values. Normal decode path does not hit this branch. */
+	if ((plc || fec) && session) {
+		switch_channel_t *channel = switch_core_session_get_channel(session);
+		if (channel) {
+			switch_channel_set_variable_printf(channel, "opus_decoder_plc", "%u",
+				context->decoder_stats.plc_counter > context->decoder_stats.fec_counter
+					? context->decoder_stats.plc_counter - context->decoder_stats.fec_counter : 0);
+			switch_channel_set_variable_printf(channel, "opus_decoder_fec", "%u", context->decoder_stats.fec_counter);
+			switch_channel_set_variable_printf(channel, "opus_decoder_plc_short", "%u", context->decoder_stats.plc_short);
+			switch_channel_set_variable_printf(channel, "opus_decoder_plc_long",  "%u", context->decoder_stats.plc_long);
+			switch_channel_set_variable_printf(channel, "opus_decoder_plc_long_starts", "%u", context->decoder_stats.plc_long_starts);
+		}
+	}
 
 	samples = opus_decode(context->decoder_object, encoded_data, encoded_data_len, decoded_data, frame_size, fec);
 

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -278,24 +278,24 @@ struct switch_media_handle_s {
 void packet_stats_init(packet_stats_t *stats, int latency, int count) {
 	stats->max = latency;
 	stats->average = latency;
-	stats->count = count;
+	stats->tx_egress = count;
 }
 #define _VOR1(v) ((v)?(v):1)
 void packet_stats_update(packet_stats_t *stats, int latency)
 {
-	if (stats->count >= UINT32_MAX)
+	if (stats->tx_egress >= UINT32_MAX)
 		return;
-	stats->count++;
+	stats->tx_egress++;
 
-	if (stats->count == 1)
+	if (stats->tx_egress == 1)
 		packet_stats_init(stats, latency, 1);
 	if (stats->max < latency)
 		stats->max = latency;
 
-	if (stats->count > 1) {
+	if (stats->tx_egress > 1) {
 		float delta;
 		delta = latency - stats->average;
-		stats->average += delta/_VOR1(stats->count);
+		stats->average += delta/_VOR1(stats->tx_egress);
 	}
 }
 
@@ -310,27 +310,27 @@ void packet_stats_print(switch_core_session_t *session) {
 
 		switch_channel_set_variable_printf(session->channel, "packet_stats_report",
 			"{"
-			"\"in\" : { \"ssrc\": \"0x%08X\", \"remote_socket\": \"%s:%u\", \"local_socket\": \"%s:%u\""
-			", \"codec\": \"%s\", \"count\": %u, \"plc\": %u, \"rx\": %u}"
+			"\"rx\" : { \"ssrc\": \"0x%08X\", \"remote_socket\": \"%s:%u\", \"local_socket\": \"%s:%u\""
+			", \"codec\": \"%s\", \"ingress\": %u, \"egress\": %u, \"egress_plc\": %u}"
 			","
-			"\"out\" : { \"ssrc\": \"0x%08X\", \"remote_socket\": \"%s:%u\", \"local_socket\": \"%s:%u\""
-			", \"codec\": \"%s\", \"count\": %u, \"max\": %d, \"avg\": %.2f }}",
+			"\"tx\" : { \"ssrc\": \"0x%08X\", \"remote_socket\": \"%s:%u\", \"local_socket\": \"%s:%u\""
+			", \"codec\": \"%s\", \"egress\": %u, \"max\": %d, \"avg\": %.2f }}",
 			session->stats.io_info.in_ssrc,
                switch_get_addr(in_ipbuf, sizeof(in_ipbuf), session->stats.io_info.in_remote_addr),
                session->stats.io_info.in_remote_addr->port,
                switch_get_addr(in_l_ipbuf, sizeof(in_ipbuf), session->stats.io_info.in_local_addr),
                session->stats.io_info.in_local_addr->port,
 			session->stats.io_info.in_codec,
-			session->stats.in_count,
-			session->stats.in_plc,
-			session->stats.in_rx,
+			session->stats.rx_ingress,
+			session->stats.rx_egress,
+			session->stats.rx_egress_plc,
 			session->stats.io_info.out_ssrc,
                switch_get_addr(out_ipbuf, sizeof(out_ipbuf), session->stats.io_info.out_remote_addr),
                session->stats.io_info.out_local_addr->port,
                switch_get_addr(out_l_ipbuf, sizeof(out_ipbuf), session->stats.io_info.out_local_addr),
                session->stats.io_info.out_remote_addr->port,
 			session->stats.io_info.out_codec,
-			session->stats.count,
+			session->stats.tx_egress,
 			session->stats.max,
 			session->stats.average
 		);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -35,6 +35,7 @@
 #include <switch_stun.h>
 #include <switch_nat.h>
 #include "private/switch_core_pvt.h"
+#include <fspr_network_io.h>
 #include <switch_curl.h>
 #include <errno.h>
 #include <sofia-sip/sdp.h>
@@ -273,6 +274,72 @@ struct switch_media_handle_s {
 	switch_time_t last_text_frame;
 
 };
+
+void packet_stats_init(packet_stats_t *stats, int latency, int count) {
+	stats->max = latency;
+	stats->average = latency;
+	stats->count = count;
+}
+#define _VOR1(v) ((v)?(v):1)
+void packet_stats_update(packet_stats_t *stats, int latency)
+{
+	if (stats->count >= UINT32_MAX)
+		return;
+	stats->count++;
+
+	if (stats->count == 1)
+		packet_stats_init(stats, latency, 1);
+	if (stats->max < latency)
+		stats->max = latency;
+
+	if (stats->count > 1) {
+		float delta;
+		delta = latency - stats->average;
+		stats->average += delta/_VOR1(stats->count);
+	}
+}
+
+void packet_stats_print(switch_core_session_t *session) {
+	if (session->stats.io_info.in_remote_addr && session->stats.io_info.out_local_addr
+		       && !session->stats.reported) {
+		char in_ipbuf[48];
+		char in_l_ipbuf[48];
+		char out_ipbuf[48];
+		char out_l_ipbuf[48];
+		const char *v=NULL;
+
+		switch_channel_set_variable_printf(session->channel, "packet_stats_report",
+			"{"
+			"\"in\" : { \"ssrc\": \"0x%08X\", \"remote_socket\": \"%s:%u\", \"local_socket\": \"%s:%u\""
+			", \"codec\": \"%s\", \"count\": %u, \"plc\": %u, \"rx\": %u}"
+			","
+			"\"out\" : { \"ssrc\": \"0x%08X\", \"remote_socket\": \"%s:%u\", \"local_socket\": \"%s:%u\""
+			", \"codec\": \"%s\", \"count\": %u, \"max\": %d, \"avg\": %.2f }}",
+			session->stats.io_info.in_ssrc,
+               switch_get_addr(in_ipbuf, sizeof(in_ipbuf), session->stats.io_info.in_remote_addr),
+               session->stats.io_info.in_remote_addr->port,
+               switch_get_addr(in_l_ipbuf, sizeof(in_ipbuf), session->stats.io_info.in_local_addr),
+               session->stats.io_info.in_local_addr->port,
+			session->stats.io_info.in_codec,
+			session->stats.in_count,
+			session->stats.in_plc,
+			session->stats.in_rx,
+			session->stats.io_info.out_ssrc,
+               switch_get_addr(out_ipbuf, sizeof(out_ipbuf), session->stats.io_info.out_remote_addr),
+               session->stats.io_info.out_local_addr->port,
+               switch_get_addr(out_l_ipbuf, sizeof(out_ipbuf), session->stats.io_info.out_local_addr),
+               session->stats.io_info.out_remote_addr->port,
+			session->stats.io_info.out_codec,
+			session->stats.count,
+			session->stats.max,
+			session->stats.average
+		);
+		v = switch_channel_get_variable_dup(session->channel,"packet_stats_report", SWITCH_FALSE, -1);
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "[packet_stats_report] %s\n", v);
+		session->stats.reported = true;
+
+	}
+}
 
 switch_srtp_crypto_suite_t SUITES[CRYPTO_INVALID] = {
 	{ "AEAD_AES_256_GCM_8", "", AEAD_AES_256_GCM_8, 44, 12},
@@ -1941,12 +2008,65 @@ SWITCH_DECLARE(void) switch_core_media_sync_stats(switch_core_session_t *session
 
 }
 
+static void set_jb_stats(switch_core_session_t *session, switch_media_type_t type)
+{
+	switch_media_handle_t *smh;
+	switch_rtp_engine_t *engine;
+	switch_jb_t *jb;
+	const char *type_str = (type == SWITCH_MEDIA_TYPE_AUDIO) ? "audio" :
+	                       (type == SWITCH_MEDIA_TYPE_VIDEO) ? "video" : "text";
+
+	if (!(smh = session->media_handle)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+			"set_jb_stats(%s): no media handle\n", type_str);
+		return;
+	}
+
+	engine = &smh->engines[type];
+	if (!engine->rtp_session) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG,
+			"set_jb_stats(%s): no rtp_session\n", type_str);
+		return;
+	}
+
+	/* Use _for_stats variant which bypasses switch_rtp_ready() check
+	 * since RTP session may not be "ready" during hangup but JB still exists */
+	jb = switch_rtp_get_jitter_buffer_for_stats(engine->rtp_session);
+	if (jb) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+			"set_jb_stats(%s): exporting JB stats\n", type_str);
+		switch_jb_export_stats(jb);
+	} else {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+			"set_jb_stats(%s): no jitter buffer\n", type_str);
+	}
+}
+
+SWITCH_DECLARE(void) switch_core_media_export_jb_stats(switch_core_session_t *session)
+{
+	if (!session->media_handle) {
+		return;
+	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+		"switch_core_media_export_jb_stats() exporting JB stats before hangup handlers\n");
+
+	/* Export jitter buffer stats so they're available in hangup hooks */
+	set_jb_stats(session, SWITCH_MEDIA_TYPE_AUDIO);
+	set_jb_stats(session, SWITCH_MEDIA_TYPE_VIDEO);
+	set_jb_stats(session, SWITCH_MEDIA_TYPE_TEXT);
+}
+
 SWITCH_DECLARE(void) switch_core_media_set_stats(switch_core_session_t *session)
 {
+	switch_channel_t *channel = switch_core_session_get_channel(session);
 
 	if (!session->media_handle) {
 		return;
 	}
+
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO,
+		"[%s] switch_core_media_set_stats() called\n", switch_channel_get_name(channel));
 
 	switch_core_media_sync_stats(session);
 
@@ -15824,7 +15944,6 @@ SWITCH_DECLARE(switch_msrp_session_t *) switch_core_media_get_msrp_session(switc
 	return session->media_handle->msrp_session;
 }
 
-
 SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_session_t *session, switch_frame_t *frame, switch_io_flag_t flags,
 																int stream_id)
 {
@@ -16183,6 +16302,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 		goto done;
 	}
 
+	write_frame->received_ts = frame->received_ts;
 	if (session->write_codec) {
 		if (!ptime_mismatch && write_frame->codec && write_frame->codec->implementation &&
 			write_frame->codec->implementation->decoded_bytes_per_packet == session->write_impl.decoded_bytes_per_packet) {
@@ -16458,6 +16578,16 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 	}
 
   error:
+	if (frame->received_ts > 0) {
+		int64_t d = (switch_micro_time_now() - frame->received_ts)/1000;
+		if (d > 2000) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "excessive delay[%ld]-[%ld]=[%ldms] seq[%u]ssrc[0x%08X]\n",
+					(int64_t)(switch_micro_time_now()/1000), (int64_t)(frame->received_ts/1000), d, ntohs(frame->seq), frame->ssrc);
+		}
+		packet_stats_update(&session->stats, d);
+	}
+	session->stats.io_info.out_codec = write_frame->codec->implementation->iananame;
+	session->stats.io_info.in_codec = frame->codec->implementation->iananame;
 
 	switch_mutex_unlock(session->write_codec->mutex);
 	switch_mutex_unlock(frame->codec->mutex);

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -1976,6 +1976,14 @@ static void set_stats(switch_core_session_t *session, switch_media_type_t type, 
 		add_stat(stats->rtcp.packet_count, "rtcp_packet_count");
 		add_stat(stats->rtcp.octet_count, "rtcp_octet_count");
 
+		/* Inbound sequence-loss counters from the RTCP receiver-report path.
+		 * cum_lost is the running total of packets FS never received (detected
+		 * via sequence-number gaps). Expected = high_ext_seq - base_seq + 1,
+		 * so cum_lost / expected is the true inbound loss ratio. Only populated
+		 * when rtcp-audio-interval-msec is set on the profile. */
+		add_stat(stats->rtcp.cum_lost, "in_cum_lost");
+		add_stat((stats->rtcp.high_ext_seq_recv - stats->rtcp.base_seq + 1), "in_expected_pkt");
+
 	}
 }
 

--- a/src/switch_core_session.c
+++ b/src/switch_core_session.c
@@ -36,10 +36,47 @@
 #include "switch.h"
 #include "switch_core.h"
 #include "private/switch_core_pvt.h"
+#include <fspr_network_io.h>
 
 #define DEBUG_THREAD_POOL
 
 struct switch_session_manager session_manager;
+
+SWITCH_DECLARE(void) switch_core_session_increment_plc(switch_core_session_t *session)
+{
+	session->stats.in_plc++;
+}
+
+SWITCH_DECLARE(void) switch_core_session_increment_read(switch_core_session_t *session)
+{
+	session->stats.in_count++;
+}
+
+SWITCH_DECLARE(void) switch_core_session_increment_rx(switch_core_session_t *session)
+{
+	session->stats.in_rx++;
+}
+
+SWITCH_DECLARE(void) switch_core_session_set_io_stats(switch_core_session_t *session, packet_stats_io_info_t *packet_stats_io_info)
+{
+	if ((session->stats.io_info.out_ssrc != 0 && session->stats.io_info.out_ssrc != packet_stats_io_info->out_ssrc)
+	 || (session->stats.io_info.in_ssrc != 0 && session->stats.io_info.in_ssrc != packet_stats_io_info->in_ssrc)) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING, "SSRC change[%u][%u] [%u][%u]\n",
+				session->stats.io_info.out_ssrc, packet_stats_io_info->out_ssrc,
+				session->stats.io_info.in_ssrc, packet_stats_io_info->in_ssrc
+				);
+		packet_stats_print(session);
+		memset(&session->stats, '\0', sizeof(packet_stats_t));
+	}
+	session->stats.io_info.out_remote_addr = packet_stats_io_info->out_remote_addr;
+	session->stats.io_info.out_local_addr = packet_stats_io_info->out_local_addr;
+	session->stats.io_info.out_ssrc = packet_stats_io_info->out_ssrc;
+	session->stats.io_info.out_callid = packet_stats_io_info->out_callid;
+	session->stats.io_info.in_remote_addr = packet_stats_io_info->in_remote_addr;
+	session->stats.io_info.in_local_addr = packet_stats_io_info->in_local_addr;
+	session->stats.io_info.in_ssrc = packet_stats_io_info->in_ssrc;
+	session->stats.io_info.in_callid = packet_stats_io_info->in_callid;
+}
 
 SWITCH_DECLARE(void) switch_core_session_set_dmachine(switch_core_session_t *session, switch_ivr_dmachine_t *dmachine, switch_digit_action_target_t target)
 {
@@ -1497,6 +1534,7 @@ SWITCH_DECLARE(void) switch_core_session_signal_state_change(switch_core_session
 			}
 		}
 	}
+	packet_stats_print(session);
 	switch_core_session_kill_channel(session, SWITCH_SIG_BREAK);
 }
 

--- a/src/switch_core_session.c
+++ b/src/switch_core_session.c
@@ -42,19 +42,19 @@
 
 struct switch_session_manager session_manager;
 
-SWITCH_DECLARE(void) switch_core_session_increment_plc(switch_core_session_t *session)
+SWITCH_DECLARE(void) switch_core_session_increment_rx_ingress(switch_core_session_t *session)
 {
-	session->stats.in_plc++;
+	session->stats.rx_ingress++;
 }
 
-SWITCH_DECLARE(void) switch_core_session_increment_read(switch_core_session_t *session)
+SWITCH_DECLARE(void) switch_core_session_increment_rx_egress(switch_core_session_t *session)
 {
-	session->stats.in_count++;
+	session->stats.rx_egress++;
 }
 
-SWITCH_DECLARE(void) switch_core_session_increment_rx(switch_core_session_t *session)
+SWITCH_DECLARE(void) switch_core_session_increment_rx_egress_plc(switch_core_session_t *session)
 {
-	session->stats.in_rx++;
+	session->stats.rx_egress_plc++;
 }
 
 SWITCH_DECLARE(void) switch_core_session_set_io_stats(switch_core_session_t *session, packet_stats_io_info_t *packet_stats_io_info)

--- a/src/switch_core_state_machine.c
+++ b/src/switch_core_state_machine.c
@@ -843,6 +843,9 @@ SWITCH_DECLARE(void) switch_core_session_hangup_state(switch_core_session_t *ses
 	switch_channel_set_timestamps(session->channel);
 	switch_channel_set_callstate(session->channel, CCS_HANGUP);
 
+	/* Export JB stats before hangup handlers run, while JB still exists */
+	switch_core_media_export_jb_stats(session);
+
 	STATE_MACRO(hangup, "HANGUP");
 
 	switch_core_media_set_stats(session);

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -814,6 +814,14 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 				continue;
 			}
 
+			if (switch_test_flag((read_frame), SFF_PLC)) {
+				read_frame->received_ts = 0;
+				switch_core_session_increment_plc(session_b);
+			} else {
+				if (read_frame->packetlen > 0)
+					switch_core_session_increment_read(session_b);
+			}
+
 			if (status != SWITCH_STATUS_BREAK && !switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {
 				if (switch_core_session_write_frame(session_b, read_frame, SWITCH_IO_FLAG_NONE, stream_id) != SWITCH_STATUS_SUCCESS) {
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session_a), SWITCH_LOG_DEBUG,

--- a/src/switch_ivr_bridge.c
+++ b/src/switch_ivr_bridge.c
@@ -816,10 +816,10 @@ static void *audio_bridge_thread(switch_thread_t *thread, void *obj)
 
 			if (switch_test_flag((read_frame), SFF_PLC)) {
 				read_frame->received_ts = 0;
-				switch_core_session_increment_plc(session_b);
+				switch_core_session_increment_rx_egress_plc(session_b);
 			} else {
 				if (read_frame->packetlen > 0)
-					switch_core_session_increment_read(session_b);
+					switch_core_session_increment_rx_egress(session_b);
 			}
 
 			if (status != SWITCH_STATUS_BREAK && !switch_channel_test_flag(chan_a, CF_HOLD) && !switch_channel_test_flag(chan_b, CF_LEG_HOLDING)) {

--- a/src/switch_jitterbuffer.c
+++ b/src/switch_jitterbuffer.c
@@ -32,6 +32,7 @@
 #include <switch.h>
 #include <switch_jitterbuffer.h>
 #include "private/switch_hashtable_private.h"
+#include <math.h>
 
 #define NACK_TIME 80000
 #define RENACK_TIME 100000
@@ -60,6 +61,9 @@ typedef struct switch_jb_node_s {
 
 typedef struct switch_jb_stats_s {
 	uint32_t reset_too_big;
+	uint32_t reset_too_big_drops;  /* total queued packets discarded by reset_too_big events */
+	uint32_t reset_too_expanded;
+	uint32_t reset_too_expanded_drops;  /* total queued packets discarded by reset_too_expanded events */
 	uint32_t reset_missing_frames;
 	uint32_t reset_ts_jump;
 	uint32_t reset_error;
@@ -67,10 +71,25 @@ typedef struct switch_jb_stats_s {
 	uint32_t size_max;
 	uint32_t size_est;
 	uint32_t acceleration;
+	uint32_t fast_acceleration;
+	uint32_t forced_acceleration;
 	uint32_t expand;
+	uint32_t consecutive_miss;
+	int32_t expand_frame_len;
 	uint32_t jitter_max_ms;
+	uint32_t buffering_skip;
 	int estimate_ms;
 	int buffer_size_ms;
+	/* Elastic algorithm activity */
+	uint32_t grew;          /* count of frame_len increases */
+	uint32_t shrunk;        /* count of frame_len decreases */
+	uint32_t grow_to_max;   /* count of times grow hit max_frame_len */
+	uint32_t at_min_ms;     /* cumulative ms parked at min_frame_len */
+	uint32_t at_max_ms;     /* cumulative ms parked at max_frame_len */
+	switch_time_t edge_since; /* us; when current min/max stretch started (0 if not at an edge) */
+	/* Setup vs runtime reset split (set by switch_jb_reset based on jb->media_started) */
+	uint32_t reset_setup;   /* resets that fired before first media packet was put */
+	uint32_t reset_runtime; /* resets that fired after media flow started */
 } switch_jb_stats_t;
 
 typedef struct switch_jb_jitter_s {
@@ -116,6 +135,40 @@ struct switch_jb_s {
 	uint8_t write_init;
 	uint8_t read_init;
 	uint8_t debug_level;
+	uint8_t media_started; /* set on first put_packet; switch_jb_reset uses it to split setup vs runtime resets */
+	uint32_t packets_total; /* lifetime count of put_packet calls - used for expand_ratio */
+	/* Arrival-time-based jitter estimate. The RFC 3550 inter_jitter that feeds
+	 * jb->jitter.estimate measures drift against the local read timer and
+	 * heavily smooths alternating bursts (e.g. pair-bunching from upstream
+	 * coalescing). This second estimate measures absolute deviation of
+	 * wall-clock inter-arrival from the expected ptime, so a bimodal
+	 * early/late pattern surfaces as real jitter the expand path can act on. */
+	switch_time_t last_arrival_us;
+	/* Two-tier EWMA + EWMV of |delta_ms - ptime_ms|.
+	 * Fast (α=1/4, ~320ms memory) reacts to immediate bursts.
+	 * Slow (α=1/128, ~10s memory) holds the line on sustained burstiness
+	 * even after the fast tier forgets. Consumers take max(fast_est, slow_est).
+	 * Each tier carries its own mean + variance; sizing uses mean + 3*sigma. */
+	double arrival_jitter_ms;        /* fast EWMA mean */
+	double arrival_jitter_var;       /* fast EWMV variance */
+	double arrival_jitter_ms_slow;   /* slow EWMA mean (α=1/128) */
+	double arrival_jitter_var_slow;  /* slow EWMV variance (α=1/128) */
+	/* Clock drift tracker — GStreamer-style sliding baseline.
+	 * Records (recv_us − rtp_us) for each packet and slides the baseline
+	 * DOWN to the smallest observed offset. This avoids the bias problem
+	 * where a delayed first packet would lock in a wrong reference. PPM is
+	 * computed against this sliding min, not against packet 1.
+	 * Logged only, not used in sizing.
+	 * RTP clock rate is inferred from observed timestamps because
+	 * jitter.samples_per_second is the codec sample rate, which doesn't
+	 * match the RTP timestamp rate for codecs like opus (RTP clock always
+	 * 48000 per RFC 7587 regardless of internal rate). */
+	switch_time_t arrival_first_recv_us;     /* first recv timestamp (for slope denominator) */
+	uint32_t      arrival_first_rtp_ts;      /* first RTP timestamp seen */
+	uint32_t      arrival_rtp_clock_hz;      /* 0 = not yet measured; otherwise 8000/16000/48000 */
+	int64_t       arrival_offset_min_us;     /* sliding min(recv_us − rtp_us) */
+	uint8_t       arrival_offset_min_set;    /* 0 until first sample */
+	double        arrival_clock_drift_ppm;
 	uint16_t next_seq;
 	switch_size_t last_len;
 	switch_inthash_t *missing_seq_hash;
@@ -134,6 +187,7 @@ struct switch_jb_s {
 	uint32_t buffer_lag;
 	uint32_t flush;
 	uint32_t packet_count;
+	int32_t packets_in_buffer;
 	uint32_t max_packet_len;
 	uint32_t period_len;
 	uint32_t nack_saved_the_day;
@@ -262,6 +316,7 @@ static inline switch_jb_node_t *new_node(switch_jb_t *jb)
 		if (jb->allocated_nodes > jb->max_frame_len * mult) {
 			jb_debug(jb, 2, "ALLOCATED FRAMES TOO HIGH! %d\n", jb->allocated_nodes);
 			jb->jitter.stats.reset_too_big++;
+			jb->jitter.stats.reset_too_big_drops += jb->visible_nodes;
 			switch_jb_reset(jb);
 			switch_mutex_unlock(jb->list_mutex);
 			return NULL;
@@ -571,7 +626,32 @@ static void jb_frame_inc_line(switch_jb_t *jb, int i, int line)
 	}
 
 	if (old_frame_len != jb->frame_len) {
+		switch_time_t now = switch_micro_time_now();
+
 		jb_debug(jb, 1, "%d Change framelen from %u to %u\n", line, old_frame_len, jb->frame_len);
+
+		if (jb->jitter.stats.edge_since) {
+			uint32_t held_ms = (uint32_t)((now - jb->jitter.stats.edge_since) / 1000);
+			if (old_frame_len == jb->min_frame_len) {
+				jb->jitter.stats.at_min_ms += held_ms;
+			} else if (old_frame_len == jb->max_frame_len) {
+				jb->jitter.stats.at_max_ms += held_ms;
+			}
+			jb->jitter.stats.edge_since = 0;
+		}
+
+		if (jb->frame_len > old_frame_len) {
+			jb->jitter.stats.grew++;
+			if (jb->frame_len == jb->max_frame_len) {
+				jb->jitter.stats.grow_to_max++;
+			}
+		} else {
+			jb->jitter.stats.shrunk++;
+		}
+
+		if (jb->frame_len == jb->min_frame_len || jb->frame_len == jb->max_frame_len) {
+			jb->jitter.stats.edge_since = now;
+		}
 
 		//if (jb->session) {
 		//	switch_core_session_request_video_refresh(jb->session);
@@ -784,8 +864,8 @@ static inline void increment_seq(switch_jb_t *jb)
 
 static inline void decrement_seq(switch_jb_t *jb)
 {
-	jb->last_target_seq = jb->target_seq;
 	jb->target_seq = htons((ntohs(jb->target_seq) - 1));
+	jb->last_target_seq = htons((ntohs(jb->target_seq) - 1));
 }
 
 static inline void set_read_seq(switch_jb_t *jb, uint16_t seq)
@@ -930,9 +1010,14 @@ static inline int check_jb_size(switch_jb_t *jb)
 
 		seq_hs = ntohs(np->packet.header.seq);
 		if (target_seq_hs > seq_hs) {
-			hide_node(np, SWITCH_FALSE);
-			old++;
-			continue;
+			const int MAX_DROPOUT = 3000;
+			uint16_t udelta = target_seq_hs - seq_hs;
+			if (udelta > 1 && udelta < MAX_DROPOUT) {
+				// not a sequence id roll-over, this is an old packet, we can hide it
+				hide_node(np, SWITCH_FALSE);
+				old++;
+				continue;
+			}
 		}
 
 		if (count == 0) {
@@ -962,23 +1047,10 @@ static inline int check_jb_size(switch_jb_t *jb)
 
 	/* update the stats every x packets */
 	if (target_seq_hs % 50 == 0) {
-		int packet_ms = jb->jitter.samples_per_frame / (jb->jitter.samples_per_second / 1000);
-
 		jb->jitter.stats.estimate_ms = (*jb->jitter.estimate) / jb->jitter.samples_per_second * 1000;
-		if (jb->channel) {
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_max_ms", "%u", jb->jitter.stats.size_max * packet_ms);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_est_ms", "%u", jb->jitter.stats.size_est * packet_ms);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_acceleration_ms", "%u", jb->jitter.stats.acceleration * packet_ms);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ms", "%u", jb->jitter.stats.expand * packet_ms);
-		}
 
 		if (jb->jitter.stats.jitter_max_ms < jb->jitter.stats.estimate_ms) {
 			jb->jitter.stats.jitter_max_ms = jb->jitter.stats.estimate_ms;
-		}
-
-		if (jb->channel) {
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_max_ms", "%u", jb->jitter.stats.jitter_max_ms);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_est_ms", "%u", jb->jitter.stats.estimate_ms);
 		}
 	}
 
@@ -1004,10 +1076,43 @@ static inline switch_status_t jb_next_packet_by_seq_with_acceleration(switch_jb_
 	   select packet to drop/accelerate. */
 
 	if (jb->elastic && jb->jitter.estimate && (jb->visible_nodes * jb->jitter.samples_per_frame) > 0 && jb->jitter.samples_per_second) {
-		int visible_not_old = check_jb_size(jb);
+		int rfc_estimate_ms;
+		jb->packets_in_buffer = check_jb_size(jb);
 
-		jb->jitter.stats.estimate_ms = (int)((*jb->jitter.estimate) / ((jb->jitter.samples_per_second)) * 1000);
-		jb->jitter.stats.buffer_size_ms = (int)((visible_not_old * jb->jitter.samples_per_frame) / (jb->jitter.samples_per_second / 1000));
+		rfc_estimate_ms = (int)((*jb->jitter.estimate) / ((jb->jitter.samples_per_second)) * 1000);
+		/* Take the larger of the RFC inter_jitter and our arrival-time-based
+		 * estimate. Arrival side uses MAX of fast (~320ms) and slow (~10s) tiers,
+		 * each as mean + 3*sigma — fast catches bursts, slow holds the line. */
+		{
+			int fast_est = (int)(jb->arrival_jitter_ms      + 3.0 * sqrt(jb->arrival_jitter_var));
+			int slow_est = (int)(jb->arrival_jitter_ms_slow + 3.0 * sqrt(jb->arrival_jitter_var_slow));
+			int arrival_est_ms = fast_est > slow_est ? fast_est : slow_est;
+			jb->jitter.stats.estimate_ms = rfc_estimate_ms > arrival_est_ms ? rfc_estimate_ms : arrival_est_ms;
+		}
+		jb->jitter.stats.buffer_size_ms = (int)((jb->packets_in_buffer * jb->jitter.samples_per_frame) / (jb->jitter.samples_per_second / 1000));
+
+		/* If the jitter buffer size is above the its max size, we force accelerate */
+		if (jb->packets_in_buffer >= jb->max_frame_len) {
+			if (packet_vad(jb, packet, len) == SWITCH_FALSE) {
+				jb_debug(jb, SWITCH_LOG_ALERT, "JITTER_BUFFER above max size: [%d>%d] inactive fast acceleration\n", jb->packets_in_buffer, jb->max_frame_len);
+				jb->jitter.drop_gap = 3;
+				jb->jitter.stats.acceleration++;
+				jb->jitter.stats.expand_frame_len--;
+				jb->jitter.stats.fast_acceleration++;
+				return jb_next_packet_by_seq(jb, nodep);
+			} else {
+				if (jb->jitter.drop_gap > 0) {
+					jb->jitter.drop_gap--;
+				} else {
+					jb_debug(jb, SWITCH_LOG_ALERT, "JITTER_BUFFER above max size: [%d>%d] forced acceleration\n", jb->packets_in_buffer, jb->max_frame_len);
+					jb->jitter.drop_gap = 10;
+					jb->jitter.stats.acceleration++;
+					jb->jitter.stats.expand_frame_len--;
+					jb->jitter.stats.forced_acceleration++;
+					return jb_next_packet_by_seq(jb, nodep);
+				}
+			}
+		}
 
 		/* We try to accelerate in order to remove delay when the jitter buffer is 3x larger than the estimation. */
 		if (jb->jitter.stats.buffer_size_ms > (3 * jb->jitter.stats.estimate_ms) && jb->jitter.stats.buffer_size_ms > 60) {
@@ -1025,14 +1130,15 @@ static inline switch_status_t jb_next_packet_by_seq_with_acceleration(switch_jb_
 				if (status != SWITCH_STATUS_SUCCESS || packet_vad(jb, packet, len) == SWITCH_FALSE) {
 					jb->jitter.drop_gap = 3;
 					if (status != SWITCH_STATUS_SUCCESS) {
-						jb_debug(jb, SWITCH_LOG_INFO, "JITTER estimation n/a buffersize %d/%d %dms seq:%u [drop-missing/no-plc]\n",
+						jb_debug(jb, SWITCH_LOG_ALERT, "JITTER estimation n/a buffersize %d/%d %dms seq:%u [drop-missing/no-plc]\n",
 								 jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms, seq);
 					} else {
-						jb_debug(jb, SWITCH_LOG_INFO, "JITTER estimation %dms buffersize %d/%d %dms seq:%u ACCELERATE [drop]\n",
+						jb_debug(jb, SWITCH_LOG_ALERT, "JITTER estimation %dms buffersize %d/%d %dms seq:%u ACCELERATE [drop]\n",
 								 jb->jitter.stats.estimate_ms, jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms, seq);
 					}
 
 					jb->jitter.stats.acceleration++;
+					jb->jitter.stats.expand_frame_len--;
 
 					return jb_next_packet_by_seq(jb, nodep);
 				} else {
@@ -1080,19 +1186,6 @@ SWITCH_DECLARE(void) switch_jb_set_jitter_estimator(switch_jb_t *jb, double *jit
 {
 	if (jb && jitter) {
 		memset(&jb->jitter, 0, sizeof(switch_jb_jitter_t));
-		if (jb->channel) {
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_max_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_acceleration_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_max_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_ms", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_count", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_big", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_missing_frames", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_ts_jump", "%u", 0);
-			switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_error", "%u", 0);
-		}
 
 		jb->jitter.estimate = jitter;
 		jb->jitter.samples_per_frame = samples_per_frame;
@@ -1174,13 +1267,21 @@ SWITCH_DECLARE(void) switch_jb_debug_level(switch_jb_t *jb, uint8_t level)
 SWITCH_DECLARE(void) switch_jb_reset(switch_jb_t *jb)
 {
 	jb->jitter.stats.reset++;
-	if (jb->channel) {
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_count", "%u", jb->jitter.stats.reset);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_big", "%u", jb->jitter.stats.reset_too_big);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_missing_frames", "%u", jb->jitter.stats.reset_missing_frames);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_ts_jump", "%u", jb->jitter.stats.reset_ts_jump);
-		switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_error", "%u", jb->jitter.stats.reset_error);
+	if (jb->media_started) {
+		jb->jitter.stats.reset_runtime++;
+	} else {
+		jb->jitter.stats.reset_setup++;
 	}
+	jb->jitter.stats.expand_frame_len = 0;
+	/* After a reset there's no previous arrival to delta from — clear that.
+	 * Fast tier is per-burst, so reset alongside it.
+	 * Slow tier and clock-drift state survive resets: their whole purpose is
+	 * long-term measurement across the call, so zeroing them on each reset
+	 * would defeat the design (and made our channel-var hangup snapshots
+	 * read as zero when a reset happened near hangup). */
+	jb->last_arrival_us = 0;
+	jb->arrival_jitter_ms = 0;
+	jb->arrival_jitter_var = 0;
 
 	if (jb->type == SJB_VIDEO) {
 		switch_mutex_lock(jb->mutex);
@@ -1230,13 +1331,18 @@ SWITCH_DECLARE(uint32_t) switch_jb_get_nack_success(switch_jb_t *jb)
 	return nack_recovered;
 }
 
-SWITCH_DECLARE(uint32_t) switch_jb_get_packets_per_frame(switch_jb_t *jb) 
+SWITCH_DECLARE(uint32_t) switch_jb_get_packets_per_frame(switch_jb_t *jb)
 {
 	uint32_t ppf;
 	switch_mutex_lock(jb->mutex);
 	ppf = jb->packet_count; /* get current packets per frame */
 	switch_mutex_unlock(jb->mutex);
 	return ppf;
+}
+
+SWITCH_DECLARE(switch_bool_t) switch_jb_is_elastic(switch_jb_t *jb)
+{
+	return jb && jb->elastic ? SWITCH_TRUE : SWITCH_FALSE;
 }
 
 SWITCH_DECLARE(switch_status_t) switch_jb_peek_frame(switch_jb_t *jb, uint32_t ts, uint16_t seq, int peek, switch_frame_t *frame)
@@ -1314,6 +1420,20 @@ SWITCH_DECLARE(switch_status_t) switch_jb_set_frames(switch_jb_t *jb, uint32_t m
 		jb->frame_len = jb->min_frame_len;
 	}
 
+	/* Floor/ceiling just moved - flush the in-flight at-edge timer and re-stamp if still at an edge. */
+	if (jb->jitter.stats.edge_since) {
+		uint32_t held_ms = (uint32_t)((switch_micro_time_now() - jb->jitter.stats.edge_since) / 1000);
+		if (jb->frame_len == jb->min_frame_len) {
+			jb->jitter.stats.at_min_ms += held_ms;
+		} else if (jb->frame_len == jb->max_frame_len) {
+			jb->jitter.stats.at_max_ms += held_ms;
+		}
+		jb->jitter.stats.edge_since = 0;
+	}
+	if (jb->frame_len == jb->min_frame_len || jb->frame_len == jb->max_frame_len) {
+		jb->jitter.stats.edge_since = switch_micro_time_now();
+	}
+
 	switch_mutex_unlock(jb->mutex);
 
 	return SWITCH_STATUS_SUCCESS;
@@ -1337,6 +1457,7 @@ SWITCH_DECLARE(switch_status_t) switch_jb_create(switch_jb_t **jbp, switch_jb_ty
 	jb->pool = pool;
 	jb->type = type;
 	jb->highest_frame_len = jb->frame_len;
+	jb->jitter.stats.edge_since = switch_micro_time_now();
 
 	if (jb->type == SJB_VIDEO) {
 		switch_core_inthash_init(&jb->missing_seq_hash);
@@ -1352,6 +1473,152 @@ SWITCH_DECLARE(switch_status_t) switch_jb_create(switch_jb_t **jbp, switch_jb_ty
 	*jbp = jb;
 
 	return SWITCH_STATUS_SUCCESS;
+}
+
+SWITCH_DECLARE(void) switch_jb_export_stats(switch_jb_t *jb)
+{
+	int packet_ms = 0;
+
+	if (!jb || !jb->channel) {
+		return;
+	}
+
+	switch_mutex_lock(jb->mutex);
+
+	/* Export jitter buffer configuration */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_type", "%s",
+		jb->type == SJB_VIDEO ? "video" : (jb->type == SJB_AUDIO ? "audio" : "text"));
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_min_frame_len", "%u", jb->min_frame_len);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_max_frame_len", "%u", jb->max_frame_len);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_cur_frame_len", "%u", jb->frame_len);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_highest_frame_len", "%u", jb->highest_frame_len);
+
+	/* Export buffer state */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_visible_nodes", "%u", jb->visible_nodes);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_allocated_nodes", "%u", jb->allocated_nodes);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_complete_frames", "%u", jb->complete_frames);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_packets_in_buffer", "%d", jb->packets_in_buffer);
+
+	/* Export miss/hit statistics */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_period_miss_count", "%u", jb->period_miss_count);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_consec_miss_count", "%u", jb->consec_miss_count);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_period_good_count", "%u", jb->period_good_count);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_consec_good_count", "%u", jb->consec_good_count);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_period_miss_pct", "%.2f", jb->period_miss_pct);
+
+	/* Export jitter estimator statistics */
+	if (jb->jitter.samples_per_frame && jb->jitter.samples_per_second) {
+		packet_ms = jb->jitter.samples_per_frame / (jb->jitter.samples_per_second / 1000);
+	}
+
+	if (jb->jitter.estimate && jb->jitter.samples_per_second) {
+		int rfc_estimate_ms = (*jb->jitter.estimate) / jb->jitter.samples_per_second * 1000;
+		int fast_est = (int)(jb->arrival_jitter_ms      + 3.0 * sqrt(jb->arrival_jitter_var));
+		int slow_est = (int)(jb->arrival_jitter_ms_slow + 3.0 * sqrt(jb->arrival_jitter_var_slow));
+		int arrival_est_ms = fast_est > slow_est ? fast_est : slow_est;
+		jb->jitter.stats.estimate_ms = rfc_estimate_ms > arrival_est_ms ? rfc_estimate_ms : arrival_est_ms;
+	}
+
+	if (packet_ms) {
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_max_ms", "%u", jb->jitter.stats.size_max * packet_ms);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_size_est_ms", "%u", jb->jitter.stats.size_est * packet_ms);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_acceleration_ms", "%u", jb->jitter.stats.acceleration * packet_ms);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_fast_acceleration_ms", "%u", jb->jitter.stats.fast_acceleration * packet_ms);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_forced_acceleration_ms", "%u", jb->jitter.stats.forced_acceleration * packet_ms);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ms", "%u", jb->jitter.stats.expand * packet_ms);
+	}
+
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_buffering_skip", "%u", jb->jitter.stats.buffering_skip);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_max_ms", "%u", jb->jitter.stats.jitter_max_ms);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_est_ms", "%u", jb->jitter.stats.estimate_ms);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_mean_ms", "%u", (uint32_t)jb->arrival_jitter_ms);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_sigma_ms", "%u", (uint32_t)sqrt(jb->arrival_jitter_var));
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_mean_slow_ms", "%u", (uint32_t)jb->arrival_jitter_ms_slow);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_jitter_sigma_slow_ms", "%u", (uint32_t)sqrt(jb->arrival_jitter_var_slow));
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_clock_drift_ppm", "%d", (int)jb->arrival_clock_drift_ppm);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_rtp_clock_hz", "%u", jb->arrival_rtp_clock_hz);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_buffer_size_ms", "%u", jb->jitter.stats.buffer_size_ms);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_frame_len", "%d", jb->jitter.stats.expand_frame_len);
+
+	/* Export reset statistics */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_count", "%u", jb->jitter.stats.reset);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_big", "%u", jb->jitter.stats.reset_too_big);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_big_drops", "%u", jb->jitter.stats.reset_too_big_drops);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_expanded", "%u", jb->jitter.stats.reset_too_expanded);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_too_expanded_drops", "%u", jb->jitter.stats.reset_too_expanded_drops);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_missing_frames", "%u", jb->jitter.stats.reset_missing_frames);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_ts_jump", "%u", jb->jitter.stats.reset_ts_jump);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_error", "%u", jb->jitter.stats.reset_error);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_consecutive_miss", "%u", jb->jitter.stats.consecutive_miss);
+
+	/* Export video-specific statistics */
+	if (jb->type == SJB_VIDEO) {
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_nack_saved_the_day", "%u", jb->nack_saved_the_day);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_nack_didnt_save_the_day", "%u", jb->nack_didnt_save_the_day);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_max_packet_len", "%u", jb->max_packet_len);
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_packet_count", "%u", jb->packet_count);
+	}
+
+	/* Export elastic buffer info */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_elastic", "%s", jb->elastic ? "true" : "false");
+
+	/* Flush any in-flight time-at-edge into the cumulative counters.
+	 * Re-stamp edge_since so a later export call doesn't undercount if the JB is still alive. */
+	if (jb->jitter.stats.edge_since) {
+		switch_time_t now = switch_micro_time_now();
+		uint32_t held_ms = (uint32_t)((now - jb->jitter.stats.edge_since) / 1000);
+		if (jb->frame_len == jb->min_frame_len) {
+			jb->jitter.stats.at_min_ms += held_ms;
+			jb->jitter.stats.edge_since = now;
+		} else if (jb->frame_len == jb->max_frame_len) {
+			jb->jitter.stats.at_max_ms += held_ms;
+			jb->jitter.stats.edge_since = now;
+		} else {
+			jb->jitter.stats.edge_since = 0;
+		}
+	}
+
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_grew", "%u", jb->jitter.stats.grew);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_shrunk", "%u", jb->jitter.stats.shrunk);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_grow_to_max", "%u", jb->jitter.stats.grow_to_max);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_at_min_ms", "%u", jb->jitter.stats.at_min_ms);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_at_max_ms", "%u", jb->jitter.stats.at_max_ms);
+
+	/* Setup vs runtime reset split */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_setup", "%u", jb->jitter.stats.reset_setup);
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_reset_runtime", "%u", jb->jitter.stats.reset_runtime);
+
+	/* Lifetime packets seen + expand ratio (pct of audio that was concealed) */
+	switch_channel_set_variable_printf(jb->channel, "rtp_jb_packets_total", "%u", jb->packets_total);
+	{
+		double expand_ratio_pct = 0.0;
+		if (packet_ms && jb->packets_total) {
+			expand_ratio_pct = (double)jb->jitter.stats.expand * 100.0 / (double)jb->packets_total;
+		}
+		switch_channel_set_variable_printf(jb->channel, "rtp_jb_expand_ratio_pct", "%.2f", expand_ratio_pct);
+
+		switch_log_printf(SWITCH_CHANNEL_CHANNEL_LOG(jb->channel), SWITCH_LOG_INFO,
+			"switch_jb_export_stats: type=%s elastic=%s "
+			"frame_len=%u/%u/%u/%u(min/cur/highest/max) "
+			"miss_pct=%.2f consec_miss=%u "
+			"jitter_est_ms=%u jitter_max_ms=%u buffer_size_ms=%u "
+			"reset=%u setup=%u runtime=%u (too_big=%u too_big_drops=%u too_expanded=%u missing_frames=%u ts_jump=%u error=%u) "
+			"grew=%u shrunk=%u grow_to_max=%u at_min_ms=%u at_max_ms=%u "
+			"packets=%u expand_ratio_pct=%.2f\n",
+			jb->type == SJB_VIDEO ? "video" : (jb->type == SJB_AUDIO ? "audio" : "text"),
+			jb->elastic ? "true" : "false",
+			jb->min_frame_len, jb->frame_len, jb->highest_frame_len, jb->max_frame_len,
+			jb->period_miss_pct, jb->consec_miss_count,
+			jb->jitter.stats.estimate_ms, jb->jitter.stats.jitter_max_ms, jb->jitter.stats.buffer_size_ms,
+			jb->jitter.stats.reset, jb->jitter.stats.reset_setup, jb->jitter.stats.reset_runtime,
+			jb->jitter.stats.reset_too_big, jb->jitter.stats.reset_too_big_drops, jb->jitter.stats.reset_too_expanded,
+			jb->jitter.stats.reset_missing_frames, jb->jitter.stats.reset_ts_jump, jb->jitter.stats.reset_error,
+			jb->jitter.stats.grew, jb->jitter.stats.shrunk, jb->jitter.stats.grow_to_max,
+			jb->jitter.stats.at_min_ms, jb->jitter.stats.at_max_ms,
+			jb->packets_total, expand_ratio_pct);
+	}
+
+	switch_mutex_unlock(jb->mutex);
 }
 
 SWITCH_DECLARE(switch_status_t) switch_jb_destroy(switch_jb_t **jbp)
@@ -1485,6 +1752,82 @@ SWITCH_DECLARE(switch_status_t) switch_jb_put_packet(switch_jb_t *jb, switch_rtp
 		jb->highest_dropped_ts = 0;
 	}
 
+	jb->media_started = 1;
+	jb->packets_total++;
+
+	/* Maintain arrival-time-based jitter estimate. Two-tier EWMA + EWMV of
+	 * |actual_interval - ptime|. Fast tier reacts to bursts; slow tier holds
+	 * the line on sustained burstiness past the fast tier's ~320ms memory. */
+	if (jb->jitter.samples_per_frame && jb->jitter.samples_per_second) {
+		switch_time_t now_us = switch_micro_time_now();
+		double delta_ms, ptime_ms, deviation, abs_dev, diff_f, diff_s, drift_ppm;
+		uint32_t rtp_ts_now;
+		int64_t elapsed_us, rtp_us, offset_us;
+
+		if (jb->last_arrival_us) {
+			delta_ms = (double)(now_us - jb->last_arrival_us) / 1000.0;
+			ptime_ms = (double)jb->jitter.samples_per_frame * 1000.0 / (double)jb->jitter.samples_per_second;
+			deviation = delta_ms - ptime_ms;
+			abs_dev = deviation < 0 ? -deviation : deviation;
+			/* Fast tier (α=1/4, ~320ms memory) */
+			diff_f = abs_dev - jb->arrival_jitter_ms;
+			jb->arrival_jitter_ms  += diff_f / 4.0;
+			jb->arrival_jitter_var += (diff_f * diff_f - jb->arrival_jitter_var) / 4.0;
+			/* Slow tier (α=1/128, ~10s memory) */
+			diff_s = abs_dev - jb->arrival_jitter_ms_slow;
+			jb->arrival_jitter_ms_slow  += diff_s / 128.0;
+			jb->arrival_jitter_var_slow += (diff_s * diff_s - jb->arrival_jitter_var_slow) / 128.0;
+		}
+		jb->last_arrival_us = now_us;
+
+		/* Clock-drift tracker — GStreamer-style sliding-min baseline.
+		 *
+		 * Per-packet offset = (recv_us − rtp_us). Without drift, this is a
+		 * constant: the wall-clock time the packet spent in flight plus a
+		 * fixed phase. With drift, it slowly rises (sender ahead) or falls.
+		 *
+		 * Anchoring to packet 1 (our old approach) was fragile: if packet 1
+		 * arrived during a jitter spike, every later sample inherited that
+		 * bias. GStreamer instead tracks min(offset) as the running baseline
+		 * — whenever a packet arrives at a smaller offset, the baseline slides
+		 * down. Drift PPM is then (current_offset − min) / elapsed.
+		 *
+		 * RTP clock rate is inferred from observed timestamps (snapped to
+		 * 8/16/48 kHz) because jitter.samples_per_second is the codec sample
+		 * rate, not the RTP timestamp rate. Opus uses 48000 per RFC 7587. */
+		if (!jb->arrival_first_recv_us) {
+			jb->arrival_first_recv_us = now_us;
+			jb->arrival_first_rtp_ts  = ntohl(packet->header.ts);
+		} else {
+			rtp_ts_now = ntohl(packet->header.ts);
+			elapsed_us = (int64_t)(now_us - jb->arrival_first_recv_us);
+			if (!jb->arrival_rtp_clock_hz && elapsed_us > 3000000) {
+				int64_t rtp_ticks = (int64_t)(rtp_ts_now - jb->arrival_first_rtp_ts);
+				int64_t hz_est = (rtp_ticks * 1000000LL) / elapsed_us;
+				if      (hz_est > 24000) jb->arrival_rtp_clock_hz = 48000;
+				else if (hz_est > 12000) jb->arrival_rtp_clock_hz = 16000;
+				else                     jb->arrival_rtp_clock_hz = 8000;
+			}
+			if (jb->arrival_rtp_clock_hz) {
+				/* Compute current per-packet offset in microseconds. */
+				rtp_us = ((int64_t)(rtp_ts_now - jb->arrival_first_rtp_ts) * 1000000LL)
+				          / (int64_t)jb->arrival_rtp_clock_hz;
+				offset_us = elapsed_us - rtp_us;
+				/* Slide baseline DOWN whenever we see a smaller offset.
+				 * First sample initializes the baseline. */
+				if (!jb->arrival_offset_min_set || offset_us < jb->arrival_offset_min_us) {
+					jb->arrival_offset_min_us  = offset_us;
+					jb->arrival_offset_min_set = 1;
+				}
+				/* Drift PPM relative to sliding baseline. Only compute after
+				 * a warmup window so the baseline has had a chance to settle. */
+				if (elapsed_us > 1000000) {
+					drift_ppm = 1e6 * (double)(offset_us - jb->arrival_offset_min_us) / (double)elapsed_us;
+					jb->arrival_clock_drift_ppm += (drift_ppm - jb->arrival_clock_drift_ppm) / 16.0;
+				}
+			}
+		}
+	}
 
 	if (!want) want = got;
 
@@ -1582,12 +1925,13 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 		switch_goto_status(SWITCH_STATUS_BREAK, end);
 	}
 
-	if (jb->complete_frames < jb->frame_len) {
+	if (!jb->elastic && (jb->complete_frames < jb->frame_len)) {
 
 		switch_jb_poll(jb);
 
 		if (!jb->flush) {
 			jb_debug(jb, 2, "BUFFERING %u/%u\n", jb->complete_frames , jb->frame_len);
+			jb->jitter.stats.buffering_skip++;
 			switch_goto_status(SWITCH_STATUS_MORE_DATA, end);
 		}
 	}
@@ -1596,7 +1940,13 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 
 	if (++jb->period_count >= jb->period_len) {
 
-		if (jb->consec_good_count >= (jb->period_len - 5)) {
+		/* This shrink-on-consecutive-good heuristic is the fixed-size JB controller
+		 * and conflicts with the elastic acceleration/expand feedback (which already
+		 * grows/shrinks frame_len based on estimator-vs-buffer comparisons). On a
+		 * bursty stream the "early" packet of each pair counts as good, climbing
+		 * consec_good_count fast and shrinking the buffer just as expand was trying
+		 * to grow it. Gate to non-elastic only. */
+		if (!jb->elastic && jb->consec_good_count >= (jb->period_len - 5)) {
 			jb_frame_inc(jb, -1);
 		}
 
@@ -1695,16 +2045,46 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 					switch_goto_status(SWITCH_STATUS_RESTART, end);
 				} else {
 					if (jb->elastic) {
-						int visible_not_old = check_jb_size(jb);
-
-						jb->jitter.stats.estimate_ms = (int)((*jb->jitter.estimate) / ((jb->jitter.samples_per_second)) * 1000);
-						jb->jitter.stats.buffer_size_ms = (int)((visible_not_old * jb->jitter.samples_per_frame) / (jb->jitter.samples_per_second / 1000));
+						int rfc_estimate_ms = (int)((*jb->jitter.estimate) / ((jb->jitter.samples_per_second)) * 1000);
+						int fast_est = (int)(jb->arrival_jitter_ms      + 3.0 * sqrt(jb->arrival_jitter_var));
+						int slow_est = (int)(jb->arrival_jitter_ms_slow + 3.0 * sqrt(jb->arrival_jitter_var_slow));
+						int arrival_est_ms = fast_est > slow_est ? fast_est : slow_est;
+						jb->jitter.stats.estimate_ms = rfc_estimate_ms > arrival_est_ms ? rfc_estimate_ms : arrival_est_ms;
+						jb->jitter.stats.buffer_size_ms = (int)((jb->packets_in_buffer * jb->jitter.samples_per_frame) / (jb->jitter.samples_per_second / 1000));
 						/* When playing PLC, we take the oportunity to expand the buffer if the jitter buffer is smaller than the 3x the estimated jitter. */
-						if (jb->jitter.stats.buffer_size_ms < (3 * jb->jitter.stats.estimate_ms)) {
-							jb_debug(jb, SWITCH_LOG_INFO, "JITTER estimation %dms buffersize %d/%d %dms EXPAND [plc]\n",
-									 jb->jitter.stats.estimate_ms, jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms);
+						if (jb->jitter.stats.expand_frame_len < 0) jb->jitter.stats.expand_frame_len = 0;
+
+						if (jb->jitter.stats.expand_frame_len > jb->max_frame_len) {
+							jb_debug(jb, SWITCH_LOG_ALERT, "JITTER  estimation %dms buffersize %d/%d %dms RESET TOO EXPANDED [%d>%d] visible[%u] target seq[%u]\n",
+							   jb->jitter.stats.estimate_ms, jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms,
+							   jb->jitter.stats.expand_frame_len, jb->max_frame_len, jb->visible_nodes, ntohs(jb->target_seq));
+							jb->jitter.stats.reset_too_expanded++;
+							/* Count the queued packets the listener will never hear, mirroring
+							 * reset_too_big_drops accounting. visible_nodes is the count at the
+							 * moment of reset; switch_jb_reset() then hides them all. */
+							jb->jitter.stats.reset_too_expanded_drops += jb->visible_nodes;
+							jb->jitter.stats.expand_frame_len=0;
+							switch_jb_reset(jb);
+							switch_goto_status(SWITCH_STATUS_RESTART, end);
+						} else if (jb->jitter.stats.buffer_size_ms < 40 ||
+								   jb->jitter.stats.buffer_size_ms < (3 * jb->jitter.stats.estimate_ms)) {
+							/* Floor: if we're about to PLC and the buffer is under 40ms, always
+							 * expand. The configured min (often 20ms = 1 packet) leaves zero
+							 * cushion, and the jitter estimator under-reads systematic bursting,
+							 * so the "3x estimate" clause alone often won't trigger expansion
+							 * even when one extra packet of headroom would catch the late
+							 * arrivals we're about to silence. */
+							jb_debug(jb, SWITCH_LOG_ALERT, "JITTER estimation %dms buffersize %d/%d %dms EXPAND [plc] target_seq[%u] expand[%d] now[%ld]\n",
+									 jb->jitter.stats.estimate_ms, jb->complete_frames, jb->frame_len, jb->jitter.stats.buffer_size_ms,
+									 ntohs(jb->target_seq), jb->jitter.stats.expand_frame_len, (int64_t)(switch_micro_time_now()/1000));
 							jb->jitter.stats.expand++;
+							jb->jitter.stats.expand_frame_len++;
 							decrement_seq(jb);
+						} else if (jb->jitter.stats.expand_frame_len >= jb->max_frame_len) {
+							jb->jitter.stats.reset_error++;
+							jb->jitter.stats.expand_frame_len=0;
+							switch_jb_reset(jb);
+							switch_goto_status(SWITCH_STATUS_RESTART, end);
 						} else {
 							jb_debug(jb, 2, "%s", "Frame not found suggest PLC\n");
 						}
@@ -1712,6 +2092,33 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 						jb_debug(jb, 2, "%s", "Frame not found suggest PLC\n");
 					}
 
+					if (jb->elastic) {
+						jb->jitter.stats.consecutive_miss++;
+						/* Too many consecutive missing frames - the JB keeps advancing its
+						 * target but the packets aren't there. Most common cause in this
+						 * deployment is a dead client (browser tab closed, network drop).
+						 * Reset the JB so it re-seeds on the next arrival, but stay elastic:
+						 * if the stream resumes the JB is ready to absorb whatever shape it
+						 * comes back in. Teardown is handled separately by the RTP layer. */
+						if (jb->jitter.stats.consecutive_miss > 100) {
+								jb_debug(jb, SWITCH_LOG_ALERT, "JITTER reset after %u consecutive misses, reset_missing_frames=%u target_seq[%u]\n",
+									jb->jitter.stats.consecutive_miss, jb->jitter.stats.reset_missing_frames + 1, ntohs(jb->target_seq));
+								jb->jitter.stats.reset_missing_frames++;
+								jb->jitter.stats.consecutive_miss=0;
+								/* Raise the minimum buffer floor to 3 frames after a disruption
+								 * serious enough to trigger this reset. Whatever cushion the
+								 * dialplan asked for at setup wasn't enough to keep the JB in
+								 * sync; on the recovery side, give the new stream more headroom. */
+								if (jb->min_frame_len < 3) {
+									jb->min_frame_len = 3;
+									if (jb->frame_len < jb->min_frame_len) {
+										jb->frame_len = jb->min_frame_len;
+									}
+								}
+								switch_jb_reset(jb);
+								switch_goto_status(SWITCH_STATUS_RESTART, end);
+						}
+					}
 					plc = 1;
 					switch_goto_status(SWITCH_STATUS_NOTFOUND, end);
 				}
@@ -1742,6 +2149,8 @@ SWITCH_DECLARE(switch_status_t) switch_jb_get_packet(switch_jb_t *jb, switch_rtp
 
 		packet->header.seq = seq;
 		packet->header.ts = ts;
+	} else {
+		jb->jitter.stats.consecutive_miss=0;
 	}
 
 	switch_mutex_unlock(jb->mutex);

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -6417,7 +6417,7 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 			 * Counts every RTP packet FS got off the wire. Used downstream as
 			 * "what came in" vs out_count "what went out" to expose JB loss. */
 			if (rtp_session->session) {
-				switch_core_session_increment_rx(rtp_session->session);
+				switch_core_session_increment_rx_ingress(rtp_session->session);
 			}
 		}
 	} else {

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -113,6 +113,7 @@ typedef struct {
 	char body[SWITCH_RTP_MAX_BUF_LEN+4+sizeof(char *)];
 	switch_rtp_hdr_ext_t *ext;
 	char *ebody;
+	switch_time_t received_ts;
 } rtp_msg_t;
 
 #define RTP_BODY(_s) (char *) (_s->recv_msg.ebody ? _s->recv_msg.ebody : _s->recv_msg.body)
@@ -543,6 +544,7 @@ struct switch_rtp {
 	int skip_timer;
 	uint32_t prev_nacks_inflight;
 	switch_rtp_inject_dos_t inject_dos;
+	switch_bool_t packet_stats_io_info_set;
 };
 
 struct switch_rtcp_report_block {
@@ -758,6 +760,7 @@ static handle_rfc2833_result_t handle_rfc2833(switch_rtp_t *rtp_session, switch_
 				}
 
 				if (rtp_session->jb && (rtp_session->rtp_bugs & RTP_BUG_FLUSH_JB_ON_DTMF)) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "jb_reset : RTP_BUG_FLUSH_JB_ON_DTMF - ssrc[0x%.8X]\n", rtp_session->ssrc);
 					switch_jb_reset(rtp_session->jb);
 				}
 
@@ -3059,6 +3062,7 @@ SWITCH_DECLARE(void) switch_rtp_reset_jb(switch_rtp_t *rtp_session)
 {
 	if (switch_rtp_ready(rtp_session)) {
 		if (rtp_session->jb) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "switch_jb_reset SWITCH RESET - ssrc[0x%.8X]\n", rtp_session->ssrc);
 			switch_jb_reset(rtp_session->jb);
 		}
 	}
@@ -4568,11 +4572,32 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_change_interval(switch_rtp_t *rtp_ses
 	return status;
 }
 
+static void reset_packet_stats_io_info(switch_rtp_t *rtp_session) {
+	switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
+	const char *uuid=NULL;
+	switch_core_session_t *b_session=NULL;
+	switch_rtp_t *b_rtp_session=NULL;
+
+	rtp_session->packet_stats_io_info_set = SWITCH_FALSE;
+	if (channel) {
+		uuid = switch_channel_get_variable_dup(channel,"bridge_uuid", SWITCH_FALSE, -1);
+	}
+	if (uuid) {
+		b_session = switch_core_session_locate(uuid);
+	}
+	if (b_session) {
+		b_rtp_session = switch_core_media_get_rtp_session(b_session, SWITCH_MEDIA_TYPE_AUDIO);
+		b_rtp_session->packet_stats_io_info_set = SWITCH_FALSE;
+		switch_core_session_rwunlock(b_session);
+	}
+	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO, ">>>> PACKET STATS IO INFO UNSET <<<<\n");
+}
+
 SWITCH_DECLARE(switch_status_t) switch_rtp_set_ssrc(switch_rtp_t *rtp_session, uint32_t ssrc)
 {
 	rtp_session->ssrc = ssrc;
 	rtp_session->send_msg.header.ssrc = htonl(rtp_session->ssrc);
-
+	reset_packet_stats_io_info(rtp_session);
 	return SWITCH_STATUS_SUCCESS;
 }
 
@@ -4580,6 +4605,7 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_set_remote_ssrc(switch_rtp_t *rtp_ses
 {
 	rtp_session->remote_ssrc = ssrc;
 	rtp_session->flags[SWITCH_RTP_FLAG_DETECT_SSRC] = 0;
+	reset_packet_stats_io_info(rtp_session);
 	return SWITCH_STATUS_SUCCESS;
 }
 
@@ -4885,16 +4911,29 @@ SWITCH_DECLARE(switch_jb_t *) switch_rtp_get_jitter_buffer(switch_rtp_t *rtp_ses
 	return rtp_session->jb ? rtp_session->jb : rtp_session->vb;
 }
 
+SWITCH_DECLARE(switch_jb_t *) switch_rtp_get_jitter_buffer_for_stats(switch_rtp_t *rtp_session)
+{
+	/* Bypass ready check - used for stats export during shutdown
+	 * when rtp_session may not be "ready" but JB still exists */
+	if (!rtp_session) {
+		return NULL;
+	}
+
+	return rtp_session->jb ? rtp_session->jb : rtp_session->vb;
+}
+
 SWITCH_DECLARE(switch_status_t) switch_rtp_pause_jitter_buffer(switch_rtp_t *rtp_session, switch_bool_t pause)
 {
 	int new_val;
 
 	if (rtp_session->pause_jb && !pause) {
 		if (rtp_session->jb) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "switch_jb_reset PAUSE - ssrc[0x%.8X]\n", rtp_session->ssrc);
 			switch_jb_reset(rtp_session->jb);
 		}
 
 		if (rtp_session->vb) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "switch_jb_reset PAUSE VB - ssrc[0x%.8X]\n", rtp_session->ssrc);
 			switch_jb_reset(rtp_session->vb);
 		}
 	}
@@ -5386,15 +5425,25 @@ SWITCH_DECLARE(void) switch_rtp_destroy(switch_rtp_t **rtp_session)
 		switch_safe_free(pop);
 	}
 
+	/* Export jitter buffer stats before destroying them */
 	if ((*rtp_session)->jb) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG((*rtp_session)->session), SWITCH_LOG_INFO,
+			"switch_rtp_destroy: exporting audio JB stats before destroy\n");
+		switch_jb_export_stats((*rtp_session)->jb);
 		switch_jb_destroy(&(*rtp_session)->jb);
 	}
 
 	if ((*rtp_session)->vb) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG((*rtp_session)->session), SWITCH_LOG_INFO,
+			"switch_rtp_destroy: exporting video JB stats before destroy\n");
+		switch_jb_export_stats((*rtp_session)->vb);
 		switch_jb_destroy(&(*rtp_session)->vb);
 	}
 
 	if ((*rtp_session)->vbw) {
+		switch_log_printf(SWITCH_CHANNEL_SESSION_LOG((*rtp_session)->session), SWITCH_LOG_INFO,
+			"switch_rtp_destroy: exporting video write JB stats before destroy\n");
+		switch_jb_export_stats((*rtp_session)->vbw);
 		switch_jb_destroy(&(*rtp_session)->vbw);
 	}
 
@@ -5580,6 +5629,7 @@ SWITCH_DECLARE(void) switch_rtp_set_flag(switch_rtp_t *rtp_session, switch_rtp_f
 
 
 		if (rtp_session->jb) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO, "switch_jb_reset SET FLAG - ssrc[0x%.8X]\n", rtp_session->ssrc);
 			switch_jb_reset(rtp_session->jb);
 		}
 	} else if (flag == SWITCH_RTP_FLAG_NOBLOCK && rtp_session->sock_input) {
@@ -5873,6 +5923,7 @@ static switch_size_t do_flush(switch_rtp_t *rtp_session, int force, switch_size_
 		}
 
 		if (rtp_session->vbw) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "switch_jb_reset VBW - ssrc[0x%.8X]\n", rtp_session->ssrc);
 			switch_jb_reset(rtp_session->vbw);
 		}
 
@@ -6239,6 +6290,43 @@ static inline void switch_rtp_inject_dos_tick(switch_rtp_t *rtp_session)
 	return;
 }
 
+static void set_packet_stats_io_info(switch_rtp_t *rtp_session) {
+	switch_channel_t *channel = switch_core_session_get_channel(rtp_session->session);
+	const char *uuid=NULL;
+	switch_core_session_t *b_session=NULL;
+	switch_rtp_t *b_rtp_session=NULL;
+	switch_channel_t *b_channel=NULL;
+	if (rtp_session->packet_stats_io_info_set)
+		return;
+	if (channel) {
+		uuid = switch_channel_get_variable_dup(channel,"bridge_uuid", SWITCH_FALSE, -1);
+	}
+	if (uuid) {
+		b_session = switch_core_session_locate(uuid);
+	}
+	if (b_session) {
+		b_rtp_session = switch_core_media_get_rtp_session(b_session, SWITCH_MEDIA_TYPE_AUDIO);
+		b_channel = switch_core_session_get_channel(b_session);
+		switch_core_session_rwunlock(b_session);
+
+		if (b_rtp_session && b_channel) {
+			packet_stats_io_info_t packet_stats_io_info;
+			packet_stats_io_info.out_ssrc = b_rtp_session->ssrc;
+			packet_stats_io_info.out_codec = '\0';
+			packet_stats_io_info.out_remote_addr = b_rtp_session->remote_addr;
+			packet_stats_io_info.out_local_addr = b_rtp_session->local_addr;
+
+			packet_stats_io_info.in_ssrc = rtp_session->remote_ssrc;
+			packet_stats_io_info.in_codec = '\0';
+			packet_stats_io_info.in_remote_addr = rtp_session->remote_addr;
+			packet_stats_io_info.in_local_addr = rtp_session->local_addr;
+			if (rtp_session->remote_ssrc && b_rtp_session->ssrc)
+				rtp_session->packet_stats_io_info_set = SWITCH_TRUE;
+			switch_core_session_set_io_stats(b_rtp_session->session, &packet_stats_io_info);
+		}
+	}
+}
+
 static switch_bool_t rtp_is_remote_address_advertised_host(switch_rtp_t *rtp_session, const char *tx_host)
 {
 	return (!zstr(rtp_session->remote_host_str) && !strcasecmp(rtp_session->remote_host_str, tx_host));
@@ -6263,8 +6351,13 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 
 	tries++;
 
-	if (tries > 20) {
+	/* Bail out of the more: loop after 20 tries. The elastic JB is the only
+	 * legitimate reason to keep spinning past that — its acceleration path
+	 * needs the extra reads to drain a burst. Anything else (no JB, fixed-size
+	 * JB, or an EJB that has self-disabled) must take the safety break. */
+	if (tries > 20 && !switch_jb_is_elastic(rtp_session->jb)) {
 		if (rtp_session->jb && !rtp_session->pause_jb && jb_valid(rtp_session)) {
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "switch_jb_reset TRIES > 20 ssrc[0x%.8X]\n", rtp_session->ssrc);
 			switch_jb_reset(rtp_session->jb);
 		}
 		rtp_session->punts++;
@@ -6318,6 +6411,15 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 
 	if (poll_status == SWITCH_STATUS_SUCCESS) {
 		status = switch_socket_recvfrom(rtp_session->from_addr, rtp_session->sock_input, 0, (void *) &rtp_session->recv_msg, bytes);
+		if (*bytes) {
+			rtp_session->recv_msg.received_ts = switch_micro_time_now();
+			/* Physical packet receive point — same instant we stamp received_ts.
+			 * Counts every RTP packet FS got off the wire. Used downstream as
+			 * "what came in" vs out_count "what went out" to expose JB loss. */
+			if (rtp_session->session) {
+				switch_core_session_increment_rx(rtp_session->session);
+			}
+		}
 	} else {
 		*bytes = 0;
 	}
@@ -6945,15 +7047,25 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 	if (rtp_session->flags[SWITCH_RTP_FLAG_KILL_JB]) {
 		rtp_session->flags[SWITCH_RTP_FLAG_KILL_JB] = 0;
 
+		/* Export jitter buffer stats before destroying them */
 		if (rtp_session->jb) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
+				"KILL_JB: exporting audio JB stats before destroy\n");
+			switch_jb_export_stats(rtp_session->jb);
 			switch_jb_destroy(&rtp_session->jb);
 		}
 
 		if (rtp_session->vb) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
+				"KILL_JB: exporting video JB stats before destroy\n");
+			switch_jb_export_stats(rtp_session->vb);
 			switch_jb_destroy(&rtp_session->vb);
 		}
 
 		if (rtp_session->vbw) {
+			switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_INFO,
+				"KILL_JB: exporting video write JB stats before destroy\n");
+			switch_jb_export_stats(rtp_session->vbw);
 			switch_jb_destroy(&rtp_session->vbw);
 		}
 
@@ -6983,6 +7095,7 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 
 		if (rtp_session->jb && jb_valid(rtp_session)) {
 			if (rtp_session->last_jb_read_ssrc && rtp_session->last_jb_read_ssrc != read_ssrc) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "switch_jb_reset SSRC change - ssrc[0x%.8X]\n", rtp_session->ssrc);
 				switch_jb_reset(rtp_session->jb);
 			}
 
@@ -7099,7 +7212,7 @@ static switch_status_t read_rtp_packet(switch_rtp_t *rtp_session, switch_size_t 
 			}
 		}
 	}
-
+	set_packet_stats_io_info(rtp_session);
 	return status;
 }
 
@@ -7794,7 +7907,7 @@ static int rtp_common_read(switch_rtp_t *rtp_session, switch_payload_t *payload_
 			rtp_session->read_pollfd) {
 
 			if (rtp_session->jb && !rtp_session->pause_jb && jb_valid(rtp_session)) {
-				while (switch_poll(rtp_session->read_pollfd, 1, &fdr, 0) == SWITCH_STATUS_SUCCESS) {
+				while (switch_rtp_ready(rtp_session) && switch_poll(rtp_session->read_pollfd, 1, &fdr, 0) == SWITCH_STATUS_SUCCESS) {
 					status = read_rtp_packet(rtp_session, &bytes, flags, pmapP, SWITCH_STATUS_SUCCESS, SWITCH_FALSE);
 
 					if (status == SWITCH_STATUS_GENERR) {
@@ -8687,6 +8800,8 @@ SWITCH_DECLARE(switch_status_t) switch_rtp_zerocopy_read_frame(switch_rtp_t *rtp
 			switch_set_flag(frame, SFF_RFC2833);
 		}
 		frame->timestamp = ntohl(rtp_session->last_rtp_hdr.ts);
+
+		frame->received_ts = rtp_session->recv_msg.received_ts;
 		frame->seq = (uint16_t) ntohs((uint16_t) rtp_session->last_rtp_hdr.seq);
 		frame->ssrc = ntohl(rtp_session->last_rtp_hdr.ssrc);
 		frame->m = rtp_session->last_rtp_hdr.m ? SWITCH_TRUE : SWITCH_FALSE;
@@ -9094,7 +9209,7 @@ static int rtp_common_write(switch_rtp_t *rtp_session,
 		rtp_session->seq += delta;
 
 		send_msg->header.seq = htons(rtp_session->seq);
-		
+
 		if (rtp_session->flags[SWITCH_RTP_FLAG_BYTESWAP] && send_msg->header.pt == rtp_session->payload) {
 			switch_swap_linear((int16_t *)send_msg->body, (int) datalen);
 		}


### PR DESCRIPTION
## Summary

Rework of the elastic jitter buffer and the surrounding instrumentation
needed to distinguish JB-induced audio loss from carrier-side loss.
Restructured from prior JB-only history into 4 logical commits:

1. **[Core] EJB: add per-leg RTP packet statistics** —
   `packet_stats_t` on the session plus counters wired through the RTP
   read path, bridge, and state machine. Adds the `in_rx` counter
   (packets received pre-JB) that the damage model joins against
   bridge/JB writes.

2. **[Codec] Opus: per-call PLC/FEC stats and run-length classification** —
   Codec-truth PLC/FEC counters exported as
   `opus_decoder_frames/plc/fec`. Gap-tolerant run-length
   classification splits PLC into `plc_short` (≤60ms, inaudible) and
   `plc_long` (>60ms, audible comfort noise).

3. **[Core] EJB: elastic jitter buffer overhaul** — the core rework:
   - Two-tier EWMA+EWMV jitter estimator (fast ~320ms + slow ~10s),
     exported as `jitter_mean_ms`, `sigma_ms`, and `_slow_ms` variants.
   - Clock-drift tracker with sliding-min baseline (survives
     `switch_jb_reset`), logged as ppm.
   - Categorized reset accounting: `reset_too_big`, `reset_too_expanded`,
     `reset_missing_frames`, plus `buffering_skip` and `expand_ms`.
   - Expand floor and "keep elastic on miss" to avoid collapsing the
     EJB on brief gaps.
   - `switch_jb_is_elastic()` and `switch_jb_export_stats()` for
     hangup-time per-leg export.

4. **[Core] Media: export inbound sequence-loss counters** —
   `rtp_audio_in_cum_lost` and `rtp_audio_in_expected_pkt` channel
   variables from the RTCP receiver-report path, so `cum_lost /
   expected_pkt` gives the true inbound loss rate independent of JB
   behavior. Populated only when `rtcp-audio-interval-msec` is set.

## Damage model

Together these expose enough state to separate three sources of audio
loss on a call:

- **Carrier-side loss** — `rtp_audio_in_cum_lost / expected_pkt`
- **JB-side silence loss** — `max(0, in_rx − jb_out − plc)`
- **Concealment** — split into inaudible (`plc_short`) and audible
  (`plc_long`) via opus run-length classification

## Testing

Validated in canary via A/B testing (EJB on vs off), using the counters
introduced in commits 1–4 to compare per-leg audio quality on matched
call volumes. Key findings:

- **Non-elastic JB drifts under load.** Per-packet delay is more likely
  to accumulate over the call, resulting in roughly 2× the per-call max
  delay compared with EJB (bucket-level p95: EJB-off ~1640ms vs EJB-on
  ~520ms).
- **PLC counts alone under-count audible damage.** The honest metric
  is `silence + plc_long`, where `silence = max(0, in_rx − jb_out −
  plc)` captures JB-side loss and `plc_long` (>60ms runs) is the
  audible portion of concealment. `plc_short` is inaudible spectral
  interpolation and should not be counted as damage.
- **RTCP-derived `cum_lost / expected_pkt`** cleanly separates
  carrier-side loss (upstream of FS) from JB-side loss, so
  regressions can be attributed correctly.
- **EJB reset baseline:** ~5 setup + ~2 runtime resets per call are
  normal when the categorized `reset_*` counters are all zero; the
  categorized counters isolate pathological cases (`reset_too_big`,
  `reset_too_expanded`, `reset_missing_frames`).
