### PR TITLE
[mod_sofia] Pass api_on_ prefix to switch_channel_api_on in sofia_glue_set_extra_headers

### DIFF
--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -967,6 +967,7 @@ void sofia_glue_set_extra_headers(switch_core_session_t *session, sip_t const *s
 
 	switch_snprintf(pstr, sizeof(pstr), "execute_on_%sprefix", prefix);
 	switch_channel_execute_on(channel, pstr);
+	switch_snprintf(pstr, sizeof(pstr), "api_on_%sprefix", prefix);
 	switch_channel_api_on(channel, pstr);
 
 	switch_channel_execute_on(channel, "execute_on_sip_extra_headers");


### PR DESCRIPTION
`sofia_glue_set_extra_headers()` built a single `execute_on_<prefix>prefix` variable name and passed it to both `switch_channel_execute_on()` and `switch_channel_api_on()`.

Both functions match channel variables by prefix (`strncasecmp(var, variable_prefix, strlen(variable_prefix))` in `src/switch_channel.c`), so `switch_channel_api_on()` also matched the `execute_on_*` variables and ran their values a second time as API commands. API commands have no session context, so scripts invoked this way saw a NULL session, and any logic in an `execute_on_sip_ph_prefix` / `execute_on_sip_rh_prefix` (and other SIP header prefix) hook ran twice per SIP message.

Build the `api_on_<prefix>prefix` variable name before calling `switch_channel_api_on()`, matching the pattern already used for `execute_on_sip_extra_headers` / `api_on_sip_extra_headers` just below.

Resolves: #3005