### PR TITLE
[mod_hiredis] Add username support for Redis ACL authentication

### DIFF
--- a/conf/vanilla/autoload_configs/hiredis.conf.xml
+++ b/conf/vanilla/autoload_configs/hiredis.conf.xml
@@ -4,6 +4,8 @@
       <connections>
 	<connection name="primary">
 	  <param name="hostname" value="172.18.101.101"/>
+	  <!-- Optional ACL username (Redis 6+). If omitted, AUTH uses the default user. -->
+	  <!-- <param name="username" value="freeswitch"/> -->
 	  <param name="password" value="redis"/>	
 	  <param name="port" value="6379"/>
 	  <param name="timeout_ms" value="500"/>

--- a/src/mod/applications/mod_hiredis/hiredis_profile.c
+++ b/src/mod/applications/mod_hiredis/hiredis_profile.c
@@ -32,12 +32,17 @@
 
 #include <mod_hiredis.h>
 
-/* auth if password is set */
+/* auth if password is set, using the configured ACL username if present */
 static switch_status_t hiredis_context_auth(hiredis_context_t *context)
 {
 	switch_status_t status = SWITCH_STATUS_SUCCESS;
 	if ( !zstr(context->connection->password) ) {
-		redisReply *response = redisCommand(context->context, "AUTH %s", context->connection->password);
+		redisReply *response;
+		if ( !zstr(context->connection->username) ) {
+			response = redisCommand(context->context, "AUTH %s %s", context->connection->username, context->connection->password);
+		} else {
+			response = redisCommand(context->context, "AUTH %s", context->connection->password);
+		}
 		if ( !response || response->type == REDIS_REPLY_ERROR ) {
 			status = SWITCH_STATUS_FALSE;
 		}
@@ -163,12 +168,13 @@ switch_status_t hiredis_profile_destroy(hiredis_profile_t **old_profile)
 	return SWITCH_STATUS_SUCCESS;
 }
 
-switch_status_t hiredis_profile_connection_add(hiredis_profile_t *profile, char *host, char *password, uint32_t port, uint32_t timeout_ms, uint32_t max_contexts)
+switch_status_t hiredis_profile_connection_add(hiredis_profile_t *profile, char *host, char *username, char *password, uint32_t port, uint32_t timeout_ms, uint32_t max_contexts)
 {
 	hiredis_connection_t *connection = NULL, *new_conn = NULL;
 
 	new_conn = switch_core_alloc(profile->pool, sizeof(hiredis_connection_t));
 	new_conn->host = host ? switch_core_strdup(profile->pool, host) : "localhost";
+	new_conn->username = username ? switch_core_strdup(profile->pool, username) : NULL;
 	new_conn->password = password ? switch_core_strdup(profile->pool, password) : NULL;
 	new_conn->port = port ? port : 6379;
 	new_conn->pool = profile->pool;

--- a/src/mod/applications/mod_hiredis/hiredis_utils.c
+++ b/src/mod/applications/mod_hiredis/hiredis_utils.c
@@ -80,7 +80,7 @@ switch_status_t mod_hiredis_do_config()
 			/* Add connection to profile */
 			if ( (connections = switch_xml_child(profile, "connections")) != NULL) {
 				for (connection = switch_xml_child(connections, "connection"); connection; connection = connection->next) {
-					char *host = NULL, *password = NULL;
+					char *host = NULL, *username = NULL, *password = NULL;
 					uint32_t port = 0, timeout_ms = 0, max_connections = 0;
 
 					for (param = switch_xml_child(connection, "param"); param; param = param->next) {
@@ -92,6 +92,8 @@ switch_status_t mod_hiredis_do_config()
 							switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_NOTICE, "hiredis: adding conn[%u == %s]\n", port, switch_xml_attr_soft(param, "value"));
 						} else if ( !strncmp(var, "timeout-ms", 10) || !strncmp(var, "timeout_ms", 10) ) {
 							timeout_ms = atoi(switch_xml_attr_soft(param, "value"));
+						} else if ( !strncmp(var, "username", 8) ) {
+							username = (char *) switch_xml_attr_soft(param, "value");
 						} else if ( !strncmp(var, "password", 8) ) {
 							password = (char *) switch_xml_attr_soft(param, "value");
 						} else if ( !strncmp(var, "max-connections", 15) ) {
@@ -99,7 +101,7 @@ switch_status_t mod_hiredis_do_config()
 						}
 					}
 
-					if ( hiredis_profile_connection_add(new_profile, host, password, port, timeout_ms, max_connections) == SWITCH_STATUS_SUCCESS) {
+					if ( hiredis_profile_connection_add(new_profile, host, username, password, port, timeout_ms, max_connections) == SWITCH_STATUS_SUCCESS) {
 						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Created profile[%s]\n", name);
 					} else {
 						switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Failed to create profile[%s]\n", name);

--- a/src/mod/applications/mod_hiredis/mod_hiredis.h
+++ b/src/mod/applications/mod_hiredis/mod_hiredis.h
@@ -38,6 +38,7 @@ typedef struct mod_hiredis_context_s {
 
 typedef struct hiredis_connection_s {
 	char *host;
+	char *username;
 	char *password;
 	uint32_t port;
 	switch_interval_time_t timeout_us;
@@ -81,7 +82,7 @@ typedef struct hiredis_limit_pvt_s {
 switch_status_t mod_hiredis_do_config(void);
 switch_status_t hiredis_profile_create(hiredis_profile_t **new_profile, char *name, uint8_t ignore_connect_fail, uint8_t ignore_error, int max_pipelined_requests, int delete_when_zero);
 switch_status_t hiredis_profile_destroy(hiredis_profile_t **old_profile);
-switch_status_t hiredis_profile_connection_add(hiredis_profile_t *profile, char *host, char *password, uint32_t port, uint32_t timeout_ms, uint32_t max_connections);
+switch_status_t hiredis_profile_connection_add(hiredis_profile_t *profile, char *host, char *username, char *password, uint32_t port, uint32_t timeout_ms, uint32_t max_connections);
 switch_status_t hiredis_profile_execute_requests(hiredis_profile_t *profile, switch_core_session_t *session, hiredis_request_t *requests);
 switch_status_t hiredis_profile_execute_sync(hiredis_profile_t *profile, switch_core_session_t *session, char **response, const char *data);
 switch_status_t hiredis_profile_execute_sync_printf(hiredis_profile_t *profile, switch_core_session_t *session, char **response, const char *data_format_string, ...);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->

This pull request adds optional Redis ACL username support to `mod_hiredis`.

Redis 6 introduced ACL authentication using:
`AUTH username password`

`mod_hiredis` currently supports only the password, which implicitly authenticates the Redis default user. This prevents FreeSWITCH deployments from using a dedicated least-privilege Redis ACL user.

The new optional username connection parameter changes the authentication behavior as follows:
-  When both username and password are configured, the module sends `AUTH username password`.
- When only the password is configured, the module preserves the existing `AUTH password` behavior.
- When no password is configured, the module does not send `AUTH`.

The change is backward compatible with existing configurations.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

Closes #3145

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [x] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

Manual integration testing was performed in an isolated Docker environment using:
- FreeSWITCH 1.11.3
- hiredis 0.14.1
- Redis 7.4.11

The patched mod_hiredis module was compiled from commit 9230f7e4dedfc5a43753a4887ffdb751f80e51f1 and loaded successfully by FreeSWITCH.

The following scenarios were verified:

1. Redis ACL authentication with username and password
- A named Redis ACL user was configured.
- The Redis default user was disabled.
- An unauthenticated PING returned `NOAUTH Authentication` required.
- `hiredis_raw` acl PING returned PONG.

2. Backward-compatible password-only authentication
- A separate Redis instance was configured with requirepass.
- The FreeSWITCH profile contained a password but no username.
- `hiredis_raw` legacy PING returned PONG.

3. Reconnection and re-authentication
- The active FreeSWITCH connection was terminated from the Redis server.
- A subsequent `hiredis_raw` acl PING returned PONG, confirming successful reconnection and ACL re-authentication.

(Live SignalWire credentials are not applicable to this change).

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->

The optional username is stored per Redis connection and is applied during both initial authentication and reconnection of pooled connections.

The shipped `hiredis.conf.xml` example documents the new parameter without enabling it by default, preserving compatibility with Redis versions earlier than 6.