### PR TITLE
[docker] Fix ERLANG_EXITS typo in healthcheck script

### DIFF
--- a/docker/base_image/healthcheck.sh
+++ b/docker/base_image/healthcheck.sh
@@ -32,9 +32,9 @@ fs_cli -x status | grep -q ^UP || exit 1
 
 # Check erlang related modules is registered on epmd daemon
 KAZOO_EXIST=$(fs_cli -x "module_exists mod_kazoo")
-ERLANG_EXITS=$(fs_cli -x "module_exists mod_erlang_event")
+ERLANG_EXIST=$(fs_cli -x "module_exists mod_erlang_event")
 
-if [ "$KAZOO_EXIST" == "true" -o "$ERLANG_EXITS" == "true" ]; then
+if [ "$KAZOO_EXIST" == "true" -o "$ERLANG_EXIST" == "true" ]; then
     /usr/bin/epmd -names | grep -qE "^name freeswitch at port" || exit 1
 fi
 


### PR DESCRIPTION
The Docker healthcheck script `docker/base_image/healthcheck.sh` contains a variable name typo: `ERLANG_EXITS` should be `ERLANG_EXIST`.

## Root cause

Line 35 assigns the variable as `ERLANG_EXITS`, and line 37 references it as `$ERLANG_EXITS`. While the script is internally consistent (the same misspelled name is used in both places, so the script works), the name is clearly intended to be `ERLANG_EXIST` to match the sibling variable `KAZOO_EXIST` on line 34, and to reflect the actual meaning (checking whether the module _exists_).

## Fix

Rename `ERLANG_EXITS` to `ERLANG_EXIST` in both the assignment (line 35) and the conditional check (line 37).

## Testing

- Verified the script logic is unchanged: the variable is renamed consistently in both the assignment and the usage.
- No behavioral change — the script was already working because the same (misspelled) name was used throughout.

Resolves: #3126