### PR TITLE
[mod_lua] Guard JSON::execute2() against NULL cJSON output

### DIFF
--- a/src/mod/languages/mod_lua/freeswitch_lua.cpp
+++ b/src/mod/languages/mod_lua/freeswitch_lua.cpp
@@ -786,7 +786,7 @@ std::string JSON::execute2(const char *str)
 {
     cJSON *reply = execute(str);
     char *s = _return_unformatted_json ? cJSON_PrintUnformatted(reply) : cJSON_Print(reply);
-    std::string result = std::string(s);
+    std::string result = std::string(s ? s : "");
     free(s);
     cJSON_Delete(reply);
     return result;
@@ -796,7 +796,7 @@ std::string JSON::execute2(SWIGLUA_TABLE table)
 {
     cJSON *reply = execute(table);
     char *s = _return_unformatted_json ? cJSON_PrintUnformatted(reply) : cJSON_Print(reply);
-    std::string result = std::string(s);
+    std::string result = std::string(s ? s : "");
     free(s);
     cJSON_Delete(reply);
     return result;


### PR DESCRIPTION
mod_lua's JSON::execute2() crashes the whole FreeSWITCH process with SIGSEGV whenever the underlying switch_json_api_execute() call returns no reply.

## Root cause

src/mod/languages/mod_lua/freeswitch_lua.cpp (JSON::execute2, both the const char * and SWIGLUA_TABLE overloads):

`cpp
cJSON *reply = execute(str);
char *s = _return_unformatted_json ? cJSON_PrintUnformatted(reply) : cJSON_Print(reply);
std::string result = std::string(s);   /* <-- std::string(NULL) -> SIGSEGV */
`

When the JSON API command fails / does not exist, switch_json_api_execute() leaves eply == NULL. cJSON_Print(NULL) / cJSON_PrintUnformatted(NULL) then return NULL, and passing NULL to the std::string constructor is undefined behavior - on Linux it dereferences NULL and raises SIGSEGV, taking down every active call.

## Fix

Null-check the pointer before constructing the std::string in both overloads:

`cpp
std::string result = std::string(s ? s : "");
`

ree(NULL) and cJSON_Delete(NULL) are already safe no-ops, so the only unsafe spot was the std::string construction. A failed API call now yields an empty string instead of crashing the process.

## Testing

- Reproduced on master: luarun invoking reeswitch.JSON():execute('{ "command": "no_such_command" }') segfaults mod_lua.
- With the fix, the same call returns an empty string and the process stays up.
- Builds cleanly; no behavioral change for the success path.

Resolves: #3124