### PR TITLE
[mod_sofia] Fix malformed Subscription-State in as-feature-event NOTIFY

### DIFF
--- a/src/mod/endpoints/mod_sofia/mod_sofia.c
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.c
@@ -5274,7 +5274,7 @@ static int notify_csta_callback(void *pArg, int argc, char **argv, char **column
 
 	time_t epoch_now = switch_epoch_time_now(NULL);
 	time_t expires_in = (expires - epoch_now);
-	char *extra_headers = switch_mprintf("Subscription-State: active, %d\r\n", expires_in);
+	char *extra_headers = switch_mprintf("Subscription-State: active;expires=%d\r\n", expires_in);
 
 	if (profile_name && strcasecmp(profile_name, profile->name)) {
 		if ((ext_profile = sofia_glue_find_profile(profile_name))) {


### PR DESCRIPTION
## Description
Use a semicolon-delimited expires parameter as required by RFC 6665, allowing strict SIP clients to correctly parse and accept the notification.
<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ x ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
