### PR TITLE
[mod_voicemail] Skip unplayable message files instead of aborting playback

### DIFF
--- a/src/mod/applications/mod_voicemail/mod_voicemail.c
+++ b/src/mod/applications/mod_voicemail/mod_voicemail.c
@@ -1636,7 +1636,12 @@ static switch_status_t listen_file(switch_core_session_t *session, vm_profile_t 
 			cc.fh = &fh;
 			cc.playback_controls_active = 1;
 			if (switch_file_exists(cbt->file_path, switch_core_session_get_pool(session)) == SWITCH_STATUS_SUCCESS) {
-				TRY_CODE(switch_ivr_play_file(session, &fh, cbt->file_path, &args));
+				status = switch_ivr_play_file(session, &fh, cbt->file_path, &args);
+				if (status != SWITCH_STATUS_SUCCESS && status != SWITCH_STATUS_BREAK) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_WARNING,
+									  "Failed to play message file [%s], skipping\n", cbt->file_path);
+					status = SWITCH_STATUS_SUCCESS;
+				}
 			}
 			cc.playback_controls_active = 0;
 		}


### PR DESCRIPTION
When a stored voicemail message file is empty or otherwise unreadable, playing it back fails and the caller is thrown back to the main voicemail menu on the same message, unable to reach the other messages.

`listen_file()` plays the message with `TRY_CODE(switch_ivr_play_file(...))`. When `switch_core_file_open()` cannot open the file, `switch_ivr_play_file()` returns `SWITCH_STATUS_NOTFOUND` (`src/switch_ivr_play_say.c:1494-1497`), and `TRY_CODE` treats anything other than SUCCESS or BREAK as fatal and jumps to `end`. `listen_file()` returns that failure to its caller, which breaks out of the message loop (`mod_voicemail.c:2162`) and drops back to the main menu. The message is never marked read, so asking for unheard messages replays the same broken file and the caller stays stuck on it.

Log the failure at WARNING and treat it as a normal end of playback, so the code falls through to the date announcement and the `VM_LISTEN_FILE_CHECK_MACRO` prompt and the caller can save, delete or move to the next message. Only a failed playback is affected: BREAK (caller pressed a key during playback) and successful playback keep their existing behaviour.

Resolves: #2876