### PR TITLE
[mod_sofia] add ACL authentication for SUBSCRIBE

### DIFF
--- a/src/mod/endpoints/mod_sofia/conf/sofia.conf.xml
+++ b/src/mod/endpoints/mod_sofia/conf/sofia.conf.xml
@@ -340,6 +340,8 @@
              By default authentication is enabled.
              disable-auth-subscriptions param has higher priority than the deprecated auth-subscriptions param. -->
         <!-- <param name="disable-auth-subscriptions" value="true"/> -->
+        <!-- Allow SUBSCRIBE requests from this ACL without SIP Digest authentication. -->
+        <!-- <param name="apply-subscribe-acl" value="list"/> -->
 
         <!-- external_sip_ip
              Used as the public IP address for SDP.

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -737,6 +737,8 @@ struct sofia_profile {
 	char *acl_pass_context[SOFIA_MAX_ACL];
 	char *acl_fail_context[SOFIA_MAX_ACL];
 	uint32_t acl_count;
+	char *subscribe_acl[SOFIA_MAX_ACL];
+	uint32_t subscribe_acl_count;
 	char *proxy_acl[SOFIA_MAX_ACL];
 	uint32_t proxy_acl_count;
 	char *reg_acl[SOFIA_MAX_ACL];

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -4693,6 +4693,7 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 
 					/* you could change profile->foo here if it was a minor change like context or dialplan ... */
 					profile->acl_count = 0;
+					profile->subscribe_acl_count = 0;
 					profile->nat_acl_count = 0;
 					profile->reg_acl_count = 0;
 					profile->proxy_acl_count = 0;
@@ -5748,6 +5749,14 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 
 						} else {
 							switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Max acl records of %d reached\n", SOFIA_MAX_ACL);
+						}
+					} else if (!strcasecmp(var, "apply-subscribe-acl") && !zstr(val)) {
+						if (!strcasecmp(val, "none")) {
+							profile->subscribe_acl_count = 0;
+						} else if (profile->subscribe_acl_count < SOFIA_MAX_ACL) {
+							profile->subscribe_acl[profile->subscribe_acl_count++] = switch_core_strdup(profile->pool, val);
+						} else {
+							switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Max subscribe acl records of %d reached\n", SOFIA_MAX_ACL);
 						}
 					} else if (!strcasecmp(var, "apply-proxy-acl") && !zstr(val)) {
 						if (!strcasecmp(val,"none")) {

--- a/src/mod/endpoints/mod_sofia/sofia_presence.c
+++ b/src/mod/endpoints/mod_sofia/sofia_presence.c
@@ -3689,6 +3689,7 @@ void sofia_presence_handle_sip_i_subscribe(int status,
 	char *p;
 	uint32_t callsequence;
     sip_cseq_t * cseq;
+	int acl_authenticated = 0;
 
 	if (!sip) {
 		return;
@@ -3731,6 +3732,26 @@ void sofia_presence_handle_sip_i_subscribe(int status,
 	}
 
 	event = sip_header_as_string(nua_handle_get_home(nh), (void *) sip->sip_event);
+
+	if (profile->subscribe_acl_count) {
+		char network_ip[80];
+		int network_port;
+		int acl_port;
+		uint32_t x;
+
+		sofia_glue_get_addr(de->data->e_msg, network_ip, sizeof(network_ip), &network_port);
+		acl_port = sofia_test_pflag(profile, PFLAG_USE_PORT_FOR_ACL_CHECK) ? network_port : 0;
+
+		for (x = 0; x < profile->subscribe_acl_count; x++) {
+			if (switch_check_network_list_ip_port_token(network_ip, acl_port, profile->subscribe_acl[x], NULL)) {
+				switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG,
+								  "SUBSCRIBE from %s:%d approved by subscribe ACL \"%s\". Access Granted.\n",
+								  network_ip, network_port, profile->subscribe_acl[x]);
+				acl_authenticated = 1;
+				break;
+			}
+		}
+	}
 
 	if (to) {
 		to_str = switch_mprintf("sip:%s@%s", to->a_url->url_user, to->a_url->url_host);
@@ -3775,7 +3796,7 @@ void sofia_presence_handle_sip_i_subscribe(int status,
 
 	switch_snprintf(exp_delta_str, sizeof(exp_delta_str), "%ld", exp_delta);
 
-	if (!strcmp("as-feature-event", event)) {
+	if (!acl_authenticated && !strcmp("as-feature-event", event)) {
 		sip_authorization_t const *authorization = NULL;
 		auth_res_t auth_res = AUTH_FORBIDDEN;
 		char key[128] = "";
@@ -3805,7 +3826,7 @@ void sofia_presence_handle_sip_i_subscribe(int status,
 			nua_respond(nh, SIP_401_UNAUTHORIZED, NUTAG_WITH_THIS_MSG(de->data->e_msg), TAG_END());
 			goto end;
 		}
-	} else if (sofia_test_pflag(profile, PFLAG_AUTH_SUBSCRIPTIONS)) {
+	} else if (!acl_authenticated && sofia_test_pflag(profile, PFLAG_AUTH_SUBSCRIPTIONS)) {
 		sip_authorization_t const *authorization = NULL;
 		auth_res_t auth_res = AUTH_FORBIDDEN;
 		char keybuf[128] = "";


### PR DESCRIPTION
## Description
Adds a profile-level apply-subscribe-acl setting for SUBSCRIBE requests.

Requests from a configured trusted ACL bypass SIP Digest authentication; requests from other sources retain existing authentication behavior. This allows trusted SIP infrastructure to create subscriptions without requiring sip credentials.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [x] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
