### PR TITLE
mod_shell_stream: flush inherited stdio buffers in child before dup2 to stop console log leaking into the audio pipe

### DIFF
--- a/src/mod/formats/mod_shell_stream/mod_shell_stream.c
+++ b/src/mod/formats/mod_shell_stream/mod_shell_stream.c
@@ -142,6 +142,16 @@ static switch_status_t shell_stream_file_open(switch_file_handle_t *handle, cons
 			goto end;
 		} else {				/*  child */
 			close(context->fds[0]);
+
+			/* Flush the stdout/stderr buffers inherited from the parent BEFORE
+			 * dup2'ing them to the pipe. Otherwise the grandchild spawned by
+			 * switch_system()/system() flushes the inherited buffered console
+			 * log text into the audio pipe at exit, and the playback pump
+			 * plays those log bytes as audio, producing a pop/clip noise at
+			 * the end of the stream. */
+			fflush(stdout);
+			fflush(stderr);
+
 			dup2(context->fds[1], STDOUT_FILENO);
 			switch_system(context->command, SWITCH_TRUE);
 			printf("EOF");


### PR DESCRIPTION
## Description

Fixes pop/clip noise at the end of every `shell_stream://` playback (see #3120).

The child branch forks from the parent while FreeSWITCH console logs (e.g. sofia's `hash(insert/...last_dial/...)` notices) are still sitting in the block-buffered stdout `FILE*` stream. The sequence:

1. `fprintf(runtime.console = stdout)` buffers console log text, not flushed yet
2. `switch_fork()` — the child **inherits a copy of the buffered data**
3. `dup2(fds[1], STDOUT_FILENO)` points stdout at the audio pipe
4. `switch_system()` forks a grandchild that runs `system(dcmd)` (the audio source); when it `exit(0)`s, **stdio flushes the inherited stdout buffer into the audio pipe**
5. The playback pump plays those log bytes as audio → tail pop/clip

This patch flushes `stdout`/`stderr` in the child **before** the `dup2`, so there is nothing buffered to leak into the pipe. The flush must happen before `dup2`, otherwise the logs get flushed into the pipe.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #3120

## Testing

- [x] Tested manually (verified on 1.10.12 in a Docker container, 24 kHz L16 → 8 kHz alaw)

With a pure-silence repro (`shell_stream://sh -c "dd if=/dev/zero bs=24000 count=4"`), the pipe previously contained 1,145 bytes of log text after the 96,000 bytes of stream data, e.g.:

```
pipe read=1145 first=5d20736f6669612f last=0a1b5b6d   ("] sofia/..." ... "\n\x1b[m")
```

After the fix the pipe contains exactly the stream data, RTP capture shows a clean silence tail, and the audible pop is gone. Note this is a different failure mode than #3104 (blocking `wait()` in `file_open`): that one is addressed separately.

Note: `master`'s `printf("EOF")` sentinel and 1.10.12's `read()==0` end-of-stream both leave the leak path intact; flushing in the child fixes the leak for both.