### PR TITLE
[mod_opus] Add decoder-complexity param to enable Deep PLC and OSCE

### DIFF
--- a/conf/vanilla/autoload_configs/opus.conf.xml
+++ b/conf/vanilla/autoload_configs/opus.conf.xml
@@ -3,6 +3,8 @@
         <param name="use-vbr" value="1"/>
         <!--<param name="use-dtx" value="1"/>-->
         <param name="complexity" value="10"/>
+        <!-- Decoder complexity 0-10, default 0. With libopus 1.5 or later, 5 and above enables Deep PLC, 6 adds OSCE LACE, 7 adds NoLACE. Costs CPU per decoding channel. -->
+        <!--<param name="decoder-complexity" value="5"/>-->
 	<!-- Set the initial packet loss percentage 0-100 -->
         <!--<param name="packet-loss-percent" value="10"/>-->
 	<!-- Support asymmetric sample rates -->

--- a/src/mod/codecs/mod_opus/mod_opus.c
+++ b/src/mod/codecs/mod_opus/mod_opus.c
@@ -150,6 +150,7 @@ struct {
 	switch_bool_t use_vbr;
 	switch_bool_t use_dtx;
 	int complexity;
+	int decoder_complexity;
 	int maxaveragebitrate;
 	int maxplaybackrate;
 	int sprop_maxcapturerate;
@@ -716,6 +717,13 @@ static switch_status_t switch_opus_init(switch_codec_t *codec, switch_codec_flag
 
 			return SWITCH_STATUS_GENERR;
 		}
+
+		if (opus_prefs.decoder_complexity) {
+			/* libopus >= 1.5 gates Deep PLC and OSCE on the decoder complexity, which opus_decoder_create() leaves at 0 */
+			if (opus_decoder_ctl(context->decoder_object, OPUS_SET_COMPLEXITY(opus_prefs.decoder_complexity)) != OPUS_OK) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_DEBUG, "Opus decoder complexity not supported by this libopus, ignoring\n");
+			}
+		}
 	}
 
 	context->codec_settings = opus_codec_settings;
@@ -1067,6 +1075,12 @@ static switch_status_t opus_load_config(switch_bool_t reload)
 				opus_prefs.use_dtx =  switch_true(val);
 			} else if (!strcasecmp(key, "complexity")) {
 				opus_prefs.complexity = atoi(val);
+			} else if (!strcasecmp(key, "decoder-complexity")) { /* decoder, 0-10. libopus >= 1.5 runs Deep PLC at 5 and above, OSCE LACE at 6, NoLACE at 7 */
+				opus_prefs.decoder_complexity = atoi(val);
+				if (opus_prefs.decoder_complexity < 0 || opus_prefs.decoder_complexity > 10) {
+					switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING, "Invalid decoder-complexity %d, must be 0-10, ignoring\n", opus_prefs.decoder_complexity);
+					opus_prefs.decoder_complexity = 0;
+				}
 			} else if (!strcasecmp(key, "packet-loss-percent")) {
 				opus_prefs.plpct = atoi(val);
 			} else if (!strcasecmp(key, "asymmetric-sample-rates")) {
@@ -1370,6 +1384,7 @@ SWITCH_STANDARD_API(mod_opus_debug)
 			globals.debug = 1;
 			stream->write_function(stream, "OPUS Debug: on\n");
 			stream->write_function(stream, "Library version: %s\n",opus_get_version_string());
+			stream->write_function(stream, "Decoder complexity: %d\n", opus_prefs.decoder_complexity);
 		} else if (!strcasecmp(cmd, "off")) {
 			globals.debug = 0;
 			stream->write_function(stream, "OPUS Debug: off\n");


### PR DESCRIPTION
libopus 1.5 gates the decoder's Deep PLC and OSCE on the decoder complexity: 5 and above runs Deep PLC, 6 adds LACE, 7 adds NoLACE. `opus_decoder_create()` starts at 0 and mod_opus never changes it, so none of that runs whatever the library was built with. The existing `complexity` param only reaches the encoder.

Add a `decoder-complexity` param (0 to 10) to opus.conf.xml and apply it with `opus_decoder_ctl(OPUS_SET_COMPLEXITY())` after the decoder is created in `switch_opus_init()`. The default is 0, so behaviour is unchanged unless the param is set. Values outside 0 to 10 are rejected with a warning and the default kept. libopus before 1.5 answers the request with `OPUS_UNIMPLEMENTED`; that is logged at DEBUG and ignored, so the module still loads and decodes against older libraries.

The param ships commented out in `conf/vanilla/autoload_configs/opus.conf.xml`. `opus_debug on` prints the configured value next to the library version.

No ABI change, no new dependency, no change to the encoder path.

Opened as a draft until build and call testing on Debian 13 with libopus 1.6.1 is done; results will be added here.

Fixes #3161
