### PR TITLE
[mod_conference] Disable auto recording when the recording file cannot be opened

### DIFF
--- a/src/mod/applications/mod_conference/conference_record.c
+++ b/src/mod/applications/mod_conference/conference_record.c
@@ -285,6 +285,14 @@ void *SWITCH_THREAD_FUNC conference_record_thread_run(switch_thread_t *thread, v
 			switch_event_fire(&event);
 		}
 
+		if (rec->autorec) {
+			/* The conference loop starts auto recording again as soon as auto_recording drops back to
+			 * 0, so leaving auto_record set here would spin the thread up again on every pass. Disable
+			 * it the same way conference_record_stop() does when auto recording is stopped by hand. */
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_CRIT, "Auto Recording Disabled, could not open [%s]\n", rec->path);
+			conference->auto_record = 0;
+		}
+
 		goto end;
 	}
 


### PR DESCRIPTION
When a conference has `auto-record` set and the recording file cannot be opened (remote storage unavailable, unwritable path, permissions), the recording thread logs the error and exits, and the conference loop immediately starts it again.

The loop in `mod_conference.c` starts auto recording whenever `auto_record` is set and `auto_recording` is 0, and it raises `auto_recording` before the thread is launched. The thread drops it again in its cleanup path when `switch_core_file_open()` fails, so the next pass through the loop sees `auto_recording == 0` and starts another thread. Each pass fires a `start-recording` and a `stop-recording` event and burns CPU, repeating for as long as the file stays unwritable.

Disable auto recording for the conference when the open fails, the same way `conference_record_stop()` already does when auto recording is stopped by hand (`conference->auto_record = 0`), and log it at CRIT so the condition is visible to the operator. The conference keeps running with recording off instead of looping.

Only auto recordings are affected: a manual `conference record` that fails to open its file leaves `auto_record` untouched.

Resolves: #2888