### PR TITLE
[mod_opus] Skip stereo codec registration when mono is enabled

### DIFF
--- a/src/mod/codecs/mod_opus/mod_opus.c
+++ b/src/mod/codecs/mod_opus/mod_opus.c
@@ -1462,7 +1462,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_opus_load)
 		settings.stereo = 1;
 
 		dft_fmtp = gen_fmtp(&settings, pool);
-		switch_core_codec_add_implementation(pool, codec_interface, SWITCH_CODEC_TYPE_AUDIO,	/* enumeration defining the type of the codec */
+		if (!opus_prefs.mono) switch_core_codec_add_implementation(pool, codec_interface, SWITCH_CODEC_TYPE_AUDIO,	/* enumeration defining the type of the codec */
 											 116,	/* the IANA code number */
 											 "opus",/* the IANA code name */
 											 dft_fmtp,	/* default fmtp to send (can be overridden by the init function) */
@@ -1536,7 +1536,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_opus_load)
 		codec_interface->implementations->codec_control = switch_opus_control;
 		settings.stereo = 1;
 		dft_fmtp = gen_fmtp(&settings, pool);
-		switch_core_codec_add_implementation(pool, codec_interface, SWITCH_CODEC_TYPE_AUDIO,	/* enumeration defining the type of the codec */
+		if (!opus_prefs.mono) switch_core_codec_add_implementation(pool, codec_interface, SWITCH_CODEC_TYPE_AUDIO,	/* enumeration defining the type of the codec */
 											 116,	/* the IANA code number */
 											 "opus",/* the IANA code name */
 											 dft_fmtp,	/* default fmtp to send (can be overridden by the init function) */
@@ -1633,7 +1633,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_opus_load)
 		codec_interface->implementations->codec_control = switch_opus_control;
 		settings.stereo = 1;
 		dft_fmtp = gen_fmtp(&settings, pool);
-		switch_core_codec_add_implementation(pool, codec_interface, SWITCH_CODEC_TYPE_AUDIO,	/* enumeration defining the type of the codec */
+		if (!opus_prefs.mono) switch_core_codec_add_implementation(pool, codec_interface, SWITCH_CODEC_TYPE_AUDIO,	/* enumeration defining the type of the codec */
 											 116,	/* the IANA code number */
 											 "opus",/* the IANA code name */
 											 dft_fmtp,	/* default fmtp to send (can be overridden by the init function) */


### PR DESCRIPTION
`mono` in opus.conf.xml is parsed into `opus_prefs.mono` and honoured in two places: `switch_opus_fmtp_parse()` (forces `stereo=0` when a peer offers `stereo=1`) and `switch_opus_init()` (clears `stereo`/`sprop_stereo` per call). Neither one affects what the module advertises.

The offered implementations are registered by `mod_opus_load()`, and for each of the 48 kHz, 16 kHz and 8 kHz groups it registers a second, 2-channel implementation after setting `settings.stereo = 1` unconditionally - `opus_prefs.mono` is never consulted (it is read earlier at the top of `mod_opus_load()`, so it is available there). With `mono=1` configured the module therefore still registers `opus ... 2ch` and still puts `stereo=1` in the fmtp of outbound INVITEs. A mono-only peer that answers `stereo=0; sprop-stereo=0` is then saved by codec negotiation as a 2-channel near-match while the other leg is a 1-channel exact match, and the resulting channel-count transcode produces one-way audio.

This is not covered by `max-audio-channels`: that setting is only consulted in `switch_core_media.c` when parsing the remote SDP (`switch_core_max_audio_channels()`), so it cannot stop us from advertising stereo in our own offer.

Skip the 2-channel registration when `mono` is set, so only mono Opus is registered and offered. Behaviour is unchanged when `mono` is not set.

Resolves: #3142