### PR TITLE
[core] Set CF_AUDIO when refusing an offered T.38 image m-line

### DIFF
--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -5126,7 +5126,7 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 					restore_pmaps(a_engine);
 					fmatch = 0;
 
-					goto t38_done;
+					goto done;
 				} else {
 					switch_t38_options_t *t38_options = switch_core_media_process_udptl(session, sdp, m);
 					const char *var = switch_channel_get_variable(channel, "t38_passthru");
@@ -6418,8 +6418,6 @@ SWITCH_DECLARE(uint8_t) switch_core_media_negotiate_sdp(switch_core_session_t *s
 	} else {
 		switch_channel_clear_flag(channel, CF_IMAGE_SDP);
 	}
-
- t38_done:
 
 	if (parser) {
 		sdp_parser_free(parser);


### PR DESCRIPTION
## Problem

On a call whose SDP offer carries **both** an audio m-line and a T.38
`m=image udptl t38` line, if FreeSWITCH refuses the T.38 (`refuse_t38`
set, or `fax_enable_t38` not set — the default), FS-played audio to the
caller runs at ~30% speed: IVR prompts, voicemail greetings and MOH all
drag and stutter. Plain voice calls are affected because some
gateways/SIP trunks advertise T.38 on **every** INVITE, not just on a
fax re-INVITE.

## Root cause

In `switch_core_media_negotiate_sdp()` (`src/switch_core_media.c`), the
T.38 refuse branch does `goto t38_done`. The `t38_done:` label sits
*after* the post-m-line block that sets the audio flag:

```c
if (match) {
    switch_channel_set_flag(channel, CF_AUDIO);
} else {
    switch_channel_clear_flag(channel, CF_AUDIO);
}
```

So although the audio codec matched (`match == 1`), the jump skips it and
**CF_AUDIO is never set**. `switch_core_media_read_frame()` then takes the
`!CF_AUDIO` path — `switch_yield(50000)` + return `SWITCH_STATUS_INUSE` —
`switch_core_io` returns comfort noise, and read-frame-paced players
(`play_and_get_digits`, voicemail, MOH) write ~one 20 ms frame per ~70 ms.
The refuse path also leaves the earlier `CF_IMAGE_SDP` flag set.

## Reproduction

sipp A/B into a voicemail box, measuring outbound RTP pps:

| Offer | Outbound RTP |
|---|---|
| audio only | ~50 pps (normal, 20 ms ptime) |
| audio + `m=image udptl t38` (refused) | ~14 pps (~30% speed) |

`strace` of the session thread on the slow leg shows `clock_nanosleep(50ms)`
+ `clock_nanosleep(20ms)` + `sendto()` per frame and zero `recvfrom()` on
the RTP socket for the whole call — the signature of the `!CF_AUDIO` bail.
Confirmed on 1.11.2 and 1.11.3.

## Fix

Send the refuse branch to `done:` instead of `t38_done:`. The `done:`
block performs the `CF_AUDIO`/`CF_VIDEO`/`CF_HAS_TEXT` reconciliation and,
with `fmatch == 0`, clears the stale `CF_IMAGE_SDP`, then falls straight
through into the exact cleanup `t38_done:` labelled — so nothing else
changes for the refuse case. That `goto` was the label's only reference,
so the now-unused `t38_done` label is removed (avoids an unused-label
error under `-Werror`).

Two lines of logic; builds clean with `-Werror`. ABI-neutral (no struct
or signature changes).

Refs #1297